### PR TITLE
Switch to shared CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,8 @@ jobs:
       BUILD_PROFILE: debug
     steps:
       - uses: actions/checkout@v4
-      - name: Install rust
-        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9
-        with:
-          override: true
-          components: rustfmt, clippy
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target/${{ env.BUILD_PROFILE }}
-          key: ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ env.BUILD_PROFILE }}-
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@v1
       - name: Setup DDlog
         uses: ./.github/actions/setup-ddlog
       - name: Format
@@ -43,19 +30,11 @@ jobs:
         run: cargo install cargo-tarpaulin
       - name: Run coverage
         run: cargo tarpaulin --out lcov
-      - name: Install CodeScene coverage tool
-        if: env.CS_ACCESS_TOKEN
-        run: |
-          set -euo pipefail
-          curl -fsSL -o install-cs-coverage-tool.sh https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-          bash install-cs-coverage-tool.sh -y
-          rm install-cs-coverage-tool.sh
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
-        run: cs-coverage upload --format "lcov" --metric "line-coverage" "lcov.info"
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1
+        with:
+          format: lcov
 
 
 


### PR DESCRIPTION
## Summary
- use Leynos shared action for Rust toolchain setup and caching
- upload coverage to CodeScene with shared action

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_685669b059348322b5b60de159ce28ed