### PR TITLE
Fix vec_normalize NaN behaviour

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ insta = { version = "1.38.0", features = ["ron"] }
 rstest = "0.18.0"
 regex = "1"
 once_cell = "1"
+approx = "0.5"

--- a/src/vector_math.rs
+++ b/src/vector_math.rs
@@ -5,7 +5,21 @@ pub fn vec_mag(x: f32, y: f32, z: f32) -> f32 {
     Vec3::new(x, y, z).length()
 }
 
-/// Normalizes the vector `(x, y, z)`. If the vector is zero, returns `(0, 0, 0)`.
+/// Returns the unit vector in the direction of `(x, y, z)`, or `(0.0, 0.0, 0.0)` if the input is not a valid non-zero vector.
+///
+/// The function checks that all components are finite and the vector is non-zero before normalising. If the input is invalid or the zero vector, it returns the zero vector.
+///
+/// # Examples
+///
+/// ```
+/// let (nx, ny, nz) = vec_normalize(3.0, 0.0, 4.0);
+/// assert!((nx - 0.6).abs() < 1e-6);
+/// assert!((ny - 0.0).abs() < 1e-6);
+/// assert!((nz - 0.8).abs() < 1e-6);
+///
+/// let zero = vec_normalize(0.0, 0.0, 0.0);
+/// assert_eq!(zero, (0.0, 0.0, 0.0));
+/// ```
 pub fn vec_normalize(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
     let v = Vec3::new(x, y, z);
     if v.is_finite() {

--- a/src/vector_math.rs
+++ b/src/vector_math.rs
@@ -8,7 +8,8 @@ pub fn vec_mag(x: f32, y: f32, z: f32) -> f32 {
 /// Normalizes the vector `(x, y, z)`. If the vector is zero, returns `(0, 0, 0)`.
 pub fn vec_normalize(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
     let v = Vec3::new(x, y, z);
-    if let Some(n) = v.try_normalize() {
+    if v.is_finite() && v.length_squared() > 0.0 {
+        let n = v.normalize();
         (n.x, n.y, n.z)
     } else {
         (0.0, 0.0, 0.0)

--- a/src/vector_math.rs
+++ b/src/vector_math.rs
@@ -8,10 +8,13 @@ pub fn vec_mag(x: f32, y: f32, z: f32) -> f32 {
 /// Normalizes the vector `(x, y, z)`. If the vector is zero, returns `(0, 0, 0)`.
 pub fn vec_normalize(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
     let v = Vec3::new(x, y, z);
-    if v.is_finite() && v.length_squared() > 0.0 {
-        let n = v.normalize();
-        (n.x, n.y, n.z)
-    } else {
-        (0.0, 0.0, 0.0)
+    if v.is_finite() {
+        let len_sq = v.length_squared();
+        if len_sq > f32::EPSILON {
+            let len = len_sq.sqrt();
+            let n = v / len;
+            return (n.x, n.y, n.z);
+        }
     }
+    (0.0, 0.0, 0.0)
 }

--- a/tests/vector_math.rs
+++ b/tests/vector_math.rs
@@ -1,0 +1,13 @@
+use lille::vec_normalize;
+
+#[test]
+fn normalize_returns_zero_for_nan() {
+    let result = vec_normalize(f32::NAN, 1.0, 0.0);
+    assert_eq!(result, (0.0, 0.0, 0.0));
+}
+
+#[test]
+fn normalize_returns_normalized_vector() {
+    let result = vec_normalize(3.0, 0.0, 0.0);
+    assert_eq!(result, (1.0, 0.0, 0.0));
+}

--- a/tests/vector_math.rs
+++ b/tests/vector_math.rs
@@ -1,13 +1,18 @@
+use approx::assert_relative_eq;
 use lille::vec_normalize;
 
 #[test]
 fn normalize_returns_zero_for_nan() {
     let result = vec_normalize(f32::NAN, 1.0, 0.0);
-    assert_eq!(result, (0.0, 0.0, 0.0));
+    assert_relative_eq!(result.0, 0.0, max_relative = 1e-6);
+    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
+    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
 }
 
 #[test]
 fn normalize_returns_normalized_vector() {
     let result = vec_normalize(3.0, 0.0, 0.0);
-    assert_eq!(result, (1.0, 0.0, 0.0));
+    assert_relative_eq!(result.0, 1.0, max_relative = 1e-6);
+    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
+    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
 }


### PR DESCRIPTION
## Summary
- guard against NaN inputs in `vec_normalize`
- add unit tests for `vec_normalize`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684e22bebf3483229c668421c2465e96

## Summary by Sourcery

Guard vec_normalize against NaN, non-finite, and near-zero vectors by returning (0,0,0), inject precise normalization logic, and add related unit tests using the ‘approx’ crate.

Bug Fixes:
- Prevent NaN or non-finite inputs from producing NaN outputs in vec_normalize by returning a zero vector.

Enhancements:
- Refine vec_normalize to check for finiteness and use an EPSILON threshold before normalization.

Build:
- Add the ‘approx’ crate dependency for floating-point comparison in tests.

Tests:
- Add unit tests for vec_normalize to verify NaN input handling and correct normalization of valid vectors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced vector normalisation by explicitly checking vector validity and length, ensuring consistent zero vector output for invalid or near-zero inputs.

- **Tests**
  - Added tests to verify correct behaviour when normalising vectors with NaN values and standard non-zero vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->