### PR TITLE
Add API doc comment conventions

### DIFF
--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -61,6 +61,9 @@ contents of the manual.
 
 - Begin each block with `///`.
 - Keep the summary line short, followed by further detail.
+- Explicitly document all parameters with `# Parameters`, describing each argument.
+- Document the return value with `# Returns`.
+- Document any panics or errors with `# Panics` or `# Errors` as appropriate.
 - Place examples under `# Examples` and mark the code block with `no_run` so
   they do not execute during documentation tests.
 - Put function attributes after the doc comment.
@@ -68,13 +71,20 @@ contents of the manual.
 ```rust
 /// Returns the sum of `a` and `b`.
 ///
+/// # Parameters
+/// - `a`: The first integer to add.
+/// - `b`: The second integer to add.
+///
+/// # Returns
+/// The sum of `a` and `b`.
+///
 /// # Examples
 ///
 /// ```rust,no_run
 /// assert_eq!(add(2, 3), 5);
 /// ```
 #[inline]
-fn add(a: i32, b: i32) -> i32 {
+pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 ```


### PR DESCRIPTION
## Summary
- extend documentation style guide with API doc comment rules

## Testing
- `nixie docs/documentation-style-guide.md`
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d9300cf08832297478bfcdcd5f2a1

## Summary by Sourcery

Extend the documentation style guide to include conventions for writing API doc comments for public Rust APIs.

Documentation:
- Add a new "API doc comments" section detailing use of `///`, concise summaries, `# Parameters`, `# Returns`, `# Panics/# Errors`, and `# Examples` blocks marked with `no_run`
- Include a Rust code example demonstrating the prescribed doc comment structure and attribute placement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new section on "API doc comments" to the documentation style guide, outlining conventions for documenting public APIs in Rust, including formatting, example usage, and code annotation guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->