### PR TITLE
Add build_support_runner helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,18 +1,32 @@
 # Rust Development Guidelines
 
-This repository is written in Rust and uses Cargo for building and dependency management. Contributors should follow these best practices when working on the project:
+This repository is written in Rust and uses Cargo for building and dependency
+management. Contributors should follow these best practices when working on the
+project:
 
-1. **Run `cargo fmt` and `cargo clippy`** before committing to ensure consistent code style and catch common mistakes.
-2. **Write unit tests** for new functionality. Run `cargo test` in the root crate to ensure all tests pass.
-3. **Document public APIs** using Rustdoc comments (`///`) so documentation can be generated with `cargo doc`.
-4. **Prefer immutable data** and avoid unnecessary `mut` bindings.
-5. **Handle errors with the `Result` type** instead of panicking where feasible.
-6. **Use explicit version ranges** in `Cargo.toml` and keep dependencies up-to-date.
-7. **Avoid unsafe code** unless absolutely necessary and document any usage clearly.
-8. **Keep functions small and focused**; if a function grows too large, consider splitting it into helpers.
-9. **Commit messages should be descriptive**, explaining what was changed and why.
-10. **Check for `TODO` comments** and convert them into issues if more work is required.
-11. **Validate Markdown Mermaid diagrams** with `nixie <paths>` before submitting documentation changes.
-12. **Do not construct SQL by concatenating strings.** Always use Diesel's query builder or parameter binding to avoid injection vulnerabilities.
+01. **Run `cargo fmt` and `cargo clippy`** before committing to ensure
+    consistent code style and catch common mistakes.
+02. **Write unit tests** for new functionality. Run `cargo test` in the root
+    crate to ensure all tests pass.
+03. **Document public APIs** using Rustdoc comments (`///`) so documentation can
+    be generated with `cargo doc`.
+04. **Prefer immutable data** and avoid unnecessary `mut` bindings.
+05. **Handle errors with the `Result` type** instead of panicking where
+    feasible.
+06. **Use explicit version ranges** in `Cargo.toml` and keep dependencies
+    up-to-date.
+07. **Avoid unsafe code** unless absolutely necessary and document any usage
+    clearly.
+08. **Keep functions small and focused**; if a function grows too large,
+    consider splitting it into helpers.
+09. **Commit messages should be descriptive**, explaining what was changed and
+    why.
+10. **Check for `TODO` comments** and convert them into issues if more work is
+    required.
+11. **Validate Markdown Mermaid diagrams** with `nixie <paths>` before
+    submitting documentation changes.
+12. **Do not construct SQL by concatenating strings.** Always use Diesel's query
+    builder or parameter binding to avoid injection vulnerabilities.
 
-These practices will help maintain a high-quality codebase and make collaboration easier.
+These practices will help maintain a high-quality codebase and make
+collaboration easier.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ so that `cargo build` can locate the `ddlog` compiler and standard library
 without additional setup.
 
 The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes environment
-variable assignments to `.env`. If that file already exists, it will be backed up
-with a `.bak` suffix before being replaced. Any existing directory at
+variable assignments to `.env`. If that file already exists, it will be backed
+up with a `.bak` suffix before being replaced. Any existing directory at
 `~/.local/ddlog` will be removed before extraction.
 
 ## Build script
@@ -63,7 +63,8 @@ compiles the DDlog ruleset when the compiler is available.
 
 ## Isolated build support
 
-Run the build support logic without compiling the whole game using the helper script:
+Run the build support logic without compiling the whole game using the helper
+script:
 
 ```bash
 ./scripts/build_support_runner.sh
@@ -72,4 +73,5 @@ Run the build support logic without compiling the whole game using the helper sc
 The script sets `CARGO_MANIFEST_DIR` and `OUT_DIR` so the helper binary behaves
 like a build script.
 
-This performs the same steps as `build.rs`, generating constants, downloading the font, and compiling the DDlog ruleset when available.
+This performs the same steps as `build.rs`, generating constants, downloading
+the font, and compiling the DDlog ruleset when available.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Run the build support logic without compiling the whole game using the helper sc
 ```bash
 ./scripts/build_support_runner.sh
 ```
+
 The script sets `CARGO_MANIFEST_DIR` and `OUT_DIR` so the helper binary behaves
 like a build script.
 

--- a/README.md
+++ b/README.md
@@ -63,10 +63,12 @@ compiles the DDlog ruleset when the compiler is available.
 
 ## Isolated build support
 
-Run the build support logic without compiling the whole game using the new binary:
+Run the build support logic without compiling the whole game using the helper script:
 
 ```bash
-cargo run -p build_support --bin build_support_runner
+./scripts/build_support_runner.sh
 ```
+The script sets `CARGO_MANIFEST_DIR` and `OUT_DIR` so the helper binary behaves
+like a build script.
 
 This performs the same steps as `build.rs`, generating constants, downloading the font, and compiling the DDlog ruleset when available.

--- a/scripts/build_support_runner.sh
+++ b/scripts/build_support_runner.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run build_support_runner with environment variables normally set by Cargo.
+# This allows executing the build pipeline without invoking `cargo build`.
+
+# Create a temporary OUT_DIR and clean up on exit.
+OUT_DIR="$(mktemp -d)"
+trap 'rm -rf "$OUT_DIR"' EXIT
+
+# Determine the manifest directory (repository root).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CARGO_MANIFEST_DIR="$MANIFEST_DIR" OUT_DIR="$OUT_DIR" \
+  cargo run -p build_support --bin build_support_runner "$@"
+

--- a/scripts/build_support_runner.sh
+++ b/scripts/build_support_runner.sh
@@ -12,6 +12,6 @@ trap 'rm -rf "$OUT_DIR"' EXIT
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANIFEST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-CARGO_MANIFEST_DIR="$MANIFEST_DIR" OUT_DIR="$OUT_DIR" \
-  cargo run -p build_support --bin build_support_runner "$@"
+exec CARGO_MANIFEST_DIR="$MANIFEST_DIR" OUT_DIR="$OUT_DIR" \
+  cargo run -p build_support --bin build_support_runner -- "$@"
 


### PR DESCRIPTION
## Summary
- provide `scripts/build_support_runner.sh` to run the helper binary
- document the new script in the README

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `nixie README.md`


------
https://chatgpt.com/codex/tasks/task_e_6853524995b08322810a2fec777a1d1f

## Summary by Sourcery

Provide a helper script to run the build support logic independently of Cargo’s build pipeline and update documentation accordingly.

Build:
- Add scripts/build_support_runner.sh to invoke the build_support_runner binary with Cargo-like environment variables

Documentation:
- Document the new build_support_runner.sh script in the README and explain its environment setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to recommend using a new helper script for running the build support process in isolation, providing clearer instructions and environment setup details.

- **New Features**
  - Added a shell script to simplify running the build support logic with necessary environment variables, improving ease of use for isolated build tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->