### PR TITLE
Use system roots for reqwest

### DIFF
--- a/build_support/Cargo.toml
+++ b/build_support/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 dotenvy = "0.15.7"
-reqwest = { version = "0.11.27", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.11.27", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 sha2 = "0.10.9"
 toml = "0.8.23"
 once_cell = "1.21.3"


### PR DESCRIPTION
## Summary
- use rustls native roots with reqwest so the font download works behind the proxy

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6853de71d0c08322b5c61fd8c16d3b60