### PR TITLE
Add DDlog installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,7 @@ To install the DDlog toolchain required for development run:
 source ~/.ddlog_env
 ```
 
-This downloads DDlog v1.2.3 into `~/.local/ddlog` and updates
-`PATH` and `DDLOG_HOME` via `~/.ddlog_env`.
+The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes
+environment variable assignments to `~/.ddlog_env`. If that file
+already exists it will be backed up with a `.bak` suffix before
+being replaced.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@ A simple real-time strategy prototype demonstrating a DDlog-driven
 game loop with Bevy rendering. The project currently implements
 "Phase 1" of the migration roadmap, synchronising the legacy
 `GameWorld` state into Bevy and rendering static entities.
+
+## Installing DDlog
+
+To install the DDlog toolchain required for development run:
+
+```bash
+./scripts/install_ddlog.sh
+source ~/.ddlog_env
+```
+
+This downloads DDlog v1.2.3 into `~/.local/ddlog` and updates
+`PATH` and `DDLOG_HOME` via `~/.ddlog_env`.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ To install the DDlog toolchain required for development run:
 source ~/.ddlog_env
 ```
 
+The `source` command loads the DDlog environment variables into the
+current shell session.
+
 The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes
 environment variable assignments to `~/.ddlog_env`. If that file
 already exists it will be backed up with a `.bak` suffix before

--- a/README.md
+++ b/README.md
@@ -17,4 +17,5 @@ source ~/.ddlog_env
 The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes
 environment variable assignments to `~/.ddlog_env`. If that file
 already exists it will be backed up with a `.bak` suffix before
-being replaced.
+being replaced. Any existing directory at `~/.local/ddlog` will be
+removed prior to extraction.

--- a/scripts/install_ddlog.sh
+++ b/scripts/install_ddlog.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install DDlog from the v1.2.3 release archive into ~/.local/ddlog.
+# After installation, environment variables required for DDlog
+# are written to ~/.ddlog_env in a form suitable for sourcing.
+
+ARCHIVE_URL="https://github.com/vmware-archive/differential-datalog/releases/download/v1.2.3/ddlog-v1.2.3-20211213235218-Linux.tar.gz"
+INSTALL_DIR="$HOME/.local/ddlog"
+ENV_FILE="$HOME/.ddlog_env"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+curl -L "$ARCHIVE_URL" -o "$TMP_DIR/ddlog.tgz"
+
+rm -rf "$INSTALL_DIR"
+mkdir -p "$INSTALL_DIR"
+tar -xzf "$TMP_DIR/ddlog.tgz" -C "$TMP_DIR"
+mv "$TMP_DIR/ddlog" "$INSTALL_DIR"
+
+cat > "$ENV_FILE" <<EOV
+export DDLOG_HOME="$INSTALL_DIR"
+export PATH="${INSTALL_DIR}/bin:\$PATH"
+EOV
+
+echo "DDlog installed to $INSTALL_DIR"
+echo "Source $ENV_FILE to update your environment"
+

--- a/scripts/install_ddlog.sh
+++ b/scripts/install_ddlog.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Cleanup temporary directory on exit if it was created
+TMP_DIR=""
+trap 'if [ -n "${TMP_DIR:-}" ]; then rm -rf "$TMP_DIR"; fi' EXIT
+
 # Install DDlog from the v1.2.3 release archive into ~/.local/ddlog.
 # After installation, environment variables required for DDlog
 # are written to ~/.ddlog_env in a form suitable for sourcing.
@@ -28,7 +32,6 @@ case "$(uname -m)" in
 esac
 
 TMP_DIR="$(mktemp -d)"
-trap 'rm -rf "$TMP_DIR"' EXIT
 
 echo "Downloading DDlog archive..."
 curl --fail -L "$ARCHIVE_URL" -o "$TMP_DIR/ddlog.tgz"

--- a/scripts/install_ddlog.sh
+++ b/scripts/install_ddlog.sh
@@ -34,7 +34,6 @@ echo "Downloading DDlog archive..."
 curl --fail -L "$ARCHIVE_URL" -o "$TMP_DIR/ddlog.tgz"
 
 rm -rf "$INSTALL_DIR"
-mkdir -p "$INSTALL_DIR"
 
 echo "Extracting..."
 tar -xzf "$TMP_DIR/ddlog.tgz" -C "$TMP_DIR"


### PR DESCRIPTION
## Summary
- add script to install DDlog to `~/.local/ddlog`
- document the script in the README

## Testing
- `cargo fmt --all` *(fails: mismatched closing delimiter)*
- `cargo clippy --all-targets -- -D warnings` *(fails to compile project)*
- `cargo test --all --no-run` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_6847413c8f9c8322ba9010db87a63b11

## Summary by Sourcery

Add a DDlog installer script with environment configuration and update the README to guide users through installation

New Features:
- Add a Bash installer script to download and install DDlog v1.2.3 into ~/.local/ddlog and generate environment setup

Documentation:
- Document the DDlog installation script and environment variable setup in the README