### PR TITLE
Fix ddlog cache path computation

### DIFF
--- a/.github/actions/setup-ddlog/action.yml
+++ b/.github/actions/setup-ddlog/action.yml
@@ -16,12 +16,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - id: ddlog_path
+    - name: Compute DDlog cache path
+      id: ddlog_path
       shell: bash
       run: |
-        if [ -n "${{ inputs.cache-path }}" ]; then
+        if [[ -n "${{ inputs.cache-path }}" ]]; then
           echo "path=${{ inputs.cache-path }}" >> "$GITHUB_OUTPUT"
-        elif [ "${{ runner.os }}" = "Windows" ]; then
+        elif [[ "${{ runner.os }}" == "Windows" ]]; then
           echo "path=$USERPROFILE\\.local\\ddlog" >> "$GITHUB_OUTPUT"
         else
           echo "path=$HOME/.local/ddlog" >> "$GITHUB_OUTPUT"
@@ -35,7 +36,7 @@ runs:
         version=$(grep -Eo '^ARCHIVE_URL=.*ddlog-(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?)' "$install_script" | \
           head -n1 | \
           sed -E 's/^ARCHIVE_URL=.*ddlog-(v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?).*/\1/')
-        if [ -z "$version" ]; then
+        if [[ -z "$version" ]]; then
           echo "setup-ddlog: failed to detect DDlog version in $install_script" >&2
           exit 1
         fi
@@ -54,7 +55,7 @@ runs:
       run: |
         bash "${{ inputs.install-script }}"
         # To enable debug output for this step, set the `debug` input to 'true'
-        if [ "${{ inputs.debug }}" = "true" ]; then
+        if [[ "${{ inputs.debug }}" == "true" ]]; then
           ls -l "${{ steps.ddlog_path.outputs.path }}"
           echo dotenv:
           cat .env

--- a/.github/actions/setup-ddlog/action.yml
+++ b/.github/actions/setup-ddlog/action.yml
@@ -44,7 +44,7 @@ runs:
       id: cache
       uses: actions/cache@v4
       with:
-        path: ${{ steps.ddlog_path.outputs.path }}
+        path: "${{ steps.ddlog_path.outputs.path }}"
         key: ${{ runner.os }}-ddlog-${{ steps.version.outputs.version }}
         restore-keys: |
           ${{ runner.os }}-ddlog-
@@ -63,7 +63,7 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache@v4
       with:
-        path: ${{ steps.ddlog_path.outputs.path }}
+        path: "${{ steps.ddlog_path.outputs.path }}"
         key: ${{ runner.os }}-ddlog-${{ steps.version.outputs.version }}
 outputs:
   version:

--- a/.github/actions/setup-ddlog/action.yml
+++ b/.github/actions/setup-ddlog/action.yml
@@ -8,7 +8,7 @@ inputs:
   cache-path:
     description: "Directory to cache the DDlog installation"
     required: false
-    default: ${{ runner.os == 'Windows' && env.USERPROFILE || env.HOME }}/.local/ddlog
+    default: ""
   debug:
     description: "Enable verbose debug output"
     required: false
@@ -16,6 +16,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - id: ddlog_path
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.cache-path }}" ]; then
+          echo "path=${{ inputs.cache-path }}" >> "$GITHUB_OUTPUT"
+        elif [ "${{ runner.os }}" = "Windows" ]; then
+          echo "path=$USERPROFILE\\.local\\ddlog" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=$HOME/.local/ddlog" >> "$GITHUB_OUTPUT"
+        fi
     - name: Extract DDlog version
       id: version
       shell: bash
@@ -34,7 +44,7 @@ runs:
       id: cache
       uses: actions/cache@v4
       with:
-        path: ${{ inputs.cache-path }}
+        path: ${{ steps.ddlog_path.outputs.path }}
         key: ${{ runner.os }}-ddlog-${{ steps.version.outputs.version }}
         restore-keys: |
           ${{ runner.os }}-ddlog-
@@ -45,7 +55,7 @@ runs:
         bash "${{ inputs.install-script }}"
         # To enable debug output for this step, set the `debug` input to 'true'
         if [ "${{ inputs.debug }}" = "true" ]; then
-          ls -l "${{ inputs.cache-path }}"
+          ls -l "${{ steps.ddlog_path.outputs.path }}"
           echo dotenv:
           cat .env
         fi
@@ -53,7 +63,7 @@ runs:
       if: steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache@v4
       with:
-        path: ${{ inputs.cache-path }}
+        path: ${{ steps.ddlog_path.outputs.path }}
         key: ${{ runner.os }}-ddlog-${{ steps.version.outputs.version }}
 outputs:
   version:


### PR DESCRIPTION
## Summary
- fix cache path computation in `setup-ddlog` action
- compute path dynamically and update cache steps

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -q`
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_6852c4f786b88322b425a36e8d350308

## Summary by Sourcery

Fix cache path computation in the setup-ddlog GitHub Action by dynamically determining and using the appropriate cache directory

Bug Fixes:
- Fix cache path computation by removing hardcoded default and handling OS-specific logic

Enhancements:
- Introduce a 'ddlog_path' step to compute the cache directory based on input or runner OS
- Update cache and debug steps to use the dynamically computed path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved handling of the cache path in the setup process, ensuring it is determined dynamically based on user input or platform defaults for greater consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->