### PR TITLE
Fix ddlog version warnings

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -94,7 +94,7 @@ fn ddlog_available() -> Result<bool, Box<dyn Error>> {
             );
             println!(
                 "cargo:warning=stderr: {}",
-                String::from_utf8_lossy(&output.stderr)
+                String::from_utf8_lossy(&output.stderr).trim()
             );
             Ok(false)
         }

--- a/build.rs
+++ b/build.rs
@@ -86,19 +86,21 @@ fn ddlog_available() -> Result<bool, Box<dyn Error>> {
             );
             Ok(true)
         }
+        // Use stdout so Cargo captures these warnings correctly
         Ok(output) => {
-            eprintln!(
+            println!(
                 "cargo:warning=ddlog --version failed with status {}",
                 output.status
             );
-            eprintln!(
+            println!(
                 "cargo:warning=stderr: {}",
                 String::from_utf8_lossy(&output.stderr)
             );
             Ok(false)
         }
         Err(e) => {
-            eprintln!("cargo:warning=failed to run ddlog --version: {}", e);
+            // Also print to stdout for Cargo's warning detection
+            println!("cargo:warning=failed to run ddlog --version: {}", e);
             Ok(false)
         }
     }


### PR DESCRIPTION
## Summary
- ensure ddlog version warnings are sent to stdout
- document the reason for using stdout

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ed153e55c832299ac0aa613ed6fd5

## Summary by Sourcery

Ensure ddlog version check warnings are emitted to stdout for Cargo to capture and explain this choice with an inline comment

Enhancements:
- Add comment in build.rs documenting why stdout is required for Cargo warning detection

Build:
- Switch ddlog --version failure warnings from stderr to stdout via println in build.rs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Warning and error messages related to version checks are now displayed in a way that ensures they are correctly captured by Cargo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->