### PR TITLE
Fix Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lille
+# Lille
 
 A simple real-time strategy prototype demonstrating a DDlog-driven game loop
 with Bevy rendering. The project currently implements "Phase 1" of the migration

--- a/README.md
+++ b/README.md
@@ -1,25 +1,38 @@
 # lille
 
-A simple real-time strategy prototype demonstrating a DDlog-driven
-game loop with Bevy rendering. The project currently implements
-"Phase 1" of the migration roadmap, synchronising the legacy
-`GameWorld` state into Bevy and rendering static entities.
+A simple real-time strategy prototype demonstrating a DDlog-driven game loop
+with Bevy rendering. The project currently implements "Phase 1" of the migration
+roadmap, synchronising the legacy `GameWorld` state into Bevy and rendering
+static entities.
 
-# **Lille**
+## Game Setting
 
 *A fractured city of steel, brick, and neon — and your next battlefield.*
 
-A city with too many masters and too little future. Once the jewel of a vanished federation, its streets are now ruled by whoever can seize them — corporate militias, rogue syndicates, data cults, and the last vestiges of an irrelevant state.
+A city with too many masters and too little future. Once the jewel of a vanished
+federation, its streets are now ruled by whoever can seize them — corporate
+militias, rogue syndicates, data cults and the last vestiges of an irrelevant
+state.
 
-The skyline tells the story: rusted iron arcades tower over flooded canals and cracked boulevards. Century-old stone buildings are patched with ferroglass and recycled scaffolds. Above them loom crumbling superstructures from a failed age of expansion, their data relays and skyways flickering with black market signals.
+The skyline tells the story: rusted iron arcades tower over flooded canals and
+cracked boulevards. Century-old stone buildings are patched with ferroglass and
+recycled scaffolds. Above them loom crumbling superstructures from a failed age
+of expansion, their data relays and skyways flickering with black market
+signals.
 
-Beneath this decaying grandeur, commerce thrives in the margins. Street-level markets sprawl through abandoned plazas; encrypted auction houses operate out of gutted tram stations. Every corner offers a new opportunity — or an ambush.
+Beneath this decaying grandeur, commerce thrives in the margins. Street-level
+markets sprawl through abandoned plazas; encrypted auction houses operate out of
+gutted tram stations. Every corner offers a new opportunity — or an ambush.
 
-Here, real power belongs to those who can move fastest, strike hardest, and control the flow of information. Squads operate in the open, armed and augmented. Every mission risks crossing the unseen lines between factions — and starting a war you can't finish.
+Here, real power belongs to those who can move fastest, strike hardest and
+control the flow of information. Squads operate in the open, armed and
+augmented. Every mission risks crossing the unseen lines between factions — and
+starting a war you cannot finish.
 
-## Prepare to deploy.
+## Prepare to Deploy
 
-Control is an illusion. Ownership is temporary. The streets belong to those who can take them — and keep them.
+Control is an illusion. Ownership is temporary. The streets belong to those who
+can take them — and keep them.
 
 ## Installing DDlog
 
@@ -30,15 +43,14 @@ To install the DDlog toolchain required for development run:
 source ./.env
 ```
 
-The `source` command loads the DDlog environment variables into the
-current shell session.
+The `source` command loads the DDlog environment variables into the current
+shell session.
 
-The build script also loads this `.env` automatically using the
-`dotenvy` crate so that `cargo build` can locate the `ddlog` compiler
-and standard library without additional setup.
+The build script also loads this `.env` automatically using the `dotenvy` crate
+so that `cargo build` can locate the `ddlog` compiler and standard library
+without additional setup.
 
-The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes
-environment variable assignments to `.env`. If that file
-already exists it will be backed up with a `.bak` suffix before
-being replaced. Any existing directory at `~/.local/ddlog` will be
-removed prior to extraction.
+The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes environment
+variable assignments to `.env`. If that file already exists it will be backed up
+with a `.bak` suffix before being replaced. Any existing directory at
+`~/.local/ddlog` will be removed prior to extraction.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ static entities.
 
 A city with too many masters and too little future. Once the jewel of a vanished
 federation, its streets are now ruled by whoever can seize them — corporate
-militias, rogue syndicates, data cults and the last vestiges of an irrelevant
+militias, rogue syndicates, data cults, and the last vestiges of an irrelevant
 state.
 
 The skyline tells the story: rusted iron arcades tower over flooded canals and
@@ -24,8 +24,8 @@ Beneath this decaying grandeur, commerce thrives in the margins. Street-level
 markets sprawl through abandoned plazas; encrypted auction houses operate out of
 gutted tram stations. Every corner offers a new opportunity — or an ambush.
 
-Here, real power belongs to those who can move fastest, strike hardest and
-control the flow of information. Squads operate in the open, armed and
+Here, real power belongs to those who can move fastest, strike hardest, and
+control the flow of information. Squads operate in the open, armed, and
 augmented. Every mission risks crossing the unseen lines between factions — and
 starting a war you cannot finish.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple real-time strategy prototype demonstrating a DDlog-driven game loop
 with Bevy rendering. The project currently implements "Phase 1" of the migration
-roadmap, synchronising the legacy `GameWorld` state into Bevy and rendering
+roadmap, synchronizing the legacy `GameWorld` state into Bevy and rendering
 static entities.
 
 ## Game Setting
@@ -51,6 +51,6 @@ so that `cargo build` can locate the `ddlog` compiler and standard library
 without additional setup.
 
 The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes environment
-variable assignments to `.env`. If that file already exists it will be backed up
+variable assignments to `.env`. If that file already exists, it will be backed up
 with a `.bak` suffix before being replaced. Any existing directory at
-`~/.local/ddlog` will be removed prior to extraction.
+`~/.local/ddlog` will be removed before extraction.


### PR DESCRIPTION
## Summary
- fix README Markdown lint errors

## Testing
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684d6511ef448322b15b51bfd52fbcab

## Summary by Sourcery

Fix markdown formatting issues in the README to satisfy lint rules

Documentation:
- Reflow README paragraphs for consistent line wrapping and whitespace
- Standardize headings (e.g. "Game Setting", "Prepare to Deploy") and list punctuation for uniform style

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved formatting and consistency in the README, including updated headings, clearer paragraphs, and minor wording adjustments for readability. No changes to technical content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->