### PR TITLE
Fix build_support runner environment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ script:
 ./scripts/build_support_runner.sh
 ```
 
-The script sets `CARGO_MANIFEST_DIR` and `OUT_DIR` so the helper binary behaves
-like a build script.
+The script compiles the helper binary and executes it directly so
+`CARGO_MANIFEST_DIR` points to the repository root while running. It sets
+`OUT_DIR` so the helper binary behaves like a build script.
 
 This performs the same steps as `build.rs`, generating constants, downloading
-the font, and compiling the DDlog ruleset when available.
+the font, and compiling the DDlog ruleset when available. The helper does not
+output "No such file or directory" errors when locating `constants.toml`,
+though compilation may still fail if the DDlog compiler is missing.

--- a/scripts/build_support_runner.sh
+++ b/scripts/build_support_runner.sh
@@ -14,4 +14,8 @@ MANIFEST_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 export CARGO_MANIFEST_DIR="$MANIFEST_DIR"
 export OUT_DIR="$OUT_DIR"
-exec cargo run -p build_support --bin build_support_runner -- "$@"
+
+# Compile the helper binary if needed and run it directly so Cargo does not
+# override `CARGO_MANIFEST_DIR`.
+cargo build -p build_support --bin build_support_runner
+exec "$MANIFEST_DIR/target/debug/build_support_runner" "$@"


### PR DESCRIPTION
## Summary
- run `cargo build` then run the helper binary directly
- document updated helper script usage
- clarify that the runner no longer fails to find `constants.toml`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `./scripts/build_support_runner.sh`

------
https://chatgpt.com/codex/tasks/task_e_6853d3211288832289c75d0618328f8c

## Summary by Sourcery

Fix environment handling in build_support_runner by compiling and running the helper binary directly to preserve CARGO_MANIFEST_DIR and avoid missing constants.toml errors.

Bug Fixes:
- Prevent failures locating `constants.toml` during runner execution by ensuring it points to the repository root.

Enhancements:
- Compile the build_support_runner helper binary and invoke it directly instead of using `cargo run`, preventing Cargo from overriding `CARGO_MANIFEST_DIR`.

Documentation:
- Update README to document the new script behavior and clarify improved error handling for `constants.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified the README instructions for running the helper script, including more detailed explanations of environment variables and script behaviour.

- **Chores**
  - Updated the helper script to build and execute the binary directly, ensuring correct environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->