### PR TITLE
Add configurable DDlog path to build_support

### DIFF
--- a/build_support/src/bin/build_support_runner.rs
+++ b/build_support/src/bin/build_support_runner.rs
@@ -8,5 +8,6 @@ fn main() -> Result<()> {
     color_eyre::install()?;
     build_support::build_with_options(&BuildOptions {
         fail_on_ddlog_error: true,
+        ddlog_path: None,
     })
 }

--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -16,7 +16,7 @@ pub struct BuildOptions {
 }
 
 use color_eyre::eyre::Result;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Execute all build steps required by `build.rs`.
 ///
@@ -76,14 +76,14 @@ fn set_rerun_triggers(options: &BuildOptions) {
     println!("cargo:rerun-if-changed=assets");
     let ddlog_dir = options
         .ddlog_path
-        .clone()
-        .unwrap_or_else(|| PathBuf::from("src/ddlog"));
-    track_ddlog_files(&ddlog_dir);
+        .as_deref()
+        .unwrap_or_else(|| Path::new("src/ddlog"));
+    track_ddlog_files(ddlog_dir);
     println!("cargo:rerun-if-changed=constants.toml");
     println!("cargo:rerun-if-env-changed=DDLOG_HOME");
 }
 
-fn track_ddlog_files(dir: &PathBuf) {
+fn track_ddlog_files(dir: &Path) {
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {
             let path = entry.path();


### PR DESCRIPTION
## Summary
- add `ddlog_path` option to `BuildOptions`
- pass `BuildOptions` to `set_rerun_triggers`
- use configurable path when tracking DDlog files

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685759f1f92c8322b8004624ddb09723

## Summary by Sourcery

Introduce a `ddlog_path` option to `BuildOptions` and update the build support logic to use this configurable path when setting cargo rerun triggers for DDlog files.

New Features:
- Allow configuring the DDlog source directory via a new `ddlog_path` option in `BuildOptions`

Enhancements:
- Pass `BuildOptions` to `set_rerun_triggers` and use the configured DDlog path when tracking files
- Default to `src/ddlog` when `ddlog_path` is not provided
- Change `track_ddlog_files` to accept a generic `&Path` instead of `&PathBuf`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to specify a custom directory for `.dl` files via an optional setting.

- **Refactor**
  - Improved configuration options for build processes by making the `.dl` file directory configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->