### PR TITLE
Update DDlog constants generation

### DIFF
--- a/build_support/src/bin/build_support_runner.rs
+++ b/build_support/src/bin/build_support_runner.rs
@@ -1,9 +1,12 @@
 //! Small wrapper binary to invoke build_support::build for testing.
 //!
 //! Allows running the build pipeline without compiling the entire game.
+use build_support::BuildOptions;
 use color_eyre::eyre::Result;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    build_support::build()
+    build_support::build_with_options(&BuildOptions {
+        fail_on_ddlog_error: true,
+    })
 }

--- a/build_support/src/constants.rs
+++ b/build_support/src/constants.rs
@@ -32,9 +32,9 @@ pub const RUST_FMTS: Formats = Formats {
 
 /// Default format templates for generating DDlog code.
 pub const DL_FMTS: Formats = Formats {
-    int_fmt: "const {}: signed<64> = {};\n",
-    float_fmt: "const {}: GCoord = {};\n",
-    str_fmt: "const {}: string = \"{}\";\n",
+    int_fmt: "function {}(): signed<64> { {} }\n",
+    float_fmt: "function {}(): GCoord { {} }\n",
+    str_fmt: "function {}(): string { {} }\n",
 };
 
 /// Generate Rust and DDlog constant files from `constants.toml`.
@@ -167,7 +167,11 @@ fn is_plain_integer_literal(s: &str) -> bool {
 pub fn generate_code_from_constants(parsed: &Value, fmts: &Formats) -> String {
     let mut code = String::from("// @generated - do not edit\n");
     let mut append = |k: &str, v: &Value| {
-        let name = k.to_uppercase();
+        let name = if std::ptr::eq(fmts, &DL_FMTS) {
+            k.to_lowercase()
+        } else {
+            k.to_uppercase()
+        };
         match v {
             Value::Integer(i) => code.push_str(&fill2(fmts.int_fmt, name, i)),
             Value::Float(f) => {

--- a/build_support/src/ddlog.rs
+++ b/build_support/src/ddlog.rs
@@ -89,16 +89,23 @@ fn run_ddlog(ddlog_file: &Path, out_dir: &Path) -> Result<()> {
     if let Ok(home) = env::var("DDLOG_HOME") {
         cmd.arg("-L").arg(format!("{home}/lib"));
     }
-    let status = cmd
+    let output = cmd
         .arg("-i")
         .arg(ddlog_file)
         .arg("-o")
         .arg(&target_dir)
-        .status()?;
-    if status.success() {
+        .output()?;
+    if output.status.success() {
         Ok(())
     } else {
-        Err(eyre!("ddlog compiler exited with status: {status}"))
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(eyre!(
+            "ddlog compiler exited with status: {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            stdout,
+            stderr
+        ))
     }
 }
 

--- a/build_support/tests/constants.rs
+++ b/build_support/tests/constants.rs
@@ -1,6 +1,6 @@
 //! Tests for the `build_support` constants generator.
 //! Ensures generated code is syntactically valid and handles edge cases.
-use build_support::constants::{generate_code_from_constants, RUST_FMTS};
+use build_support::constants::{generate_code_from_constants, DL_FMTS, RUST_FMTS};
 use test_utils::{assert_all_absent, assert_all_present, assert_valid_rust_syntax};
 
 #[test]
@@ -339,4 +339,13 @@ fn output_compiles_as_valid_rust() {
         assert!(line.contains("="));
         assert!(line.ends_with(";"));
     }
+}
+
+#[test]
+fn generates_ddlog_functions() {
+    let toml_str = "value = 5";
+    let parsed: toml::Value = toml_str.parse().unwrap();
+    let code = generate_code_from_constants(&parsed, &DL_FMTS);
+    assert!(code.contains("function value()"));
+    assert!(code.contains("{ 5 }"));
 }

--- a/build_support/tests/constants.rs
+++ b/build_support/tests/constants.rs
@@ -349,3 +349,21 @@ fn generates_ddlog_functions() {
     assert!(code.contains("function value()"));
     assert!(code.contains("{ 5 }"));
 }
+
+#[test]
+fn generates_ddlog_float_function() {
+    let toml_str = "pi = 3.14";
+    let parsed: toml::Value = toml_str.parse().unwrap();
+    let code = generate_code_from_constants(&parsed, &DL_FMTS);
+    assert!(code.contains("function pi()"));
+    assert!(code.contains("{ 3.14 }"));
+}
+
+#[test]
+fn generates_ddlog_string_function() {
+    let toml_str = r#"greeting = "hello \"world\"""#;
+    let parsed: toml::Value = toml_str.parse().unwrap();
+    let code = generate_code_from_constants(&parsed, &DL_FMTS);
+    assert!(code.contains("function greeting()"));
+    assert!(code.contains("{ \"hello \\\"world\\\"\" }"));
+}

--- a/src/ddlog/entity_state.dl
+++ b/src/ddlog/entity_state.dl
@@ -8,7 +8,7 @@ relation IsUnsupported(entity: EntityID)
 IsUnsupported(entity) :-
     Position(entity, x, y, z),
     MaxFloor(x, y, z_floor),
-    z > z_floor + GRACE_DISTANCE.
+    z > z_floor + grace_distance().
 
 relation IsStanding(entity: EntityID)
 IsStanding(entity) :-

--- a/src/ddlog/physics.dl
+++ b/src/ddlog/physics.dl
@@ -10,16 +10,24 @@ output relation NewVelocity(entity: EntityID, nvx: GCoord, nvy: GCoord, nvz: GCo
 relation AppliedAcceleration(e: EntityID, ax: GCoord, ay: GCoord, az: GCoord)
 AppliedAcceleration(e, fx / mass, fy / mass, fz / mass) :-
     Force(e, fx, fy, fz),
-    (Mass(e, mass) or mass = DEFAULT_MASS),
+    (Mass(e, mass) or mass = default_mass()),
     mass > 0.0.
 
 relation GravitationalAcceleration(e: EntityID, ax: GCoord, ay: GCoord, az: GCoord)
-GravitationalAcceleration(e, 0.0, 0.0, GRAVITY_PULL) :- IsUnsupported(e).
+GravitationalAcceleration(e, 0.0, 0.0, gravity_pull()) :- IsUnsupported(e).
 
 relation FrictionalDeceleration(e: EntityID, ax: GCoord, ay: GCoord, az: GCoord)
 FrictionalDeceleration(e, fdx, fdy, 0.0) :-
-    (IsStanding(e), var coeff = GROUND_FRICTION;
-     IsUnsupported(e), var coeff = AIR_FRICTION),
+    IsStanding(e),
+    var coeff = ground_friction(),
+    Velocity(e, vx, vy, _),
+    var h_mag = vec_mag(vx, vy, 0.0), h_mag > 0.0,
+    var (nx, ny, _) = vec_normalize(vx, vy, 0.0),
+    var decel_mag = min(h_mag, coeff),
+    fdx = -nx * decel_mag, fdy = -ny * decel_mag.
+FrictionalDeceleration(e, fdx, fdy, 0.0) :-
+    IsUnsupported(e),
+    var coeff = air_friction(),
     Velocity(e, vx, vy, _),
     var h_mag = vec_mag(vx, vy, 0.0), h_mag > 0.0,
     var (nx, ny, _) = vec_normalize(vx, vy, 0.0),
@@ -40,14 +48,14 @@ NetAcceleration(e, ax, ay, az) :-
     ) from NetAccelRow(e, ax_i, ay_i, az_i).
 
 relation UnclampedNewVelocity(e: EntityID, vx: GCoord, vy: GCoord, vz: GCoord)
-UnclampedNewVelocity(e, vx + ax * DELTA_TIME, vy + ay * DELTA_TIME, vz + az * DELTA_TIME) :-
+UnclampedNewVelocity(e, vx + ax * delta_time(), vy + ay * delta_time(), vz + az * delta_time()) :-
     Velocity(e, vx, vy, vz),
     NetAcceleration(e, ax, ay, az).
 
 NewVelocity(e, nvx, nvy, final_nvz) :-
     IsUnsupported(e),
     UnclampedNewVelocity(e, nvx, nvy, raw_nvz),
-    var clamped = max(min(raw_nvz, TERMINAL_VELOCITY), -TERMINAL_VELOCITY),
+    var clamped = max(min(raw_nvz, terminal_velocity()), -terminal_velocity()),
     var final_nvz = clamped.
 
 NewVelocity(e, nvx, nvy, 0.0) :-

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -42,7 +42,7 @@ fn parsed_relations() -> HashSet<String> {
 }
 
 static CONST_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^\s*const\s+([A-Za-z_][A-Za-z0-9_]*)").unwrap());
+    Lazy::new(|| Regex::new(r"(?m)^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\(").unwrap());
 
 fn parsed_constants() -> HashSet<String> {
     capture_set(&CONST_RE)
@@ -133,13 +133,13 @@ fn ddlog_program_has_floor_height_rules() {
     }
 
     assert!(
-        constants.contains("GRACE_DISTANCE"),
-        "GRACE_DISTANCE constant missing"
+        constants.contains("grace_distance"),
+        "grace_distance constant missing"
     );
 
     assert!(
-        constants.contains("DEFAULT_MASS"),
-        "DEFAULT_MASS constant missing"
+        constants.contains("default_mass"),
+        "default_mass constant missing"
     );
 
     for token in [
@@ -157,7 +157,7 @@ fn ddlog_program_has_floor_height_rules() {
 
     assert!(DL_SRC.contains("mass > 0"), "mass positivity check missing");
     assert!(
-        DL_SRC.contains("mass = DEFAULT_MASS") && !DL_SRC.contains("not Mass"),
+        DL_SRC.contains("mass = default_mass()") && !DL_SRC.contains("not Mass"),
         "default mass rule missing"
     );
 }

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -42,7 +42,7 @@ fn parsed_relations() -> HashSet<String> {
 }
 
 static CONST_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?m)^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\(").unwrap());
+    Lazy::new(|| Regex::new(r"(?m)^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(").unwrap());
 
 fn parsed_constants() -> HashSet<String> {
     capture_set(&CONST_RE)


### PR DESCRIPTION
## Summary
- generate DDlog constants as lowercase functions
- regenerate constants and modify DDlog sources to use new functions
- add DDlog function generation test
- adjust integration tests for function syntax

## Testing
- `make fmt`
- `make lint`
- `make markdownlint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685739fbcf38832281167fb14e10ac7d

## Summary by Sourcery

Refactor the build script for configurable DDlog error handling and file tracking, switch DDlog constant generation to lowercase functions, and update related tests.

New Features:
- Introduce build_with_options to control DDlog compilation failures.
- Generate DDlog constants as lowercase functions rather than const declarations.

Enhancements:
- Refactor build support into reusable functions for manifest/out directory handling and file tracking.
- Expand Cargo rerun triggers for DDlog sources and environment changes.
- Enhance DDlog compiler errors by capturing and including stdout/stderr outputs.

Tests:
- Add unit tests for DDlog function-based constant generation.
- Update integration tests to expect lowercase function syntax in DDlog sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Replaced constants with function calls in DDlog code generation and related source files, changing how values like mass, gravity, and friction are accessed.
  - Updated naming conventions for generated DDlog identifiers to use lowercase function names.
  - Split frictional deceleration logic into separate rules for standing and unsupported entities for improved clarity.
  - Modularised build process with configurable options to control failure on DDlog errors and improved diagnostic output on build failures.

- **Tests**
  - Added and updated tests to verify DDlog code generation produces function definitions instead of constant declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->