### PR TITLE
Fix clippy errors

### DIFF
--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -13,9 +13,17 @@ pub fn push_state_to_ddlog_system(
     let mut new_entities = HashMap::with_capacity(query.iter().len());
 
     for (id, transform, health, unit, target) in &query {
-        new_entities.insert(
         log::trace!(
             "Sync Entity {} pos=({:.1},{:.1}) hp={} type={:?} has_target={}",
+            id.0,
+            transform.translation.x,
+            transform.translation.y,
+            health.0,
+            unit,
+            target.is_some()
+        );
+
+        new_entities.insert(
             id.0,
             DdlogEntity {
                 position: transform.translation.truncate(),

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -14,7 +14,7 @@ pub fn push_state_to_ddlog_system(
 
     for (id, transform, health, unit, target) in &query {
         log::trace!(
-            "Sync Entity {} pos=({:.1},{:.1}) hp={} type={:?} has_target={}",
+            "Sync Entity {} pos=({:.1},{:.1}) hp={} unit={:?} has_target={}",
             id.0,
             transform.translation.x,
             transform.translation.y,


### PR DESCRIPTION
## Summary
- fix mismatched delimiter in `ddlog_sync`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684744ffda0c832285f01ee03576462d

## Summary by Sourcery

Fix mismatched delimiters in ddlog_sync by separating the log trace call from the new_entities.insert invocation and updating the trace format and arguments.

Bug Fixes:
- Remove the new_entities.insert call from inside the log::trace! macro to resolve delimiter mismatch
- Add missing parameters (id, position, health, unit, target flag) to the log trace invocation
- Change the log trace placeholder label from type to unit to match the passed value