### PR TITLE
Integrate color_eyre for richer errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,11 @@ bevy = { version = "0.12", default-features = false, features = ["bevy_asset","b
 log = "0.4"  # Structured logging facade
 env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 serde = { version = "1.0", features = ["derive"] }
+color-eyre = "0.6"
 
 [build-dependencies]
 build_support = { path = "build_support" }
+color-eyre = "0.6"
 
 [workspace]
 members = ["build_support", "test_utils"]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,8 @@
 //! Cargo build script for the project.
 //! Delegates to the `build_support` crate so the logic can be tested.
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+use color_eyre::eyre::Result;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
     build_support::build()
 }

--- a/build_support/Cargo.toml
+++ b/build_support/Cargo.toml
@@ -12,6 +12,7 @@ sha2 = "0.10.9"
 toml = "0.8.23"
 once_cell = "1.21.3"
 tempfile = "3.20.0"
+color-eyre = "0.6"
 
 [dev-dependencies]
 rstest = "0.18.0"

--- a/build_support/src/bin/build_support_runner.rs
+++ b/build_support/src/bin/build_support_runner.rs
@@ -1,6 +1,9 @@
 //! Small wrapper binary to invoke build_support::build for testing.
 //!
 //! Allows running the build pipeline without compiling the entire game.
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+use color_eyre::eyre::Result;
+
+fn main() -> Result<()> {
+    color_eyre::install()?;
     build_support::build()
 }

--- a/build_support/src/constants.rs
+++ b/build_support/src/constants.rs
@@ -1,6 +1,6 @@
 //! Utilities for generating Rust constants from the shared `constants.toml` file.
 //! Provides functions to read `constants.toml` and produce Rust and `DDlog` code.
-use std::error::Error;
+use color_eyre::eyre::Result;
 use std::fs;
 use std::path::Path;
 
@@ -51,10 +51,7 @@ pub const DL_FMTS: Formats = Formats {
 /// let out = Path::new(env!("OUT_DIR"));
 /// generate_constants(manifest, out).unwrap();
 /// ```
-pub fn generate_constants(
-    manifest_dir: impl AsRef<Path>,
-    out_dir: impl AsRef<Path>,
-) -> Result<(), Box<dyn Error>> {
+pub fn generate_constants(manifest_dir: impl AsRef<Path>, out_dir: impl AsRef<Path>) -> Result<()> {
     let manifest_dir = manifest_dir.as_ref();
     let out_dir = out_dir.as_ref();
     let parsed = parse_constants(manifest_dir)?;
@@ -86,7 +83,7 @@ pub fn generate_constants(
 /// let value = parse_constants(Path::new(env!("CARGO_MANIFEST_DIR"))).unwrap();
 /// assert!(value.is_table());
 /// ```
-pub fn parse_constants(manifest_dir: impl AsRef<Path>) -> Result<Value, Box<dyn Error>> {
+pub fn parse_constants(manifest_dir: impl AsRef<Path>) -> Result<Value> {
     let const_path = manifest_dir.as_ref().join("constants.toml");
     let toml_str = fs::read_to_string(const_path)?;
     Ok(toml_str.parse()?)

--- a/build_support/src/ddlog.rs
+++ b/build_support/src/ddlog.rs
@@ -1,8 +1,8 @@
 //! Build helper for compiling `DDlog` code.
 //! Detects the compiler and invokes it during the build process.
+use color_eyre::eyre::{eyre, Result};
 use once_cell::sync::OnceCell;
 use std::env;
-use std::error::Error;
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -26,12 +26,9 @@ static DDLOG_AVAILABLE: OnceCell<bool> = OnceCell::new();
 /// # use std::path::Path;
 /// use build_support::ddlog::compile_ddlog;
 /// compile_ddlog(Path::new("."), Path::new("./target"))?;
-/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # Ok::<(), color_eyre::Report>(())
 /// ```
-pub fn compile_ddlog(
-    manifest_dir: impl AsRef<Path>,
-    out_dir: impl AsRef<Path>,
-) -> Result<(), Box<dyn Error>> {
+pub fn compile_ddlog(manifest_dir: impl AsRef<Path>, out_dir: impl AsRef<Path>) -> Result<()> {
     dotenvy::dotenv().ok();
     let manifest_dir = manifest_dir.as_ref();
     let out_dir = out_dir.as_ref();
@@ -82,7 +79,7 @@ fn ddlog_available() -> bool {
 /// # Errors
 /// Returns an error for I/O failures or if the compiler exits with a non-zero
 /// status.
-fn run_ddlog(ddlog_file: &Path, out_dir: &Path) -> Result<(), Box<dyn Error>> {
+fn run_ddlog(ddlog_file: &Path, out_dir: &Path) -> Result<()> {
     let target_dir = out_dir.join("ddlog_lille");
     let mut cmd = Command::new("ddlog");
     if let Ok(home) = env::var("DDLOG_HOME") {
@@ -97,7 +94,7 @@ fn run_ddlog(ddlog_file: &Path, out_dir: &Path) -> Result<(), Box<dyn Error>> {
     if status.success() {
         Ok(())
     } else {
-        Err(format!("ddlog compiler exited with status: {status}").into())
+        Err(eyre!("ddlog compiler exited with status: {status}"))
     }
 }
 

--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -4,7 +4,8 @@ pub mod constants;
 pub mod ddlog;
 pub mod font;
 
-use std::{error::Error, path::PathBuf};
+use color_eyre::eyre::Result;
+use std::path::PathBuf;
 
 /// Execute all build steps required by `build.rs`.
 ///
@@ -15,7 +16,8 @@ use std::{error::Error, path::PathBuf};
 ///
 /// # Examples
 /// ```rust,no_run
-/// fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// use color_eyre::eyre::Result;
+/// fn main() -> Result<()> {
 ///     build_support::build()
 /// }
 /// ```
@@ -27,7 +29,7 @@ use std::{error::Error, path::PathBuf};
 /// # Errors
 /// Returns an error if required environment variables are missing, if any file
 /// operation fails, or when Differential Datalog compilation does not succeed.
-pub fn build() -> Result<(), Box<dyn Error>> {
+pub fn build() -> Result<()> {
     dotenvy::dotenv().ok();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=assets");

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use clap::Parser;
+use color_eyre::eyre::Result;
 use lille::{
     apply_ddlog_deltas_system, init_ddlog_system, init_logging, push_state_to_ddlog_system,
     spawn_world_system,
@@ -20,7 +21,8 @@ struct Args {
 /// Entry point for the realtime strategy game application.
 ///
 /// Parses command-line arguments, configures logging, and launches the Bevy app with custom system scheduling for DDlog integration and world setup.
-fn main() {
+fn main() -> Result<()> {
+    color_eyre::install()?;
     let args = Args::parse();
     init_logging(args.verbose);
 
@@ -37,4 +39,5 @@ fn main() {
             (push_state_to_ddlog_system, apply_ddlog_deltas_system).chain(),
         )
         .run();
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- add `color-eyre` dependency to the workspace crates
- use `color_eyre::install` in main binaries and build script
- switch build helper crates to return `color_eyre::Result`

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6854d6844c008322909ed3720762eaa8

## Summary by Sourcery

Integrate color-eyre to provide richer, unified error reporting across the application and build support crates by replacing generic error types, using the eyre macros, and installing the handler in all binaries and scripts.

Enhancements:
- Use `color_eyre::eyre::Result` and `eyre!` macros throughout build_support and application code to unify error types
- Invoke `color_eyre::install()` in all main binaries and the build script to initialize the enhanced error handler

Build:
- Add `color-eyre = "0.6"` dependency to the root crate and `build_support` workspace member

Documentation:
- Update doc comments and examples to reference `color_eyre::Result` and `color_eyre::Report`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved error reporting throughout the application by adopting enhanced error handling mechanisms for build scripts and runtime execution.
	- Updated error handling in various functions and modules to provide clearer and more consistent error messages.
- **Chores**
	- Added a new dependency to support enhanced error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->