### PR TITLE
Implement DDlog phase 1 scaffolding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ hashbrown = "0.14"  # High performance HashMap implementation
 clap = { version = "4.4", features = ["derive"] }  # Command line argument parsing
 once_cell = "1.19"  # For lazy static initialization
 glam = "0.24"  # Linear algebra for games
-bevy = "0.12"  # Bevy engine for new architecture scaffolding
-differential-datalog = "0.53"  # DDlog runtime (placeholder)
+bevy = { version = "0.12", default-features = false, features = ["bevy_asset","bevy_core_pipeline","bevy_render","bevy_sprite","bevy_winit","bevy_text","png"] }
 
 [build-dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }  # For downloading font in build script

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # lille
-RTS
+
+A simple real-time strategy prototype demonstrating a DDlog-driven
+game loop with Bevy rendering. The project currently implements
+"Phase 1" of the migration roadmap, synchronising the legacy
+`GameWorld` state into Bevy and rendering static entities.

--- a/build.rs
+++ b/build.rs
@@ -33,12 +33,18 @@ fn download_font(manifest_dir: &str) -> Result<PathBuf, Box<dyn Error>> {
 
     let write_result = reqwest::blocking::get(font_url)
         .and_then(|resp| resp.bytes())
-        .and_then(|data| fs::write(&font_path, data));
+        .map(|data| fs::write(&font_path, data));
 
     match write_result {
-        Ok(()) => Ok(font_path),
+        Ok(Ok(())) => Ok(font_path),
+        Ok(Err(e)) => {
+            println!("cargo:warning=Failed to write font: {}", e);
+            Ok(PathBuf::from(
+                "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            ))
+        }
         Err(e) => {
-            println!("cargo:warning=Failed to download/write font: {}", e);
+            println!("cargo:warning=Failed to download font: {}", e);
             Ok(PathBuf::from(
                 "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
             ))

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,6 +1,6 @@
-use glam::Vec3;
-use crate::entity::{Entity, CausesFear};
+use crate::entity::{CausesFear, Entity};
 use crate::log;
+use glam::Vec3;
 
 pub struct Actor {
     pub entity: Entity,
@@ -11,7 +11,12 @@ pub struct Actor {
 
 impl Actor {
     pub fn new(position: Vec3, target: Vec3, speed: f32, fraidiness: f32) -> Self {
-        log!("Creating actor at {:?} targeting {:?} with speed {}", position, target, speed);
+        log!(
+            "Creating actor at {:?} targeting {:?} with speed {}",
+            position,
+            target,
+            speed
+        );
         Self {
             entity: Entity::new(position.x, position.y, position.z),
             target,
@@ -20,31 +25,40 @@ impl Actor {
         }
     }
 
-    fn calculate_fear_vector(&self, threats: &[&dyn CausesFear], threat_positions: &[Vec3]) -> Vec3 {
+    fn calculate_fear_vector(
+        &self,
+        threats: &[&dyn CausesFear],
+        threat_positions: &[Vec3],
+    ) -> Vec3 {
         let mut fear_vector = Vec3::ZERO;
 
         for (threat, &threat_pos) in threats.iter().zip(threat_positions) {
             let to_actor = self.entity.position - threat_pos;
             let distance = to_actor.length();
-            
+
             // Calculate fear radius
             let fear_radius = self.fraidiness_factor * threat.meanness_factor() * 2.0;
             let avoidance_radius = fear_radius.max(self.speed);
-            
-            println!("Actor pos: {:?}, Threat pos: {:?}", self.entity.position, threat_pos);
+
+            println!(
+                "Actor pos: {:?}, Threat pos: {:?}",
+                self.entity.position, threat_pos
+            );
             println!("To actor vector: {:?}, distance: {:.2}", to_actor, distance);
-            println!("Fear radius: {:.2}, Avoidance radius: {:.2}", fear_radius, avoidance_radius);
-            
+            println!(
+                "Fear radius: {:.2}, Avoidance radius: {:.2}",
+                fear_radius, avoidance_radius
+            );
+
             // Calculate fear effect based on distance to threat
             // Start avoiding before we get too close
             if distance <= avoidance_radius {
-                
                 println!("Run away!");
                 // Get perpendicular vector for sideways avoidance
                 let perp = Vec3::new(-to_actor.y, to_actor.x, 0.0).normalize();
 
                 println!("Perpendicular vector: {:?}", perp);
-                
+
                 // Scale fear effect based on how close we are
                 let fear_scale = if distance < fear_radius {
                     // Strong avoidance when within fear radius
@@ -53,26 +67,26 @@ impl Actor {
                     // Gentle avoidance when approaching fear radius
                     distance / avoidance_radius
                 };
-                
+
                 println!("Fear scale: {:?}", fear_scale);
-                
+
                 // Combine direct avoidance with perpendicular movement
                 fear_vector += to_actor.normalize() * fear_scale + perp * fear_scale;
-                
+
                 println!("Fear vector: {:?}", fear_vector);
             }
         }
-        
+
         fear_vector
     }
 
     pub fn update(&mut self, threats: &[&dyn CausesFear], threat_positions: &[Vec3]) {
         // Calculate direction vector to target
         let to_target = self.target - self.entity.position;
-        
+
         // Get fear vector
         let fear_vector = self.calculate_fear_vector(threats, threat_positions);
-        
+
         // Normalize target direction
         let target_direction = if to_target.length() > 0.0 {
             to_target.normalize()
@@ -83,20 +97,25 @@ impl Actor {
         // Normalize vectors
         let target_dir = target_direction.normalize_or_zero();
         let fear_dir = fear_vector.normalize_or_zero();
-        
+
         // Calculate weights based on fear vector magnitude
         let fear_influence = fear_vector.length();
         let fear_weight = (fear_influence * 2.0).min(1.0); // Cap at 1.0
         let target_weight = 1.0 - fear_weight * 0.8; // Allow some target influence even when afraid
-        
+
         // Combine vectors with weights
-        let final_direction = (fear_dir * fear_weight + target_dir * target_weight).normalize() * self.speed;
-        
-        log!("Actor at {:?}, final direction: {:?}", self.entity.position, final_direction);
-        
+        let final_direction =
+            (fear_dir * fear_weight + target_dir * target_weight).normalize() * self.speed;
+
+        log!(
+            "Actor at {:?}, final direction: {:?}",
+            self.entity.position,
+            final_direction
+        );
+
         if final_direction.length() > 0.0 {
             let new_pos = self.entity.position + final_direction;
-            
+
             log!("Moving to {:?}", new_pos);
             self.entity.position = new_pos;
         }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -105,9 +105,13 @@ impl Actor {
         let fear_weight = (fear_influence * 2.0).min(1.0); // Cap at 1.0
         let target_weight = 1.0 - fear_weight * 0.8; // Allow some target influence even when afraid
 
-        // Combine vectors with weights
-        let final_direction =
-            (fear_dir * fear_weight + target_dir * target_weight).normalize() * self.speed;
+        // Combine vectors with weights, avoiding NaNs if the result is zero
+        let move_vec = fear_dir * fear_weight + target_dir * target_weight;
+        let final_direction = if move_vec.length_squared() > 0.0 {
+            move_vec.normalize() * self.speed
+        } else {
+            Vec3::ZERO
+        };
 
         log!(
             "Actor at {:?}, final direction: {:?}",

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -40,24 +40,26 @@ impl Actor {
             let fear_radius = self.fraidiness_factor * threat.meanness_factor() * 2.0;
             let avoidance_radius = fear_radius.max(self.speed);
 
-            println!(
+            log!(
                 "Actor pos: {:?}, Threat pos: {:?}",
-                self.entity.position, threat_pos
+                self.entity.position,
+                threat_pos
             );
-            println!("To actor vector: {:?}, distance: {:.2}", to_actor, distance);
-            println!(
+            log!("To actor vector: {:?}, distance: {:.2}", to_actor, distance);
+            log!(
                 "Fear radius: {:.2}, Avoidance radius: {:.2}",
-                fear_radius, avoidance_radius
+                fear_radius,
+                avoidance_radius
             );
 
             // Calculate fear effect based on distance to threat
             // Start avoiding before we get too close
             if distance <= avoidance_radius {
-                println!("Run away!");
+                log!("Run away!");
                 // Get perpendicular vector for sideways avoidance
                 let perp = Vec3::new(-to_actor.y, to_actor.x, 0.0).normalize();
 
-                println!("Perpendicular vector: {:?}", perp);
+                log!("Perpendicular vector: {:?}", perp);
 
                 // Scale fear effect based on how close we are
                 let fear_scale = if distance < fear_radius {
@@ -68,12 +70,12 @@ impl Actor {
                     distance / avoidance_radius
                 };
 
-                println!("Fear scale: {:?}", fear_scale);
+                log!("Fear scale: {:?}", fear_scale);
 
                 // Combine direct avoidance with perpendicular movement
                 fear_vector += to_actor.normalize() * fear_scale + perp * fear_scale;
 
-                println!("Fear vector: {:?}", fear_vector);
+                log!("Fear vector: {:?}", fear_vector);
             }
         }
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,0 +1,16 @@
+use bevy::prelude::*;
+
+#[derive(Component, Debug)]
+pub struct DdlogId(pub i64);
+
+#[derive(Component, Default)]
+pub struct Health(pub i32);
+
+#[derive(Component, Debug)]
+pub enum UnitType {
+    Civvy { fraidiness: f32 },
+    Baddie { meanness: f32 },
+}
+
+#[derive(Component, Debug, Deref, DerefMut)]
+pub struct Target(pub Vec2);

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -2,6 +2,7 @@ use bevy::prelude::*;
 
 use crate::components::{DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::DdlogHandle;
+use crate::log;
 
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
@@ -10,7 +11,7 @@ pub fn push_state_to_ddlog_system(
     query: Query<(&DdlogId, &Transform, &Health, &UnitType, Option<&Target>)>,
 ) {
     for (id, transform, health, unit, target) in &query {
-        info!(
+        log!(
             "Sync Entity {} pos=({:.1},{:.1}) hp={} type={:?} has_target={}",
             id.0,
             transform.translation.x,

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -1,0 +1,23 @@
+use bevy::prelude::*;
+
+use crate::components::{DdlogId, Health, Target, UnitType};
+use crate::ddlog_handle::DdlogHandle;
+
+/// Pushes the current ECS state into DDlog.
+/// This implementation is a stub that simply logs the state.
+pub fn push_state_to_ddlog_system(
+    _ddlog: Res<DdlogHandle>,
+    query: Query<(&DdlogId, &Transform, &Health, &UnitType, Option<&Target>)>,
+) {
+    for (id, transform, health, unit, target) in &query {
+        info!(
+            "Sync Entity {} pos=({:.1},{:.1}) hp={} type={:?} has_target={}",
+            id.0,
+            transform.translation.x,
+            transform.translation.y,
+            health.0,
+            unit,
+            target.is_some()
+        );
+    }
+}

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,5 +1,5 @@
-use std::fmt::Debug;
 use glam::Vec3;
+use std::fmt::Debug;
 
 #[derive(Clone, Debug)]
 pub struct Entity {

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,3 +1,4 @@
+use crate::log;
 use crate::world::GameWorld;
 use piston_window::*;
 use std::error::Error;
@@ -18,7 +19,7 @@ impl GraphicsContext {
 
         // Get font path from build script
         let font_path = env!("FONT_PATH");
-        println!("Loading font from: {}", font_path);
+        log!("Loading font from: {}", font_path);
 
         // Load font using window's built-in method
         let glyphs = window.load_font(font_path)?;
@@ -67,7 +68,7 @@ impl GraphicsContext {
                 c.transform.trans(10.0, 30.0),
                 g,
             ) {
-                eprintln!("Failed to render text: {}", e);
+                log!("Failed to render text: {}", e);
             }
 
             // Ensure glyphs are updated

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,6 +1,6 @@
+use crate::world::GameWorld;
 use piston_window::*;
 use std::error::Error;
-use crate::world::GameWorld;
 
 pub const WINDOW_SIZE: u32 = 1000;
 pub const PIXEL_SIZE: f64 = 3.0;
@@ -19,13 +19,14 @@ impl GraphicsContext {
         // Get font path from build script
         let font_path = env!("FONT_PATH");
         println!("Loading font from: {}", font_path);
-        
+
         // Load font using window's built-in method
         let glyphs = window.load_font(font_path)?;
 
         Ok(Self { window, glyphs })
     }
 
+    #[allow(clippy::should_implement_trait)]
     pub fn next(&mut self) -> Option<Event> {
         self.window.next()
     }
@@ -39,10 +40,10 @@ impl GraphicsContext {
             for (&pos, &count) in world.get_all_positions().iter() {
                 // Make bad guys appear red
                 let color = if count >= 5 {
-                    [1.0, 0.0, 0.0, 1.0]  // Red for bad guys
+                    [1.0, 0.0, 0.0, 1.0] // Red for bad guys
                 } else {
                     let value = (count as f32 * 0.3).min(1.0);
-                    [value, value, value, 1.0]  // White for others
+                    [value, value, value, 1.0] // White for others
                 };
 
                 rectangle(
@@ -59,15 +60,13 @@ impl GraphicsContext {
             }
 
             // Draw tick counter with error handling
-            if let Err(e) = text::Text::new_color([1.0, 1.0, 1.0, 1.0], 32)
-                .draw(
-                    &format!("Tick: {}", world.tick_count),
-                    &mut self.glyphs,
-                    &c.draw_state,
-                    c.transform.trans(10.0, 30.0),
-                    g,
-                )
-            {
+            if let Err(e) = text::Text::new_color([1.0, 1.0, 1.0, 1.0], 32).draw(
+                &format!("Tick: {}", world.tick_count),
+                &mut self.glyphs,
+                &c.draw_state,
+                c.transform.trans(10.0, 30.0),
+                g,
+            ) {
                 eprintln!("Failed to render text: {}", e);
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,5 +16,5 @@ pub use ddlog_sync::push_state_to_ddlog_system;
 pub use entity::{BadGuy, CausesFear, Entity};
 pub use graphics::{GraphicsContext, PIXEL_SIZE, WINDOW_SIZE};
 pub use logging::init as init_logging;
-pub use spawn_world::spawn_world_system;
+pub use spawn_world::{init_world_system, spawn_world_system};
 pub use world::GameWorld;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,20 @@
 pub mod actor;
+pub mod components;
 pub mod ddlog_handle;
+pub mod ddlog_sync;
 pub mod entity;
 pub mod graphics;
 pub mod logging;
+pub mod spawn_world;
 pub mod world;
 
 // Re-export commonly used items
 pub use actor::Actor;
+pub use components::{DdlogId, Health, Target, UnitType};
 pub use ddlog_handle::{init_ddlog_system, DdlogHandle};
+pub use ddlog_sync::push_state_to_ddlog_system;
 pub use entity::{BadGuy, CausesFear, Entity};
 pub use graphics::{GraphicsContext, PIXEL_SIZE, WINDOW_SIZE};
 pub use logging::init as init_logging;
+pub use spawn_world::spawn_world_system;
 pub use world::GameWorld;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,4 +17,4 @@ pub use entity::{BadGuy, CausesFear, Entity};
 pub use graphics::{GraphicsContext, PIXEL_SIZE, WINDOW_SIZE};
 pub use logging::init as init_logging;
 pub use spawn_world::{init_world_system, spawn_world_system};
-pub use world::GameWorld;
+pub use world::{update_world_system, GameWorld};

--- a/src/lille.dl
+++ b/src/lille.dl
@@ -1,6 +1,16 @@
-// Minimal DDlog program for Phase 0
+typedef EntityID = signed64
+typedef Coord = signed32
+typedef Health = signed32
+typedef UnitType = string
 
-input relation HelloWorld(dummy: signed32)
-output relation HelloOut(dummy: signed32)
+input relation Position(entity: EntityID, x: Coord, y: Coord)
+input relation HealthRel(entity: EntityID, hp: Health)
+input relation Unit(entity: EntityID, type: UnitType)
+input relation Target(entity: EntityID, tx: Coord, ty: Coord)
+input relation Fraidiness(entity: EntityID, factor: float)
+input relation Meanness(entity: EntityID, factor: float)
 
-HelloOut(d) :- HelloWorld(d).
+output relation NewPosition(entity: EntityID, x: Coord, y: Coord)
+output relation Damage(target: EntityID, amount: Health)
+output relation Despawn(entity: EntityID)
+

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
 use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 static VERBOSE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use clap::Parser;
-use lille::{init_ddlog_system, init_logging};
+use lille::{init_ddlog_system, init_logging, push_state_to_ddlog_system, spawn_world_system};
 
 /// A realtime strategy game
 #[derive(Parser)]
@@ -12,16 +12,19 @@ struct Args {
     verbose: bool,
 }
 
-fn hello_world() {
-    info!("Hello Bevy!");
-}
-
 fn main() {
     let args = Args::parse();
     init_logging(args.verbose);
 
     App::new()
         .add_plugins(DefaultPlugins.build().disable::<LogPlugin>())
-        .add_systems(Startup, (init_ddlog_system, hello_world))
+        .add_systems(
+            Startup,
+            (
+                init_ddlog_system,
+                spawn_world_system,
+                push_state_to_ddlog_system,
+            ),
+        )
         .run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,10 @@
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use clap::Parser;
-use lille::{init_ddlog_system, init_logging, push_state_to_ddlog_system, spawn_world_system};
+use lille::{
+    init_ddlog_system, init_logging, init_world_system, push_state_to_ddlog_system,
+    spawn_world_system,
+};
 
 /// A realtime strategy game
 #[derive(Parser)]
@@ -22,9 +25,11 @@ fn main() {
             Startup,
             (
                 init_ddlog_system,
+                init_world_system,
                 spawn_world_system,
                 push_state_to_ddlog_system,
-            ),
+            )
+                .chain(),
         )
         .run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 use clap::Parser;
 use lille::{
     init_ddlog_system, init_logging, init_world_system, push_state_to_ddlog_system,
-    spawn_world_system,
+    spawn_world_system, update_world_system,
 };
 
 /// A realtime strategy game
@@ -28,5 +28,6 @@ fn main() {
             Startup,
             push_state_to_ddlog_system.after(spawn_world_system),
         )
+        .add_systems(Update, update_world_system)
         .run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,15 +21,12 @@ fn main() {
 
     App::new()
         .add_plugins(DefaultPlugins.build().disable::<LogPlugin>())
+        .add_systems(Startup, init_ddlog_system)
+        .add_systems(Startup, init_world_system.after(init_ddlog_system))
+        .add_systems(Startup, spawn_world_system.after(init_world_system))
         .add_systems(
             Startup,
-            (
-                init_ddlog_system,
-                init_world_system,
-                spawn_world_system,
-                push_state_to_ddlog_system,
-            )
-                .chain(),
+            push_state_to_ddlog_system.after(spawn_world_system),
         )
         .run();
 }

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -8,7 +8,7 @@ use crate::world::GameWorld;
 /// This system does not spawn any entities; it only prepares the world
 /// state for later systems.
 pub fn init_world_system(mut commands: Commands) {
-    commands.insert_resource(GameWorld::new());
+    commands.insert_resource(GameWorld::default());
 }
 
 /// Spawns the entities defined in the legacy `GameWorld` into the Bevy ECS.

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -12,11 +12,11 @@ pub fn init_world_system(mut commands: Commands) {
 }
 
 /// Spawns the entities defined in the legacy `GameWorld` into the Bevy ECS.
-pub fn spawn_world_system(mut commands: Commands, mut world: ResMut<GameWorld>) {
+pub fn spawn_world_system(mut commands: Commands, world: Res<GameWorld>) {
     let mut next_id: i64 = 1;
 
     // Spawn static entities
-    for entity in world.entities.drain(..) {
+    for entity in &world.entities {
         commands.spawn((
             SpriteBundle {
                 sprite: Sprite {
@@ -32,7 +32,7 @@ pub fn spawn_world_system(mut commands: Commands, mut world: ResMut<GameWorld>) 
     }
 
     // Spawn actors
-    for actor in world.actors.drain(..) {
+    for actor in &world.actors {
         commands.spawn((
             SpriteBundle {
                 sprite: Sprite {
@@ -53,7 +53,7 @@ pub fn spawn_world_system(mut commands: Commands, mut world: ResMut<GameWorld>) 
     }
 
     // Spawn bad guys
-    for bad in world.bad_guys.drain(..) {
+    for bad in &world.bad_guys {
         commands.spawn((
             SpriteBundle {
                 sprite: Sprite {

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -3,10 +3,12 @@ use bevy::prelude::*;
 use crate::components::{DdlogId, Health, Target, UnitType};
 use crate::world::GameWorld;
 
-/// Spawns the entities defined in the legacy `GameWorld` into the Bevy ECS.
-/// Inserts a new `GameWorld` resource.
+/// Inserts the initial `GameWorld` resource used to spawn entities.
+///
+/// This system does not spawn any entities; it only prepares the world
+/// state for later systems.
 pub fn init_world_system(mut commands: Commands) {
-    commands.insert_resource(GameWorld::default());
+    commands.insert_resource(GameWorld::new());
 }
 
 /// Spawns the entities defined in the legacy `GameWorld` into the Bevy ECS.

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -4,12 +4,17 @@ use crate::components::{DdlogId, Health, Target, UnitType};
 use crate::world::GameWorld;
 
 /// Spawns the entities defined in the legacy `GameWorld` into the Bevy ECS.
-pub fn spawn_world_system(mut commands: Commands) {
-    let world = GameWorld::new();
+/// Inserts a new `GameWorld` resource.
+pub fn init_world_system(mut commands: Commands) {
+    commands.insert_resource(GameWorld::default());
+}
+
+/// Spawns the entities defined in the legacy `GameWorld` into the Bevy ECS.
+pub fn spawn_world_system(mut commands: Commands, mut world: ResMut<GameWorld>) {
     let mut next_id: i64 = 1;
 
     // Spawn actors
-    for actor in world.actors {
+    for actor in world.actors.drain(..) {
         commands.spawn((
             SpriteBundle {
                 sprite: Sprite {
@@ -30,7 +35,7 @@ pub fn spawn_world_system(mut commands: Commands) {
     }
 
     // Spawn bad guys
-    for bad in world.bad_guys {
+    for bad in world.bad_guys.drain(..) {
         commands.spawn((
             SpriteBundle {
                 sprite: Sprite {

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -13,6 +13,22 @@ pub fn init_world_system(mut commands: Commands) {
 pub fn spawn_world_system(mut commands: Commands, mut world: ResMut<GameWorld>) {
     let mut next_id: i64 = 1;
 
+    // Spawn static entities
+    for entity in world.entities.drain(..) {
+        commands.spawn((
+            SpriteBundle {
+                sprite: Sprite {
+                    color: Color::GRAY,
+                    ..default()
+                },
+                transform: Transform::from_translation(entity.position),
+                ..default()
+            },
+            DdlogId(next_id),
+        ));
+        next_id += 1;
+    }
+
     // Spawn actors
     for actor in world.actors.drain(..) {
         commands.spawn((

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -1,0 +1,54 @@
+use bevy::prelude::*;
+
+use crate::components::{DdlogId, Health, Target, UnitType};
+use crate::world::GameWorld;
+
+/// Spawns the entities defined in the legacy `GameWorld` into the Bevy ECS.
+pub fn spawn_world_system(mut commands: Commands) {
+    let world = GameWorld::new();
+    let mut next_id: i64 = 1;
+
+    // Spawn actors
+    for actor in world.actors {
+        commands.spawn((
+            SpriteBundle {
+                sprite: Sprite {
+                    color: Color::WHITE,
+                    ..default()
+                },
+                transform: Transform::from_translation(actor.entity.position),
+                ..default()
+            },
+            DdlogId(next_id),
+            Health(100),
+            UnitType::Civvy {
+                fraidiness: actor.fraidiness_factor,
+            },
+            Target(actor.target.truncate()),
+        ));
+        next_id += 1;
+    }
+
+    // Spawn bad guys
+    for bad in world.bad_guys {
+        commands.spawn((
+            SpriteBundle {
+                sprite: Sprite {
+                    color: Color::RED,
+                    ..default()
+                },
+                transform: Transform::from_translation(bad.entity.position),
+                ..default()
+            },
+            DdlogId(next_id),
+            Health(100),
+            UnitType::Baddie {
+                meanness: bad.meanness,
+            },
+        ));
+        next_id += 1;
+    }
+
+    // Camera
+    commands.spawn(Camera2dBundle::default());
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -44,11 +44,6 @@ impl Default for GameWorld {
 }
 
 impl GameWorld {
-    /// Construct an initial `GameWorld` containing the starting units.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn update(&mut self) {
         if self.last_tick.elapsed() >= TICK_DURATION {
             self.tick_count += 1;

--- a/src/world.rs
+++ b/src/world.rs
@@ -8,6 +8,7 @@ use std::time::{Duration, Instant};
 
 const TICK_DURATION: Duration = Duration::from_millis(500);
 
+/// Collection of entities and state for the legacy Lille world.
 #[derive(Resource)]
 pub struct GameWorld {
     pub entities: Vec<Entity>,

--- a/src/world.rs
+++ b/src/world.rs
@@ -18,12 +18,6 @@ pub struct GameWorld {
     last_tick: Instant,
 }
 
-impl GameWorld {
-    pub fn new() -> Self {
-        Self::default()
-    }
-}
-
 impl Default for GameWorld {
     fn default() -> Self {
         let mut world = Self {

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,7 +1,7 @@
 use crate::actor::Actor;
 use crate::entity::{BadGuy, CausesFear, Entity};
 use crate::log;
-use bevy::prelude::Resource;
+use bevy::prelude::{ResMut, Resource};
 use glam::Vec3;
 use hashbrown::HashMap;
 use std::time::{Duration, Instant};
@@ -96,4 +96,9 @@ impl GameWorld {
                 acc
             })
     }
+}
+
+/// Bevy system wrapper that updates the [`GameWorld`] each frame.
+pub fn update_world_system(mut world: ResMut<GameWorld>) {
+    world.update();
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,9 +1,9 @@
-use std::time::{Instant, Duration};
-use hashbrown::HashMap;
-use glam::Vec3;
-use crate::entity::{Entity, CausesFear, BadGuy};
 use crate::actor::Actor;
+use crate::entity::{BadGuy, CausesFear, Entity};
 use crate::log;
+use glam::Vec3;
+use hashbrown::HashMap;
+use std::time::{Duration, Instant};
 
 const TICK_DURATION: Duration = Duration::from_millis(500);
 
@@ -16,6 +16,7 @@ pub struct GameWorld {
 }
 
 impl GameWorld {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let mut world = Self {
             entities: Vec::new(),
@@ -43,29 +44,28 @@ impl GameWorld {
         if self.last_tick.elapsed() >= TICK_DURATION {
             self.tick_count += 1;
             log!("\nTick {}", self.tick_count);
-            
+
             // Collect threats and their positions
             let mut threats: Vec<&dyn CausesFear> = Vec::with_capacity(self.bad_guys.len());
             for bad_guy in &self.bad_guys {
                 threats.push(bad_guy as &dyn CausesFear);
             }
-            
-            let threat_positions: Vec<Vec3> = self.bad_guys.iter()
-                .map(|bg| bg.entity.position)
-                .collect();
-            
+
+            let threat_positions: Vec<Vec3> =
+                self.bad_guys.iter().map(|bg| bg.entity.position).collect();
+
             // Update all actors
             for actor in &mut self.actors {
                 actor.update(&threats, &threat_positions);
             }
-            
+
             self.last_tick = Instant::now();
         }
     }
 
     pub fn get_all_positions(&self) -> HashMap<(i32, i32, i32), u32> {
         let mut positions = HashMap::new();
-        
+
         // Add regular entities
         for entity in &self.entities {
             let grid_pos = (
@@ -75,7 +75,7 @@ impl GameWorld {
             );
             *positions.entry(grid_pos).or_insert(0) += 1;
         }
-        
+
         // Add actors
         for actor in &self.actors {
             let grid_pos = (
@@ -96,7 +96,7 @@ impl GameWorld {
             // Use a large count to make them appear bright red
             *positions.entry(grid_pos).or_insert(0) += 5;
         }
-        
+
         positions
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,12 +1,14 @@
 use crate::actor::Actor;
 use crate::entity::{BadGuy, CausesFear, Entity};
 use crate::log;
+use bevy::prelude::Resource;
 use glam::Vec3;
 use hashbrown::HashMap;
 use std::time::{Duration, Instant};
 
 const TICK_DURATION: Duration = Duration::from_millis(500);
 
+#[derive(Resource)]
 pub struct GameWorld {
     pub entities: Vec<Entity>,
     pub actors: Vec<Actor>,
@@ -16,8 +18,13 @@ pub struct GameWorld {
 }
 
 impl GameWorld {
-    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for GameWorld {
+    fn default() -> Self {
         let mut world = Self {
             entities: Vec::new(),
             actors: Vec::new(),
@@ -39,7 +46,9 @@ impl GameWorld {
 
         world
     }
+}
 
+impl GameWorld {
     pub fn update(&mut self) {
         if self.last_tick.elapsed() >= TICK_DURATION {
             self.tick_count += 1;

--- a/tests/actor.rs
+++ b/tests/actor.rs
@@ -1,6 +1,6 @@
+use glam::Vec3;
 use lille::actor::Actor;
 use lille::entity::BadGuy;
-use glam::Vec3;
 
 #[test]
 fn update_maintains_fear_radius() {
@@ -8,13 +8,13 @@ fn update_maintains_fear_radius() {
     let mut actor = Actor::new(
         Vec3::ZERO,
         Vec3::new(10.0, 0.0, 0.0), // Target is 10 units along x-axis
-        5.0,  // Speed
-        1.0,  // Fraidiness factor
+        5.0,                       // Speed
+        1.0,                       // Fraidiness factor
     );
 
     // Create a badguy at position (5, 0, 0) with meanness 1.0
     let badguy = BadGuy::new(5.0, 0.0, 0.0, 1.0);
-    
+
     // The fear radius should be: fraidiness (1.0) * meanness (1.0) * 2.0 = 2.0 units
     let fear_radius = 2.0;
 
@@ -46,8 +46,8 @@ fn walks_towards_target() {
     let mut actor = Actor::new(
         Vec3::ZERO,
         Vec3::new(5.0, 0.0, 0.0),
-        5.0,  // Speed
-        1.0,  // Fraidiness factor (irrelevant for this test)
+        5.0, // Speed
+        1.0, // Fraidiness factor (irrelevant for this test)
     );
 
     // Update position (no threats)
@@ -63,8 +63,8 @@ fn walks_towards_target() {
 
     // Y and Z coordinates should remain unchanged
     assert!(
-        actor.entity.position.y.abs() < f32::EPSILON &&
-        actor.entity.position.z.abs() < f32::EPSILON,
+        actor.entity.position.y.abs() < f32::EPSILON
+            && actor.entity.position.z.abs() < f32::EPSILON,
         "Actor should only move along X axis, but position is {:?}",
         actor.entity.position
     );
@@ -73,13 +73,11 @@ fn walks_towards_target() {
 #[test]
 fn stationary_when_at_target() {
     let target_pos = Vec3::new(3.0, 2.0, 1.0);
-    
+
     // Create actor already at target position
     let mut actor = Actor::new(
-        target_pos,
-        target_pos,
-        1.0,  // Speed (irrelevant since we shouldn't move)
-        1.0,  // Fraidiness factor (irrelevant for this test)
+        target_pos, target_pos, 1.0, // Speed (irrelevant since we shouldn't move)
+        1.0, // Fraidiness factor (irrelevant for this test)
     );
 
     // Store initial position

--- a/tests/actor.rs
+++ b/tests/actor.rs
@@ -1,6 +1,6 @@
 use glam::Vec3;
 use lille::actor::Actor;
-use lille::entity::BadGuy;
+use lille::entity::{BadGuy, CausesFear};
 
 #[test]
 fn update_maintains_fear_radius() {
@@ -38,6 +38,29 @@ fn update_maintains_fear_radius() {
         "Actor should move around the badguy, not just stop. Position: {:?}",
         actor.entity.position
     );
+}
+
+#[test]
+fn avoids_multiple_threats() {
+    // Actor heading towards +X axis
+    let mut actor = Actor::new(Vec3::ZERO, Vec3::new(10.0, 0.0, 0.0), 5.0, 1.0);
+
+    // Two threats close to the actor
+    let bad1 = BadGuy::new(4.0, 0.0, 0.0, 1.0);
+    let bad2 = BadGuy::new(5.0, 0.5, 0.0, 1.0);
+    let threats = [&bad1 as &dyn CausesFear, &bad2 as &dyn CausesFear];
+    let positions = [bad1.entity.position, bad2.entity.position];
+
+    actor.update(&threats, &positions);
+
+    // Fear radius = 2.0
+    for pos in positions {
+        let dist = (actor.entity.position - pos).length();
+        assert!(dist >= 2.0, "Actor too close to threat: {}", dist);
+    }
+
+    // Should have deviated from a straight line towards the target
+    assert!(actor.entity.position.y.abs() > 0.0);
 }
 
 #[test]

--- a/tests/actor.rs
+++ b/tests/actor.rs
@@ -41,6 +41,28 @@ fn update_maintains_fear_radius() {
 }
 
 #[test]
+fn moves_out_of_starting_fear_radius() {
+    // Actor begins inside the fear radius of a bad guy
+    let mut actor = Actor::new(
+        Vec3::new(1.0, 0.0, 0.0),
+        Vec3::new(10.0, 0.0, 0.0),
+        5.0,
+        1.0,
+    );
+
+    let badguy = BadGuy::new(0.0, 0.0, 0.0, 1.0);
+
+    actor.update(&[&badguy], &[badguy.entity.position]);
+
+    let dist = (actor.entity.position - badguy.entity.position).length();
+    assert!(
+        dist >= 2.0,
+        "Actor did not move out of fear radius: {}",
+        dist
+    );
+}
+
+#[test]
 fn avoids_multiple_threats() {
     // Actor heading towards +X axis
     let mut actor = Actor::new(Vec3::ZERO, Vec3::new(10.0, 0.0, 0.0), 5.0, 1.0);

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,0 +1,22 @@
+use bevy::prelude::*;
+use lille::{spawn_world_system, UnitType};
+
+#[test]
+fn spawns_world_entities() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins);
+    app.add_systems(Startup, spawn_world_system);
+    app.update();
+
+    let world = &mut app.world;
+    let mut civvy = 0;
+    let mut baddie = 0;
+    for unit in world.query::<&UnitType>().iter(world) {
+        match unit {
+            UnitType::Civvy { .. } => civvy += 1,
+            UnitType::Baddie { .. } => baddie += 1,
+        }
+    }
+    assert_eq!(civvy, 1);
+    assert_eq!(baddie, 1);
+}

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,10 +1,11 @@
 use bevy::prelude::*;
-use lille::{spawn_world_system, UnitType};
+use lille::{spawn_world_system, GameWorld, UnitType};
 
 #[test]
 fn spawns_world_entities() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
+    app.world.insert_resource(GameWorld::default());
     app.add_systems(Startup, spawn_world_system);
     app.update();
 

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -6,7 +6,7 @@ use lille::{spawn_world_system, DdlogId, GameWorld, Health, Target, UnitType};
 fn spawns_world_entities() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
-    let mut world_state = GameWorld::default();
+    let mut world_state = GameWorld::new();
     world_state.entities.push(LilleEntity::new(50.0, 50.0, 0.0));
     app.world.insert_resource(world_state);
     app.add_systems(Startup, spawn_world_system);

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,13 +1,26 @@
 use bevy::prelude::*;
 use lille::Entity as LilleEntity;
-use lille::{spawn_world_system, DdlogId, GameWorld, Health, Target, UnitType};
+use lille::{spawn_world_system, Actor, BadGuy, DdlogId, GameWorld, Health, Target, UnitType};
 
 #[test]
 fn spawns_world_entities() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
-    let mut world_state = GameWorld::new();
+    let mut world_state = GameWorld::default();
+    world_state.entities.clear();
+    world_state.actors.clear();
+    world_state.bad_guys.clear();
+
     world_state.entities.push(LilleEntity::new(50.0, 50.0, 0.0));
+    world_state.actors.push(Actor::new(
+        Vec3::new(125.0, 125.0, 0.0),
+        Vec3::new(202.0, 200.0, 0.0),
+        5.0,
+        1.0,
+    ));
+    world_state
+        .bad_guys
+        .push(BadGuy::new(150.0, 150.5, 0.0, 10.0));
     app.world.insert_resource(world_state);
     app.add_systems(Startup, spawn_world_system);
     app.update();

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,11 +1,14 @@
 use bevy::prelude::*;
-use lille::{spawn_world_system, GameWorld, Health, Target, UnitType};
+use lille::Entity as LilleEntity;
+use lille::{spawn_world_system, DdlogId, GameWorld, Health, Target, UnitType};
 
 #[test]
 fn spawns_world_entities() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins);
-    app.world.insert_resource(GameWorld::default());
+    let mut world_state = GameWorld::default();
+    world_state.entities.push(LilleEntity::new(50.0, 50.0, 0.0));
+    app.world.insert_resource(world_state);
     app.add_systems(Startup, spawn_world_system);
     app.update();
 
@@ -13,29 +16,48 @@ fn spawns_world_entities() {
 
     let mut civvy = 0;
     let mut baddie = 0;
+    let mut static_count = 0;
 
     // Query spawned units and verify their components
-    let mut query = world.query::<(Entity, &UnitType, &Transform, &Health, Option<&Target>)>();
-    for (entity, unit, transform, health, target) in query.iter(world) {
+    let mut query = world.query::<(
+        Entity,
+        Option<&DdlogId>,
+        Option<&UnitType>,
+        &Transform,
+        Option<&Health>,
+        Option<&Target>,
+    )>();
+    for (entity, dd_id, unit, transform, health, target) in query.iter(world) {
         // All units should have a Transform and Health
-        assert!(health.0 > 0, "Entity {:?} missing health", entity);
+        if let Some(h) = health {
+            assert!(h.0 > 0, "Entity {:?} missing health", entity);
+        }
 
         match unit {
-            UnitType::Civvy { fraidiness } => {
+            Some(UnitType::Civvy { fraidiness }) => {
                 civvy += 1;
                 assert!((fraidiness - 1.0).abs() < f32::EPSILON);
                 assert!(target.is_some(), "Civvy missing target");
                 assert_eq!(transform.translation, Vec3::new(125.0, 125.0, 0.0));
             }
-            UnitType::Baddie { meanness } => {
+            Some(UnitType::Baddie { meanness }) => {
                 baddie += 1;
                 assert!((meanness - 10.0).abs() < f32::EPSILON);
                 assert!(target.is_none());
                 assert_eq!(transform.translation, Vec3::new(150.0, 150.5, 0.0));
+            }
+            None => {
+                // Skip camera entities
+                if dd_id.is_none() {
+                    continue;
+                }
+                static_count += 1;
+                assert_eq!(transform.translation, Vec3::new(50.0, 50.0, 0.0));
             }
         }
     }
 
     assert_eq!(civvy, 1);
     assert_eq!(baddie, 1);
+    assert_eq!(static_count, 1);
 }

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,5 +1,5 @@
 use bevy::prelude::*;
-use lille::{spawn_world_system, GameWorld, UnitType};
+use lille::{spawn_world_system, GameWorld, Health, Target, UnitType};
 
 #[test]
 fn spawns_world_entities() {
@@ -10,14 +10,32 @@ fn spawns_world_entities() {
     app.update();
 
     let world = &mut app.world;
+
     let mut civvy = 0;
     let mut baddie = 0;
-    for unit in world.query::<&UnitType>().iter(world) {
+
+    // Query spawned units and verify their components
+    let mut query = world.query::<(Entity, &UnitType, &Transform, &Health, Option<&Target>)>();
+    for (entity, unit, transform, health, target) in query.iter(world) {
+        // All units should have a Transform and Health
+        assert!(health.0 > 0, "Entity {:?} missing health", entity);
+
         match unit {
-            UnitType::Civvy { .. } => civvy += 1,
-            UnitType::Baddie { .. } => baddie += 1,
+            UnitType::Civvy { fraidiness } => {
+                civvy += 1;
+                assert!((fraidiness - 1.0).abs() < f32::EPSILON);
+                assert!(target.is_some(), "Civvy missing target");
+                assert_eq!(transform.translation, Vec3::new(125.0, 125.0, 0.0));
+            }
+            UnitType::Baddie { meanness } => {
+                baddie += 1;
+                assert!((meanness - 10.0).abs() < f32::EPSILON);
+                assert!(target.is_none());
+                assert_eq!(transform.translation, Vec3::new(150.0, 150.5, 0.0));
+            }
         }
     }
+
     assert_eq!(civvy, 1);
     assert_eq!(baddie, 1);
 }


### PR DESCRIPTION
## Summary
- add ECS components for DDlog integration
- set up spawning logic from the old `GameWorld`
- push ECS state to DDlog (stub) and render with Bevy
- define base relations in `lille.dl`
- add a regression test for the world spawn
- clean up clippy warnings and build script

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684634a4782c83228e00259e8d2e7240

## Summary by Sourcery

Provide DDlog integration scaffolding by adding ECS components, Bevy systems for world setup and entity spawning, a stub for pushing ECS state to DDlog, and accompanying tests

New Features:
- Add ECS components (DdlogId, Health, Target, UnitType) for entity metadata
- Introduce Bevy systems to initialize, spawn, update, and stub-sync game world state to DDlog
- Define base DDlog relations in `lille.dl` and stub out state-push logic

Enhancements:
- Refactor GameWorld and Actor logic into Bevy resources and systems
- Simplify position aggregation with iterator chains and replace `println!` with structured `log!` calls
- Clean up clippy warnings and restructure GameWorld impl to use Default trait

Build:
- Update Cargo.toml to disable default Bevy features and specify required ones
- Improve build script to handle font download/write errors gracefully

Tests:
- Add regression tests for world spawning, actor movement, and multi-threat avoidance