### PR TITLE
Fix vector normalization logic

### DIFF
--- a/src/vector_math.rs
+++ b/src/vector_math.rs
@@ -5,7 +5,7 @@ pub fn vec_mag(x: f32, y: f32, z: f32) -> f32 {
     Vec3::new(x, y, z).length()
 }
 
-/// Normalises the vector `(x, y, z)`. If the vector is zero, returns `(0, 0, 0)`.
+/// Normalizes the vector `(x, y, z)`. If the vector is zero, returns `(0, 0, 0)`.
 pub fn vec_normalize(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
     let v = Vec3::new(x, y, z);
     if let Some(n) = v.try_normalize() {

--- a/src/vector_math.rs
+++ b/src/vector_math.rs
@@ -5,11 +5,10 @@ pub fn vec_mag(x: f32, y: f32, z: f32) -> f32 {
     Vec3::new(x, y, z).length()
 }
 
-/// Normalizes the vector `(x, y, z)`. If the vector is zero, returns `(0, 0, 0)`.
+/// Normalises the vector `(x, y, z)`. If the vector is zero, returns `(0, 0, 0)`.
 pub fn vec_normalize(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
     let v = Vec3::new(x, y, z);
-    if v.length_squared() > 0.0 {
-        let n = v.normalize();
+    if let Some(n) = v.try_normalize() {
         (n.x, n.y, n.z)
     } else {
         (0.0, 0.0, 0.0)


### PR DESCRIPTION
## Summary
- use British English spelling for vector normalisation
- leverage `try_normalize` to avoid redundant length checks

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684e202de1888322bef2f6aecad49fe4

## Summary by Sourcery

Streamline vector normalization by using Vec3::try_normalize and update documentation spelling

Enhancements:
- Replace manual length check with Vec3::try_normalize for vector normalization

Documentation:
- Standardise doc comment to British English spelling 'normalisation'