### PR TITLE
Fix DDlog constants path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ Cargo.lock
 *.ttf
 assets/
 .env
-src/constants.dl
+src/ddlog/constants.dl
 constants.rs

--- a/build_support/src/constants.rs
+++ b/build_support/src/constants.rs
@@ -32,9 +32,9 @@ pub const RUST_FMTS: Formats = Formats {
 
 /// Default format templates for generating DDlog code.
 pub const DL_FMTS: Formats = Formats {
-    int_fmt: "const {}: signed<64> = {}\n",
-    float_fmt: "const {}: GCoord = {}\n",
-    str_fmt: "const {}: string = \"{}\"\n",
+    int_fmt: "const {}: signed<64> = {};\n",
+    float_fmt: "const {}: GCoord = {};\n",
+    str_fmt: "const {}: string = \"{}\";\n",
 };
 
 /// Generate Rust and DDlog constant files from `constants.toml`.
@@ -63,10 +63,12 @@ pub fn generate_constants(manifest_dir: impl AsRef<Path>, out_dir: impl AsRef<Pa
         out_dir.join("constants.rs"),
         generate_code_from_constants(&parsed, &RUST_FMTS),
     )?;
-    let src_dir = manifest_dir.join("src");
-    fs::create_dir_all(&src_dir)?;
+    // Write the DDlog constants next to the other `.dl` modules so the
+    // compiler's import resolution can locate them without additional flags.
+    let ddlog_dir = manifest_dir.join("src/ddlog");
+    fs::create_dir_all(&ddlog_dir)?;
     fs::write(
-        src_dir.join("constants.dl"),
+        ddlog_dir.join("constants.dl"),
         generate_code_from_constants(&parsed, &DL_FMTS),
     )?;
     Ok(())

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -42,7 +42,7 @@ fn parsed_relations() -> HashSet<String> {
 }
 
 static CONST_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\(").unwrap());
+    Lazy::new(|| Regex::new(r"(?m)^\s*const\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap());
 
 fn parsed_constants() -> HashSet<String> {
     capture_set(&CONST_RE)

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -12,7 +12,7 @@ const DL_SRC: &str = concat!(
     include_str!("../src/ddlog/entity_state.dl"),
     include_str!("../src/ddlog/physics.dl")
 );
-const CONSTANTS_SRC: &str = include_str!("../src/constants.dl");
+const CONSTANTS_SRC: &str = include_str!("../src/ddlog/constants.dl");
 
 static REL_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(
@@ -42,7 +42,7 @@ fn parsed_relations() -> HashSet<String> {
 }
 
 static CONST_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^\s*const\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap());
+    Lazy::new(|| Regex::new(r"(?m)^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\(").unwrap());
 
 fn parsed_constants() -> HashSet<String> {
     capture_set(&CONST_RE)


### PR DESCRIPTION
## Summary
- generate Datalog constants next to other `.dl` modules
- update tests to read new path
- ignore generated constants in `src/ddlog`

## Testing
- `make fmt`
- `make markdownlint`
- `make lint` *(fails: failed to parse input file: constants.dl)*
- `make test` *(fails: failed to parse input file: constants.dl)*
- `make build-support-run` *(fails: failed to parse input file: constants.dl)*

------
https://chatgpt.com/codex/tasks/task_e_68571e885044832284b27c4449d88990

## Summary by Sourcery

Generate DDlog constants under src/ddlog to align with other .dl modules by updating output path, adding required semicolons, adjusting tests and ignoring generated files

Bug Fixes:
- Write DDlog constants to src/ddlog instead of src

Enhancements:
- Add semicolons to DL constant format templates
- Update .gitignore to ignore generated DDlog constants

Tests:
- Adjust test inclusion path for constants.dl to src/ddlog
- Change constant parsing regex to match function definitions instead of const declarations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated file generation and ignore rules so that DDlog constants are now placed in a dedicated subdirectory, improving organisation.
- **Tests**
	- Adjusted test logic to match the new location and format of DDlog constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->