### PR TITLE
Add documentation style guide

### DIFF
--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -1,0 +1,67 @@
+# Documentation style guide
+
+This guide outlines conventions for authoring documentation for Lille. Apply
+these rules to keep the documentation clear and consistent for developers.
+
+## Spelling
+
+- Use British English based on the
+  [Oxford English Dictionary](https://public.oed.com/) (en-oxendict).
+- The word **"outwith"** is acceptable.
+- Keep US spelling when used in an API, for example `color`.
+- The project licence file is spelled `LICENSE` for community consistency.
+
+## Punctuation and grammar
+
+- Use the Oxford comma: "ships, planes, and hovercraft".
+- Company names are treated as collective nouns:
+  "Lille Industries are expanding".
+
+## Headings
+
+- Write headings in sentence case.
+- Use Markdown headings (`#`, `##`, `###`, and so on) in order without skipping
+  levels.
+
+## Markdown rules
+
+- Follow [markdownlint](https://github.com/DavidAnson/markdownlint)
+  recommendations[^markdownlint].
+- Provide code blocks and lists using standard Markdown syntax.
+- Always use fenced code blocks with a language identifier;
+  use `plaintext` for non-code text.
+- Use `-` as the first level bullet and renumber lists when items change.
+
+## Expanding acronyms
+
+- Expand any uncommon acronym on first use, for example, Continuous Integration
+  (CI).
+
+## Formatting
+
+- Wrap paragraphs at 80 columns.
+- Wrap code at 120 columns.
+- Do not wrap tables.
+- Use footnotes referenced with `[^label]`.
+
+## Example snippet
+
+```rust
+/// A simple function demonstrating documentation style.
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## Diagrams
+
+Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
+
+```mermaid
+flowchart TD
+    A[Start] --> B[Draft]
+    B --> C[Review]
+    C --> D[Merge]
+```
+
+[^markdownlint]: A linter that enforces consistent Markdown formatting.

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -31,6 +31,7 @@ these rules to keep the documentation clear and consistent for developers.
 - Always use fenced code blocks with a language identifier;
   use `plaintext` for non-code text.
 - Use `-` as the first level bullet and renumber lists when items change.
+- Prefer inline links using `[text](url)` or angle brackets around the URL.
 
 ## Expanding acronyms
 
@@ -53,9 +54,12 @@ fn add(a: i32, b: i32) -> i32 {
 }
 ```
 
-## Diagrams
+## Diagrams and images
 
-Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
+Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams. When
+embedding figures, use `![alt text](path/to/image)` and provide concise alt text
+describing the content. Add a short description before each Mermaid diagram so
+screen readers can understand it.
 
 ```mermaid
 flowchart TD


### PR DESCRIPTION
## Summary
- add a style guide for project documentation
- include markdownlint link, footnotes, and formatting rules

## Testing
- `cargo fmt -- --check`
- `cargo clippy`
- `cargo test`
- `nixie docs/documentation-style-guide.md`


------
https://chatgpt.com/codex/tasks/task_e_684d76eb141c83229aa867c4117488bd

## Summary by Sourcery

Add a documentation style guide to establish consistent conventions for spelling, punctuation, headings, Markdown formatting, acronyms, examples, and diagrams.

Documentation:
- Introduce a comprehensive documentation style guide with rules for British English spelling, Oxford comma usage, and API-specific US spelling.
- Define heading and Markdown syntax conventions, including sentence case headings, fenced code blocks, and markdownlint compliance.
- Specify formatting guidelines for line wrapping, list bullets, footnotes, and table handling.
- Include examples for code snippets and Mermaid diagrams to illustrate documentation standards.