### PR TITLE
Extract DDlog install step

### DIFF
--- a/.github/actions/install-ddlog/action.yml
+++ b/.github/actions/install-ddlog/action.yml
@@ -1,0 +1,8 @@
+name: Install DDlog
+description: Download and install the DDlog toolchain.
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        ./scripts/install_ddlog.sh

--- a/.github/actions/install-ddlog/action.yml
+++ b/.github/actions/install-ddlog/action.yml
@@ -3,6 +3,7 @@ description: Download and install the DDlog toolchain.
 runs:
   using: composite
   steps:
-    - shell: bash
+    - name: Run install script
+      shell: bash
       run: |
         ./scripts/install_ddlog.sh

--- a/.github/actions/install-ddlog/action.yml
+++ b/.github/actions/install-ddlog/action.yml
@@ -21,6 +21,7 @@ runs:
       name: Run install script
       shell: bash
       run: |
+        set -euo pipefail
         DDLOG_ARCHIVE_URL="${{ inputs.archive_url }}" \
         DDLOG_INSTALL_DIR="${{ inputs.install_dir }}" \
         ./scripts/install_ddlog.sh

--- a/.github/actions/install-ddlog/action.yml
+++ b/.github/actions/install-ddlog/action.yml
@@ -1,9 +1,27 @@
 name: Install DDlog
 description: Download and install the DDlog toolchain.
+
+inputs:
+  archive_url:
+    description: URL of the DDlog release archive
+    required: false
+  install_dir:
+    description: Destination directory for the DDlog installation
+    required: false
+
+outputs:
+  ddlog_home:
+    description: Path where DDlog was installed
+    value: ${{ steps.install.outputs.ddlog_home }}
+
 runs:
   using: composite
   steps:
-    - name: Run install script
+    - id: install
+      name: Run install script
       shell: bash
       run: |
+        DDLOG_ARCHIVE_URL="${{ inputs.archive_url }}" \
+        DDLOG_INSTALL_DIR="${{ inputs.install_dir }}" \
         ./scripts/install_ddlog.sh
+        echo "ddlog_home=${DDLOG_INSTALL_DIR:-$HOME/.local/ddlog}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
       - name: Install DDlog
+        uses: ./.github/actions/install-ddlog
+      - name: Show DDlog install info
         run: |
-          ./scripts/install_ddlog.sh
           ls -l /home/runner/.local/ddlog
           echo dotenv:
           cat .env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
       - name: Install DDlog
+        id: install
         uses: ./.github/actions/install-ddlog
       - name: Show DDlog install info
         run: |
-          ls -l "$HOME/.local/ddlog"
+          ls -l "${{ steps.install.outputs.ddlog_home }}"
           echo dotenv:
           cat .env
       - name: Format

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/install-ddlog
       - name: Show DDlog install info
         run: |
-          ls -l /home/runner/.local/ddlog
+          ls -l "$HOME/.local/ddlog"
           echo dotenv:
           cat .env
       - name: Format

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ variable assignments to `.env`. If that file already exists, it will be backed u
 with a `.bak` suffix before being replaced. Any existing directory at
 `~/.local/ddlog` will be removed before extraction.
 
+For CI builds the same script is wrapped in a reusable GitHub Action located at
+`.github/actions/install-ddlog`.
+
 ## Build script
 
 The `build.rs` entry point delegates to the `build_support` crate. This helper

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ variable assignments to `.env`. If that file already exists, it will be backed u
 with a `.bak` suffix before being replaced. Any existing directory at
 `~/.local/ddlog` will be removed before extraction.
 
-For CI builds the same script is wrapped in a reusable GitHub Action located at
+For CI builds, the same script is wrapped in a reusable GitHub Action located at
 `.github/actions/install-ddlog`.
 
 ## Build script

--- a/scripts/install_ddlog.sh
+++ b/scripts/install_ddlog.sh
@@ -9,8 +9,8 @@ trap 'if [ -n "${TMP_DIR:-}" ]; then rm -rf "$TMP_DIR"; fi' EXIT
 # are written to a `.env` file in this repository so that the
 # build script can load them with `dotenvy`.
 
-ARCHIVE_URL="https://github.com/vmware-archive/differential-datalog/releases/download/v1.2.3/ddlog-v1.2.3-20211213235218-Linux.tar.gz"
-INSTALL_DIR="$HOME/.local/ddlog"
+ARCHIVE_URL="${DDLOG_ARCHIVE_URL:-https://github.com/vmware-archive/differential-datalog/releases/download/v1.2.3/ddlog-v1.2.3-20211213235218-Linux.tar.gz}"
+INSTALL_DIR="${DDLOG_INSTALL_DIR:-$HOME/.local/ddlog}"
 #ENV_FILE="$HOME/.ddlog_env"
 ENV_FILE=".env"
 


### PR DESCRIPTION
## Summary
- create a reusable composite action for installing DDlog
- use the new action in CI workflow

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685084f5c104832296060ccd861a9f3c

## Summary by Sourcery

Extract the DDlog installation into a reusable composite GitHub Action and update the CI workflow to leverage it

Enhancements:
- Introduce a composite GitHub Action for downloading and installing the DDlog toolchain

CI:
- Replace the inline DDlog install script in CI with the new composite action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to use a custom GitHub Action for installing DDlog.
	- Added a step to display information about the DDlog installation and environment after setup.
	- Enhanced installation script to allow configurable download URL and installation directory via environment variables.
	- Documented the new GitHub Action for DDlog installation in the README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->