### PR TITLE
Address review feedback for vec_normalize

### DIFF
--- a/src/vector_math.rs
+++ b/src/vector_math.rs
@@ -12,6 +12,7 @@ pub fn vec_mag(x: f32, y: f32, z: f32) -> f32 {
 /// # Examples
 ///
 /// ```
+/// use lille::vec_normalize;
 /// let (nx, ny, nz) = vec_normalize(3.0, 0.0, 4.0);
 /// assert!((nx - 0.6).abs() < 1e-6);
 /// assert!((ny - 0.0).abs() < 1e-6);
@@ -22,13 +23,10 @@ pub fn vec_mag(x: f32, y: f32, z: f32) -> f32 {
 /// ```
 pub fn vec_normalize(x: f32, y: f32, z: f32) -> (f32, f32, f32) {
     let v = Vec3::new(x, y, z);
-    if v.is_finite() {
-        let len_sq = v.length_squared();
-        if len_sq > f32::EPSILON {
-            let len = len_sq.sqrt();
-            let n = v / len;
-            return (n.x, n.y, n.z);
-        }
+    if !v.is_finite() {
+        return (0.0, 0.0, 0.0);
     }
-    (0.0, 0.0, 0.0)
+
+    let n = v.try_normalize().unwrap_or(Vec3::ZERO);
+    (n.x, n.y, n.z)
 }

--- a/tests/vector_math.rs
+++ b/tests/vector_math.rs
@@ -16,3 +16,19 @@ fn normalize_returns_normalized_vector() {
     assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
     assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
 }
+
+#[test]
+fn normalize_returns_zero_for_zero_vector() {
+    let result = vec_normalize(0.0, 0.0, 0.0);
+    assert_relative_eq!(result.0, 0.0, max_relative = 1e-6);
+    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
+    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
+}
+
+#[test]
+fn normalize_returns_zero_for_infinite_vector() {
+    let result = vec_normalize(f32::INFINITY, 0.0, 0.0);
+    assert_relative_eq!(result.0, 0.0, max_relative = 1e-6);
+    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
+    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
+}


### PR DESCRIPTION
## Summary
- fix documentation example for `vec_normalize`
- simplify `vec_normalize` logic and early-return on non-finite vectors
- test zero and infinite vectors in addition to NaN handling

## Testing
- `cargo clippy --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684e2f704c3083228dcc0fa6a6cba239

## Summary by Sourcery

Refine vec_normalize by simplifying its logic, handling non-finite inputs early, and expanding test coverage while correcting its documentation example.

Enhancements:
- Simplify vec_normalize implementation to early-return on non-finite vectors and delegate normalization to Vec3::try_normalize

Documentation:
- Add import statement to documentation example for vec_normalize

Tests:
- Add tests to ensure vec_normalize returns zero for zero and infinite vectors