### PR TITLE
Fix Makefile test rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@ This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
 
-01. **Run `cargo fmt` and `cargo clippy`** before committing to ensure
-    consistent code style and catch common mistakes.
-02. **Write unit tests** for new functionality. Run `cargo test` in the root
+01. **Run `make fmt`, `make markdownlint`, and `make lint`** before committing
+    to ensure consistent code style and catch common mistakes.
+02. **Write unit tests** for new functionality. Run `make test` in the root
     crate to ensure all tests pass.
 03. **Document public APIs** using Rustdoc comments (`///`) so documentation can
     be generated with `cargo doc`.
@@ -23,8 +23,8 @@ project:
     why.
 10. **Check for `TODO` comments** and convert them into issues if more work is
     required.
-11. **Validate Markdown Mermaid diagrams** with `nixie <paths>` before
-    submitting documentation changes.
+11. **Validate Markdown Mermaid diagrams** with `make nixie` before submitting
+    documentation changes.
 12. **Do not construct SQL by concatenating strings.** Always use Diesel's query
     builder or parameter binding to avoid injection vulnerabilities.
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,20 @@
-.PHONY: build test fmt build-support-run lint markdownlint nixie
+.PHONY: all clean build test fmt build-support-run lint markdownlint nixie
+
+.ONESHELL:
+SHELL := bash
+ENV := . ./.env && export DDLOG_HOME
+
+all: build
+
+clean:
+	cargo clean
 
 build:
-	. ./.env
-	export DDLOG_HOME
+	$(ENV)
 	RUSTFLAGS="-D warnings" cargo build
 
 test:
-	. ./.env
-	export DDLOG_HOME
+	$(ENV)
 	RUSTFLAGS="-D warnings" cargo test
 
 fmt:
@@ -15,17 +22,15 @@ fmt:
 	mdformat-all
 
 build-support-run:
-	. ./.env
-	export DDLOG_HOME
+	$(ENV)
 	./scripts/build_support_runner.sh
 
 lint:
-	. ./.env
-	export DDLOG_HOME
+	$(ENV)
 	cargo clippy --all-targets --all-features -- -D warnings
 
 markdownlint:
-	markdownlint *.md **/*.md
+	find . -name '*.md' -print0 | xargs -0 markdownlint
 
 nixie:
-	nixie *.md **/*.md
+	find . -name '*.md' -print0 | xargs -0 nixie

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: build test fmt build-support-run lint markdownlint nixie
+
+build:
+	. ./.env
+	export DDLOG_HOME
+	RUSTFLAGS="-D warnings" cargo build
+
+test:
+	. ./.env
+	export DDLOG_HOME
+	RUSTFLAGS="-D warnings" cargo test
+
+fmt:
+	cargo fmt --all
+	mdformat-all
+
+build-support-run:
+	. ./.env
+	export DDLOG_HOME
+	./scripts/build_support_runner.sh
+
+lint:
+	. ./.env
+	export DDLOG_HOME
+	cargo clippy --all-targets --all-features -- -D warnings
+
+markdownlint:
+	markdownlint *.md **/*.md
+
+nixie:
+	nixie *.md **/*.md

--- a/README.md
+++ b/README.md
@@ -80,5 +80,5 @@ The script compiles the helper binary and executes it directly so
 
 This performs the same steps as `build.rs`, generating constants, downloading
 the font, and compiling the DDlog ruleset when available. The helper does not
-output "No such file or directory" errors when locating `constants.toml`,
-though compilation may still fail if the DDlog compiler is missing.
+output "No such file or directory" errors when locating `constants.toml`, though
+compilation may still fail if the DDlog compiler is missing.


### PR DESCRIPTION
## Summary
- correct the `fmt` rule to run `mdformat-all`
- mention `make markdownlint` in `AGENTS.md`
- reflow README paragraph via mdformat

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_68560d14a0288322b06aefcb94cd90d6

## Summary by Sourcery

Provide a Makefile to centralize environment setup and common development workflows, fix the formatting rule to include Mdformat, and update documentation to reference the new make targets and reflow a README paragraph.

Bug Fixes:
- Correct the `fmt` Makefile target to run `mdformat-all`.

Enhancements:
- Introduce a Makefile with targets for building, testing, formatting, linting, markdownlint, and Mermaid diagram validation.

Documentation:
- Update AGENTS.md to reference `make fmt`, `make markdownlint`, `make lint`, and `make nixie`.
- Reflow a paragraph in README.md using mdformat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development guidelines to standardise workflow using Makefile commands.
	- Introduced a Makefile with targets for building, testing, formatting, linting, and documentation checks.
- **Documentation**
	- Minor formatting adjustment in the README for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->