### PR TITLE
Update build_support runner options

### DIFF
--- a/scripts/build_support_runner.sh
+++ b/scripts/build_support_runner.sh
@@ -1,6 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+    cat <<EOF
+Usage: ${0##*/} [--tmp|--tmp-keep] [-- <build_support args>]
+
+Run build_support_runner with environment variables normally set by Cargo.
+
+Options:
+  --tmp        Use a temporary output directory removed on exit.
+  --tmp-keep   Use a temporary output directory retained after running.
+  --           Pass all following arguments to build_support.
+  -h, --help   Show this help message and exit.
+EOF
+}
+
 # Run build_support_runner with environment variables normally set by Cargo.
 # This allows executing the build pipeline without invoking `cargo build`.
 
@@ -16,14 +30,26 @@ CLEAN_MODE=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --tmp)
+            if [[ -n "$CLEAN_MODE" ]]; then
+                echo "Error: --tmp and --tmp-keep are mutually exclusive" >&2
+                exit 1
+            fi
             OUT_DIR="$(mktemp -d)"
             CLEAN_MODE="remove"
             shift
             ;;
         --tmp-keep)
+            if [[ -n "$CLEAN_MODE" ]]; then
+                echo "Error: --tmp and --tmp-keep are mutually exclusive" >&2
+                exit 1
+            fi
             OUT_DIR="$(mktemp -d)"
             CLEAN_MODE="keep"
             shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
             ;;
         --)
             shift
@@ -37,13 +63,18 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+if [[ ! -d "$OUT_DIR" ]]; then
+    echo "Error: OUT_DIR '$OUT_DIR' does not exist" >&2
+    exit 1
+fi
+
 export CARGO_MANIFEST_DIR="$MANIFEST_DIR"
 export OUT_DIR="$OUT_DIR"
 
 if [[ "$CLEAN_MODE" == "remove" ]]; then
-    trap 'rm -rf "$OUT_DIR"' EXIT
+    trap 'rm -rf -- "$OUT_DIR"' EXIT INT TERM
 elif [[ "$CLEAN_MODE" == "keep" ]]; then
-    trap 'echo "Temporary output retained at: $OUT_DIR"' EXIT
+    trap 'echo "Temporary output retained at: $OUT_DIR"' EXIT INT TERM
 fi
 
 # Compile the helper binary if needed and run it directly so Cargo does not


### PR DESCRIPTION
## Summary
- extend build_support_runner.sh with `--tmp`, `--tmp-keep`, and `--` option handling
- use `src` as the default `OUT_DIR`

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68540d06b7388322a0ec6b29e50b08d0

## Summary by Sourcery

Enhance build_support_runner.sh to use src as the default output directory and introduce temporary directory options with flexible argument handling

New Features:
- Add support for --tmp and --tmp-keep flags to create and optionally retain a temporary OUT_DIR
- Allow passing through build_support_runner arguments after a `--` separator

Enhancements:
- Default OUT_DIR to the project's src directory when no temp flags are provided
- Set up conditional cleanup traps to remove or keep the temporary directory based on the chosen flag
- Update argument parsing to collect flags into BUILD_ARGS for the runner invocation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to specify the output directory via command-line arguments, including temporary directory modes with automatic cleanup or retention.
- **Chores**
  - Improved command-line argument handling for greater flexibility and clarity when running the script.
  - Added a usage/help function to guide users on script options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->