### PR TITLE
Support compiling multiple ddlog modules

### DIFF
--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -53,7 +53,7 @@ pub fn build() -> Result<()> {
 
     constants::generate_constants(&manifest_dir, &out_dir)?;
     let font_path = font::download_font(&manifest_dir)?;
-    ddlog::compile_ddlog(&manifest_dir, &out_dir)?;
+    ddlog::compile_ddlog(manifest_dir.join("src/ddlog"), &out_dir)?;
 
     println!("cargo:rustc-env=FONT_PATH={}", font_path.display());
 


### PR DESCRIPTION
## Summary
- allow compiling all .dl modules in a directory
- output generated code for each module under `OUT_DIR/ddlog_<name>`
- update build support tests and build script

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6856777fa6e48322b19b575cc2f7ae40

## Summary by Sourcery

Allow compiling all Differential Datalog modules by scanning a directory of `.dl` files and emitting each module’s generated code into its own output subdirectory

New Features:
- Support compiling multiple `.dl` modules within a specified directory

Enhancements:
- Iterate over all `.dl` files in the given `ddlog_dir` and generate each module’s Rust code under `OUT_DIR/ddlog_<module_name>`
- Change `compile_ddlog` signature to accept a directory of modules instead of a single file
- Rename variables and update warnings to reflect directory-based compilation

Build:
- Update `build()` in `lib.rs` to invoke `compile_ddlog` with `src/ddlog` directory

Tests:
- Revise and extend tests to use `ddlog_dir`, cover relative paths, dotenv loading, output directory creation, and module compilation handling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved DDlog compilation to support multiple `.dl` files within a specified directory.
	- Output directories are now dynamically named based on each `.dl` file.
	- Updated internal structure to compile from a `src/ddlog` subdirectory instead of a single file location.
- **Tests**
	- Updated tests to align with the new directory structure and compilation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->