### PR TITLE
Reduce noisy logging with debug-level gating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ clap = { version = "4.4", features = ["derive"] }  # Command line argument parsi
 once_cell = "1.19"  # For lazy static initialization
 glam = "0.24"  # Linear algebra for games
 bevy = { version = "0.12", default-features = false, features = ["bevy_asset","bevy_core_pipeline","bevy_render","bevy_sprite","bevy_winit","bevy_text","png"] }
+log = "0.4"  # Structured logging facade
+env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 
 [build-dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }  # For downloading font in build script

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ piston_window = "0.131"  # Provides window creation and event loop
 piston2d-graphics = "0.45"  # 2D graphics library
 hashbrown = "0.14"  # High performance HashMap implementation
 clap = { version = "4.4", features = ["derive"] }  # Command line argument parsing
-once_cell = "1.19"  # For lazy static initialization
 glam = "0.24"  # Linear algebra for games
 bevy = { version = "0.12", default-features = false, features = ["bevy_asset","bevy_core_pipeline","bevy_render","bevy_sprite","bevy_winit","bevy_text","png"] }
 log = "0.4"  # Structured logging facade

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,5 +1,5 @@
+use crate::debug_log;
 use crate::entity::{CausesFear, Entity};
-use crate::log;
 use glam::Vec3;
 
 pub struct Actor {
@@ -11,7 +11,7 @@ pub struct Actor {
 
 impl Actor {
     pub fn new(position: Vec3, target: Vec3, speed: f32, fraidiness: f32) -> Self {
-        log!(
+        debug_log!(
             "Creating actor at {:?} targeting {:?} with speed {}",
             position,
             target,
@@ -40,13 +40,13 @@ impl Actor {
             let fear_radius = self.fraidiness_factor * threat.meanness_factor() * 2.0;
             let avoidance_radius = fear_radius.max(self.speed);
 
-            log!(
+            debug_log!(
                 "Actor pos: {:?}, Threat pos: {:?}",
                 self.entity.position,
                 threat_pos
             );
-            log!("To actor vector: {:?}, distance: {:.2}", to_actor, distance);
-            log!(
+            debug_log!("To actor vector: {:?}, distance: {:.2}", to_actor, distance);
+            debug_log!(
                 "Fear radius: {:.2}, Avoidance radius: {:.2}",
                 fear_radius,
                 avoidance_radius
@@ -55,11 +55,11 @@ impl Actor {
             // Calculate fear effect based on distance to threat
             // Start avoiding before we get too close
             if distance <= avoidance_radius {
-                log!("Run away!");
+                debug_log!("Run away!");
                 // Get perpendicular vector for sideways avoidance
                 let perp = Vec3::new(-to_actor.y, to_actor.x, 0.0).normalize();
 
-                log!("Perpendicular vector: {:?}", perp);
+                debug_log!("Perpendicular vector: {:?}", perp);
 
                 // Scale fear effect based on how close we are
                 let fear_scale = if distance < fear_radius {
@@ -70,12 +70,12 @@ impl Actor {
                     distance / avoidance_radius
                 };
 
-                log!("Fear scale: {:?}", fear_scale);
+                debug_log!("Fear scale: {:?}", fear_scale);
 
                 // Combine direct avoidance with perpendicular movement
                 fear_vector += to_actor.normalize() * fear_scale + perp * fear_scale;
 
-                log!("Fear vector: {:?}", fear_vector);
+                debug_log!("Fear vector: {:?}", fear_vector);
             }
         }
 
@@ -113,7 +113,7 @@ impl Actor {
             Vec3::ZERO
         };
 
-        log!(
+        debug_log!(
             "Actor at {:?}, final direction: {:?}",
             self.entity.position,
             final_direction
@@ -122,7 +122,7 @@ impl Actor {
         if final_direction.length() > 0.0 {
             let new_pos = self.entity.position + final_direction;
 
-            log!("Moving to {:?}", new_pos);
+            debug_log!("Moving to {:?}", new_pos);
             self.entity.position = new_pos;
         }
     }

--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,4 +1,3 @@
-use crate::debug_log;
 use crate::entity::{CausesFear, Entity};
 use glam::Vec3;
 
@@ -11,7 +10,7 @@ pub struct Actor {
 
 impl Actor {
     pub fn new(position: Vec3, target: Vec3, speed: f32, fraidiness: f32) -> Self {
-        debug_log!(
+        log::debug!(
             "Creating actor at {:?} targeting {:?} with speed {}",
             position,
             target,
@@ -40,13 +39,13 @@ impl Actor {
             let fear_radius = self.fraidiness_factor * threat.meanness_factor() * 2.0;
             let avoidance_radius = fear_radius.max(self.speed);
 
-            debug_log!(
+            log::debug!(
                 "Actor pos: {:?}, Threat pos: {:?}",
                 self.entity.position,
                 threat_pos
             );
-            debug_log!("To actor vector: {:?}, distance: {:.2}", to_actor, distance);
-            debug_log!(
+            log::debug!("To actor vector: {:?}, distance: {:.2}", to_actor, distance);
+            log::debug!(
                 "Fear radius: {:.2}, Avoidance radius: {:.2}",
                 fear_radius,
                 avoidance_radius
@@ -55,11 +54,11 @@ impl Actor {
             // Calculate fear effect based on distance to threat
             // Start avoiding before we get too close
             if distance <= avoidance_radius {
-                debug_log!("Run away!");
+                log::debug!("Run away!");
                 // Get perpendicular vector for sideways avoidance
                 let perp = Vec3::new(-to_actor.y, to_actor.x, 0.0).normalize();
 
-                debug_log!("Perpendicular vector: {:?}", perp);
+                log::debug!("Perpendicular vector: {:?}", perp);
 
                 // Scale fear effect based on how close we are
                 let fear_scale = if distance < fear_radius {
@@ -70,12 +69,12 @@ impl Actor {
                     distance / avoidance_radius
                 };
 
-                debug_log!("Fear scale: {:?}", fear_scale);
+                log::debug!("Fear scale: {:?}", fear_scale);
 
                 // Combine direct avoidance with perpendicular movement
                 fear_vector += to_actor.normalize() * fear_scale + perp * fear_scale;
 
-                debug_log!("Fear vector: {:?}", fear_vector);
+                log::debug!("Fear vector: {:?}", fear_vector);
             }
         }
 
@@ -113,7 +112,7 @@ impl Actor {
             Vec3::ZERO
         };
 
-        debug_log!(
+        log::debug!(
             "Actor at {:?}, final direction: {:?}",
             self.entity.position,
             final_direction
@@ -122,7 +121,7 @@ impl Actor {
         if final_direction.length() > 0.0 {
             let new_pos = self.entity.position + final_direction;
 
-            debug_log!("Moving to {:?}", new_pos);
+            log::debug!("Moving to {:?}", new_pos);
             self.entity.position = new_pos;
         }
     }

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 
 use crate::components::{DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::DdlogHandle;
-use crate::log;
+use crate::debug_log;
 
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
@@ -11,7 +11,7 @@ pub fn push_state_to_ddlog_system(
     query: Query<(&DdlogId, &Transform, &Health, &UnitType, Option<&Target>)>,
 ) {
     for (id, transform, health, unit, target) in &query {
-        log!(
+        debug_log!(
             "Sync Entity {} pos=({:.1},{:.1}) hp={} type={:?} has_target={}",
             id.0,
             transform.translation.x,

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -10,7 +10,7 @@ pub fn push_state_to_ddlog_system(
     query: Query<(&DdlogId, &Transform, &Health, &UnitType, Option<&Target>)>,
 ) {
     for (id, transform, health, unit, target) in &query {
-        log::debug!(
+        log::trace!(
             "Sync Entity {} pos=({:.1},{:.1}) hp={} type={:?} has_target={}",
             id.0,
             transform.translation.x,

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -2,7 +2,6 @@ use bevy::prelude::*;
 
 use crate::components::{DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::DdlogHandle;
-use crate::debug_log;
 
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
@@ -11,7 +10,7 @@ pub fn push_state_to_ddlog_system(
     query: Query<(&DdlogId, &Transform, &Health, &UnitType, Option<&Target>)>,
 ) {
     for (id, transform, health, unit, target) in &query {
-        debug_log!(
+        log::debug!(
             "Sync Entity {} pos=({:.1},{:.1}) hp={} type={:?} has_target={}",
             id.0,
             transform.translation.x,

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,4 +1,4 @@
-use crate::log;
+use crate::debug_log;
 use crate::world::GameWorld;
 use piston_window::*;
 use std::error::Error;
@@ -19,7 +19,7 @@ impl GraphicsContext {
 
         // Get font path from build script
         let font_path = env!("FONT_PATH");
-        log!("Loading font from: {}", font_path);
+        debug_log!("Loading font from: {}", font_path);
 
         // Load font using window's built-in method
         let glyphs = window.load_font(font_path)?;
@@ -68,7 +68,7 @@ impl GraphicsContext {
                 c.transform.trans(10.0, 30.0),
                 g,
             ) {
-                log!("Failed to render text: {}", e);
+                debug_log!("Failed to render text: {}", e);
             }
 
             // Ensure glyphs are updated

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -1,4 +1,3 @@
-use crate::debug_log;
 use crate::world::GameWorld;
 use piston_window::*;
 use std::error::Error;
@@ -19,7 +18,7 @@ impl GraphicsContext {
 
         // Get font path from build script
         let font_path = env!("FONT_PATH");
-        debug_log!("Loading font from: {}", font_path);
+        log::debug!("Loading font from: {}", font_path);
 
         // Load font using window's built-in method
         let glyphs = window.load_font(font_path)?;
@@ -68,7 +67,7 @@ impl GraphicsContext {
                 c.transform.trans(10.0, 30.0),
                 g,
             ) {
-                debug_log!("Failed to render text: {}", e);
+                log::debug!("Failed to render text: {}", e);
             }
 
             // Ensure glyphs are updated

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,21 +1,24 @@
-use once_cell::sync::Lazy;
-use std::sync::atomic::{AtomicBool, Ordering};
+use env_logger::Builder;
+use log::LevelFilter;
 
-static VERBOSE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
-
+/// Initializes the global logger.
+///
+/// When `verbose` is `true`, all debug messages are printed. Otherwise only
+/// info level and above are shown.
 pub fn init(verbose: bool) {
-    VERBOSE.store(verbose, Ordering::SeqCst);
+    let level = if verbose {
+        LevelFilter::Debug
+    } else {
+        LevelFilter::Info
+    };
+
+    // Ignore reinitialization errors when tests call `init` multiple times.
+    let _ = Builder::new().filter_level(level).try_init();
 }
 
 #[macro_export]
 macro_rules! log {
     ($($arg:tt)*) => {
-        if $crate::logging::is_verbose() {
-            eprintln!($($arg)*);
-        }
+        log::debug!($($arg)*);
     };
-}
-
-pub fn is_verbose() -> bool {
-    VERBOSE.load(Ordering::SeqCst)
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,17 +15,6 @@ pub fn init(verbose: bool) {
     let env = Env::default().default_filter_or(level.to_string());
     let mut builder = Builder::from_env(env);
 
-    if let Err(err) = builder.try_init() {
-        // Only suppress errors caused by multiple initializations.
-        if !err.to_string().contains("set a logger") {
-            eprintln!("Failed to initialize logger: {err}");
-        }
-    }
-}
-
-#[macro_export]
-macro_rules! debug_log {
-    ($($arg:tt)*) => {
-        log::debug!($($arg)*);
-    };
+    // Ignore repeated initialization attempts.
+    let _ = builder.try_init();
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,4 +1,4 @@
-use env_logger::Builder;
+use env_logger::{Builder, Env};
 use log::LevelFilter;
 
 /// Initializes the global logger.
@@ -12,12 +12,19 @@ pub fn init(verbose: bool) {
         LevelFilter::Info
     };
 
-    // Ignore reinitialization errors when tests call `init` multiple times.
-    let _ = Builder::new().filter_level(level).try_init();
+    let env = Env::default().default_filter_or(level.to_string());
+    let mut builder = Builder::from_env(env);
+
+    if let Err(err) = builder.try_init() {
+        // Only suppress errors caused by multiple initializations.
+        if !err.to_string().contains("set a logger") {
+            eprintln!("Failed to initialize logger: {err}");
+        }
+    }
 }
 
 #[macro_export]
-macro_rules! log {
+macro_rules! debug_log {
     ($($arg:tt)*) => {
         log::debug!($($arg)*);
     };

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -15,6 +15,7 @@ pub fn init(verbose: bool) {
     let env = Env::default().default_filter_or(level.to_string());
     let mut builder = Builder::from_env(env);
 
-    // Ignore repeated initialization attempts.
+    // `try_init` only fails if a logger was already set. Ignore that case so
+    // tests can call `init` multiple times without panicking.
     let _ = builder.try_init();
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,5 +1,5 @@
 use env_logger::{Builder, Env};
-use log::{LevelFilter, SetLoggerError};
+use log::LevelFilter;
 
 /// Initializes the global logger.
 ///
@@ -7,20 +7,15 @@ use log::{LevelFilter, SetLoggerError};
 /// info level and above are shown.
 pub fn init(verbose: bool) {
     let level = if verbose {
-        LevelFilter::Debug
+        LevelFilter::Trace
     } else {
         LevelFilter::Info
     };
 
-    let env = Env::default().default_filter_or(level.to_string().to_lowercase());
-    let mut builder = Builder::from_env(env);
+    let mut builder = Builder::from_env(Env::default());
+    builder.filter_level(level);
     builder.format_timestamp_secs().format_module_path(true);
 
-    if let Err(e) = builder.try_init() {
-        // Only suppress the AlreadyInit error so tests can call `init` multiple
-        // times. Log any other error so it's not silently ignored.
-        if !matches!(e, SetLoggerError { .. }) {
-            eprintln!("Failed to initialize logger: {e}");
-        }
-    }
+    // Ignore the error if the logger has already been initialized.
+    let _ = builder.try_init();
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,4 @@
 use crate::actor::Actor;
-use crate::debug_log;
 use crate::entity::{BadGuy, CausesFear, Entity};
 use bevy::prelude::{ResMut, Resource};
 use glam::Vec3;
@@ -47,7 +46,7 @@ impl GameWorld {
     pub fn update(&mut self) {
         if self.last_tick.elapsed() >= TICK_DURATION {
             self.tick_count += 1;
-            debug_log!("\nTick {}", self.tick_count);
+            log::debug!("\nTick {}", self.tick_count);
 
             // Collect threats and their positions
             let threats: Vec<&dyn CausesFear> = self

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,6 +1,6 @@
 use crate::actor::Actor;
+use crate::debug_log;
 use crate::entity::{BadGuy, CausesFear, Entity};
-use crate::log;
 use bevy::prelude::{ResMut, Resource};
 use glam::Vec3;
 use hashbrown::HashMap;
@@ -47,7 +47,7 @@ impl GameWorld {
     pub fn update(&mut self) {
         if self.last_tick.elapsed() >= TICK_DURATION {
             self.tick_count += 1;
-            log!("\nTick {}", self.tick_count);
+            debug_log!("\nTick {}", self.tick_count);
 
             // Collect threats and their positions
             let threats: Vec<&dyn CausesFear> = self


### PR DESCRIPTION
## Summary
- add `log` and `env_logger` dependencies
- overhaul `logging` module to initialise `env_logger` and emit debug logs via `log::debug!`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846c87dba588322856866a4ff12f87f

## Summary by Sourcery

Overhaul the logging system to use the standard `log` facade and `env_logger`, gating verbose output behind configurable log levels and removing the custom logging macro.

Enhancements:
- Initialize global logging in `logging::init` with `env_logger` to respect a verbose flag for debug/trace levels
- Replace the custom `log!` macro and static verbose flag with standard `log::debug!` and `log::trace!` calls across actor, graphics, ddlog_sync, and world modules

Build:
- Add `log` and `env_logger` dependencies and remove the `once_cell` crate dependency