### PR TITLE
Use dotenv_override for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 
 .ONESHELL:
 SHELL := bash
-ENV := . ./.env && export DDLOG_HOME
 
 all: build
 
@@ -10,11 +9,9 @@ clean:
 	cargo clean
 
 build:
-	$(ENV)
 	RUSTFLAGS="-D warnings" cargo build
 
 test:
-	$(ENV)
 	RUSTFLAGS="-D warnings" cargo test
 
 fmt:
@@ -22,11 +19,9 @@ fmt:
 	mdformat-all
 
 build-support-run:
-	$(ENV)
 	./scripts/build_support_runner.sh
 
 lint:
-	$(ENV)
 	cargo clippy --all-targets --all-features -- -D warnings
 
 markdownlint:

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ source ./.env
 The `source` command loads the DDlog environment variables into the current
 shell session.
 
-The build script also loads this `.env` automatically using the `dotenvy` crate
-so that `cargo build` can locate the `ddlog` compiler and standard library
-without additional setup.
+The build script automatically loads this `.env` using
+`dotenvy::dotenv_override` so that `cargo build` can locate the `ddlog` compiler
+and standard library without additional setup.
 
 The script downloads DDlog v1.2.3 into `~/.local/ddlog` and writes environment
 variable assignments to `.env`. If that file already exists, it will be backed

--- a/build_support/src/ddlog.rs
+++ b/build_support/src/ddlog.rs
@@ -33,7 +33,7 @@ static DDLOG_AVAILABLE: OnceCell<bool> = OnceCell::new();
 /// # Ok::<(), color_eyre::Report>(())
 /// ```
 pub fn compile_ddlog(manifest_dir: impl AsRef<Path>, out_dir: impl AsRef<Path>) -> Result<()> {
-    dotenvy::dotenv().ok();
+    dotenvy::dotenv_override().ok();
     let manifest_dir = manifest_dir.as_ref();
     let out_dir = out_dir.as_ref();
     if !ddlog_available() {

--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 /// Returns an error if required environment variables are missing, if any file
 /// operation fails, or when Differential Datalog compilation does not succeed.
 pub fn build() -> Result<()> {
-    dotenvy::dotenv().ok();
+    dotenvy::dotenv_override().ok();
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=assets");
     // Re-run the build script if any DDlog source file changes. Iterate over

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,9 +53,9 @@ The movement calculation considers:
 - Phase 0 introduced Bevy as the new runtime. The current binary starts a Bevy
   window and prints a greeting.
 - The `build.rs` script downloads the Fira Sans font if needed and compiles
-  `src/ddlog/lille.dl` with the `ddlog` compiler. The generated crate is written to
-  Cargo's `OUT_DIR` to keep the project root clean. The download client uses the
-  system's root certificates to verify TLS connections.
+  `src/ddlog/lille.dl` with the `ddlog` compiler. The generated crate is written
+  to Cargo's `OUT_DIR` to keep the project root clean. The download client uses
+  the system's root certificates to verify TLS connections.
 - A placeholder `DdlogHandle` resource is inserted during startup.
 - `DefaultPlugins` are loaded with `LogPlugin` disabled, so the custom logger
   from `logging.rs` controls output.


### PR DESCRIPTION
## Summary
- use `dotenv_override` when loading env files
- simplify the Makefile by removing `ENV`
- document the new loading behaviour
- run repo formatters

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make build-support-run` *(fails: module 'constants' not found)*

------
https://chatgpt.com/codex/tasks/task_e_685720a72cc48322ab11e4b935bac507

## Summary by Sourcery

Use dotenv_override for environment variable loading in build scripts, remove Makefile ENV sourcing, and update documentation accordingly

Enhancements:
- Switch build scripts to use dotenv_override for loading environment variables

Build:
- Remove ENV variable and implicit .env sourcing from Makefile targets

Documentation:
- Update README to describe dotenv_override behavior
- Reflow lines in architecture.md for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity in the README regarding how environment variables are loaded during the build process.
	- Minor formatting adjustments in the architecture documentation for better readability.

- **Chores**
	- Updated environment variable loading to always override existing values with those from the `.env` file during the build process.
	- Simplified the build process by removing redundant environment variable setup in the build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->