### PR TITLE
Add missing module comments

### DIFF
--- a/build_support/src/constants.rs
+++ b/build_support/src/constants.rs
@@ -1,5 +1,9 @@
-//! Utilities for generating Rust constants from the shared `constants.toml` file.
-//! Provides functions to read `constants.toml` and produce Rust and `DDlog` code.
+//! Generate Rust and DDlog constant definitions from `constants.toml`.
+//!
+//! This module is invoked from the build script to read `constants.toml` and
+//! output Rust and Differential Datalog source files. It keeps the two
+//! languages in sync so both parts of the project share the same numerical and
+//! string constants.
 use color_eyre::eyre::Result;
 use std::fs;
 use std::path::Path;

--- a/build_support/src/ddlog.rs
+++ b/build_support/src/ddlog.rs
@@ -1,5 +1,8 @@
-//! Build helper for compiling `DDlog` code.
-//! Detects the compiler and invokes it during the build process.
+//! Build helper for compiling Differential Datalog rules.
+//!
+//! This module is responsible for locating the `ddlog` compiler and invoking
+//! it as part of the build. When the compiler is unavailable the build skips
+//! DDlog compilation so the rest of the project can still build successfully.
 use color_eyre::eyre::{eyre, Result};
 use once_cell::sync::OnceCell;
 use std::env;

--- a/build_support/src/ddlog.rs
+++ b/build_support/src/ddlog.rs
@@ -1,7 +1,7 @@
 //! Build helper for compiling Differential Datalog rules.
 //!
 //! This module is responsible for locating the `ddlog` compiler and invoking
-//! it as part of the build. When the compiler is unavailable the build skips
+//! it as part of the build. When the compiler is unavailable, the build skips
 //! DDlog compilation so the rest of the project can still build successfully.
 use color_eyre::eyre::{eyre, Result};
 use once_cell::sync::OnceCell;

--- a/build_support/src/font.rs
+++ b/build_support/src/font.rs
@@ -1,5 +1,9 @@
-//! Downloads and verifies font files for inclusion in the project.
-//! Provides a `FontFetcher` trait and checksum validation used by the build script.
+//! Download and verify the Fira Sans font during the build.
+//!
+//! The build script fetches the font using an implementation of
+//! [`FontFetcher`], checks its SHA-256 digest and writes the verified font to
+//! disk. This ensures deterministic builds without shipping the font in the
+//! repository.
 use color_eyre::eyre::{eyre, Result};
 use reqwest::blocking::Client;
 use sha2::{Digest, Sha256};


### PR DESCRIPTION
## Summary
- clarify module-level docs for build helpers

## Testing
- `cargo clippy -q`
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_68552b2765b083229d04652a44cc491f

## Summary by Sourcery

Documentation:
- Add module-level comments to constants, ddlog, and font modules in build_support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved and clarified module-level documentation for build support modules, providing more detailed explanations of their roles in generating constants, compiling Differential Datalog code, and handling font downloads and verification. No changes to functionality or exported entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->