### PR TITLE
Implement FloorHeightAt rules

### DIFF
--- a/src/lille.dl
+++ b/src/lille.dl
@@ -4,13 +4,49 @@ typedef BlockID = signed<64>
 // Continuous coordinate used for sub-block precision
 typedef GCoord = float
 
+// --- Physics Constants ---
+const GRACE_DISTANCE: GCoord = 0.1
+
 // --- World Geometry Relations ---
 input relation Block(id: BlockID, x: signed32, y: signed32, z: signed32)
 input relation BlockSlope(block: BlockID, grad_x: GCoord, grad_y: GCoord)
 
+// Finds the highest block at a given (x,y) grid location.
+relation HighestBlockAt(x_grid: signed32, y_grid: signed32, block: BlockID, z_grid: signed32) :-
+    Block(block, x_grid, y_grid, z_grid),
+    not Block(_, x_grid, y_grid, z_grid + 1).
+
+// Calculates the floor Z coordinate at a given continuous (x,y) position when the block has a slope.
+relation FloorHeightAt(x: GCoord, y: GCoord, z_floor: GCoord) :-
+    var x_grid = floor(x),
+    var y_grid = floor(y),
+    HighestBlockAt(x_grid, y_grid, block, z_grid),
+    BlockSlope(block, grad_x, grad_y),
+    var x_in_block = x - x_grid,
+    var y_in_block = y - y_grid,
+    z_floor = (z_grid as GCoord) + 1.0 + (x_in_block * grad_x) + (y_in_block * grad_y).
+
+// Calculates the floor Z coordinate for a flat block.
+relation FloorHeightAt(x: GCoord, y: GCoord, z_floor: GCoord) :-
+    var x_grid = floor(x),
+    var y_grid = floor(y),
+    HighestBlockAt(x_grid, y_grid, block, z_grid),
+    not BlockSlope(block, _, _),
+    z_floor = (z_grid as GCoord) + 1.0.
+
 // --- Entity Position Relations ---
 input relation Position(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
 output relation NewPosition(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
+
+// --- Entity State Relations ---
+relation IsUnsupported(entity: EntityID) :-
+    Position(entity, x, y, z),
+    FloorHeightAt(x, y, z_floor),
+    z > z_floor + GRACE_DISTANCE.
+
+relation IsStanding(entity: EntityID) :-
+    Position(entity, _, _, _),
+    not IsUnsupported(entity).
 
 // Placeholder rule mirroring input to output
 NewPosition(e, x, y, z) :- Position(e, x, y, z).

--- a/src/lille.dl
+++ b/src/lille.dl
@@ -11,10 +11,14 @@ const GRACE_DISTANCE: GCoord = 0.1
 input relation Block(id: BlockID, x: signed32, y: signed32, z: signed32)
 input relation BlockSlope(block: BlockID, grad_x: GCoord, grad_y: GCoord)
 
-// Finds the highest block at a given (x,y) grid location.
+// 1. Aggregate highest Z per (x,y)
+relation HighestZAt(x_grid: signed32, y_grid: signed32, z_top: signed32) :-
+    z_top = max(z) (Block(_, x_grid, y_grid, z)).
+
+// 2. Produce the matching block id
 relation HighestBlockAt(x_grid: signed32, y_grid: signed32, block: BlockID, z_grid: signed32) :-
     Block(block, x_grid, y_grid, z_grid),
-    not Block(_, x_grid, y_grid, z_grid + 1).
+    HighestZAt(x_grid, y_grid, z_grid).
 
 // Calculates the floor Z coordinate at a given continuous (x,y) position when the block has a slope.
 relation FloorHeightAt(x: GCoord, y: GCoord, z_floor: GCoord) :-
@@ -24,7 +28,8 @@ relation FloorHeightAt(x: GCoord, y: GCoord, z_floor: GCoord) :-
     BlockSlope(block, grad_x, grad_y),
     var x_in_block = x - x_grid,
     var y_in_block = y - y_grid,
-    z_floor = (z_grid as GCoord) + 1.0 + (x_in_block * grad_x) + (y_in_block * grad_y).
+    var z_base: GCoord = z_grid as GCoord + 1.0,
+    z_floor = z_base + (x_in_block * grad_x) + (y_in_block * grad_y).
 
 // Calculates the floor Z coordinate for a flat block.
 relation FloorHeightAt(x: GCoord, y: GCoord, z_floor: GCoord) :-
@@ -39,9 +44,12 @@ input relation Position(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
 output relation NewPosition(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
 
 // --- Entity State Relations ---
+relation MaxFloor(x: GCoord, y: GCoord, z_max: GCoord) :-
+    z_max = max(z) (FloorHeightAt(x, y, z)).
+
 relation IsUnsupported(entity: EntityID) :-
     Position(entity, x, y, z),
-    FloorHeightAt(x, y, z_floor),
+    MaxFloor(x, y, z_floor),
     z > z_floor + GRACE_DISTANCE.
 
 relation IsStanding(entity: EntityID) :-

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -62,3 +62,15 @@ fn ddlog_flees_from_baddie() {
         ent.position.x
     );
 }
+
+#[test]
+fn ddlog_program_has_floor_height_rules() {
+    let dl = std::fs::read_to_string("src/lille.dl").expect("read lille.dl");
+    assert!(dl.contains("FloorHeightAt"), "FloorHeightAt rule missing");
+    assert!(dl.contains("IsUnsupported"), "IsUnsupported rule missing");
+    assert!(dl.contains("IsStanding"), "IsStanding rule missing");
+    assert!(
+        dl.contains("GRACE_DISTANCE"),
+        "GRACE_DISTANCE constant missing"
+    );
+}

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -1,6 +1,8 @@
 use glam::Vec2;
 use lille::{ddlog_handle::DdlogEntity, DdlogHandle, UnitType};
 
+const DL_SRC: &str = include_str!("../src/lille.dl");
+
 #[test]
 fn ddlog_moves_towards_target() {
     let mut handle = DdlogHandle::default();
@@ -65,12 +67,28 @@ fn ddlog_flees_from_baddie() {
 
 #[test]
 fn ddlog_program_has_floor_height_rules() {
-    let dl = std::fs::read_to_string("src/lille.dl").expect("read lille.dl");
-    assert!(dl.contains("FloorHeightAt"), "FloorHeightAt rule missing");
-    assert!(dl.contains("IsUnsupported"), "IsUnsupported rule missing");
-    assert!(dl.contains("IsStanding"), "IsStanding rule missing");
     assert!(
-        dl.contains("GRACE_DISTANCE"),
-        "GRACE_DISTANCE constant missing"
+        DL_SRC
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|tok| tok == "FloorHeightAt"),
+        "FloorHeightAt rule missing",
+    );
+    assert!(
+        DL_SRC
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|tok| tok == "IsUnsupported"),
+        "IsUnsupported rule missing",
+    );
+    assert!(
+        DL_SRC
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|tok| tok == "IsStanding"),
+        "IsStanding rule missing",
+    );
+    assert!(
+        DL_SRC
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .any(|tok| tok == "GRACE_DISTANCE"),
+        "GRACE_DISTANCE constant missing",
     );
 }


### PR DESCRIPTION
## Summary
- implement FloorHeightAt and entity state rules in DDlog
- check DDlog file for new rules in tests

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c703ed0d88322b9efe8195814f485

## Summary by Sourcery

Implement FloorHeightAt, IsUnsupported, and IsStanding rules along with the GRACE_DISTANCE constant in the DDlog program and add a test to verify their presence in lille.dl.

New Features:
- Add FloorHeightAt rule, IsUnsupported and IsStanding entity state rules, and GRACE_DISTANCE constant to the DDlog program

Tests:
- Add ddlog_program_has_floor_height_rules test to check for FloorHeightAt, IsUnsupported, IsStanding, and GRACE_DISTANCE in src/lille.dl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new physics-related constants and logic for determining floor height, highest block positions, and entity standing status.
- **Tests**
  - Added a test to verify the presence of new rules and constants related to floor height and entity support in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->