### PR TITLE
Add build support runner binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,13 @@ with a `.bak` suffix before being replaced. Any existing directory at
 The `build.rs` entry point delegates to the `build_support` crate. This helper
 crate generates constants from `constants.toml`, downloads the project font, and
 compiles the DDlog ruleset when the compiler is available.
+
+## Isolated build support
+
+Run the build support logic without compiling the whole game using the new binary:
+
+```bash
+cargo run -p build_support --bin build_support_runner
+```
+
+This performs the same steps as `build.rs`, generating constants, downloading the font, and compiling the DDlog ruleset when available.

--- a/build_support/Cargo.toml
+++ b/build_support/Cargo.toml
@@ -18,3 +18,8 @@ rstest = "0.18.0"
 mockall = "0.13.1"
 test_utils = { path = "../test_utils" }
 
+
+[[bin]]
+name = "build_support_runner"
+path = "src/bin/build_support_runner.rs"
+

--- a/build_support/src/bin/build_support_runner.rs
+++ b/build_support/src/bin/build_support_runner.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    build_support::build()
+}

--- a/build_support/src/bin/build_support_runner.rs
+++ b/build_support/src/bin/build_support_runner.rs
@@ -1,3 +1,6 @@
+//! Small wrapper binary to invoke build_support::build for testing.
+//!
+//! Allows running the build pipeline without compiling the entire game.
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     build_support::build()
 }


### PR DESCRIPTION
## Summary
- add `build_support_runner` target to call `build_support::build`
- document how to run the new binary

## Testing
- `cargo clippy -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6853481e906483229e401bc5daf495ca

## Summary by Sourcery

Add a standalone build_support_runner binary to execute the build_support logic independently and update the README with usage instructions

New Features:
- Introduce build_support_runner binary target that invokes build_support::build

Documentation:
- Document how to run the build_support_runner binary to perform build support steps in isolation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for running the build support process independently via a dedicated command.
- **Documentation**
	- Updated the README with instructions for using isolated build support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->