### PR TITLE
move shared entity inputs

### DIFF
--- a/docs/differential-datalog-with-rust.md
+++ b/docs/differential-datalog-with-rust.md
@@ -324,6 +324,26 @@ typedef EntityID = signed<64>
 import types
 ```
 
+#### Shared input state modules
+
+Visibility only flows one way, so relations used by multiple subsystems should
+live in a tiny module with no dependencies. Each subsystem then imports that
+module before the first use of those relations. This avoids cycles such as
+`geometry` → `physics` → `geometry` and keeps a single authoritative definition:
+
+```datalog
+// entity_state.dl
+input relation Position(e: EntityID, x: GCoord, y: GCoord, z: GCoord)
+input relation Velocity(e: EntityID, vx: GCoord, vy: GCoord, vz: GCoord)
+input relation Mass(e: EntityID, kg: GCoord)
+```
+
+Modules that need the state import it explicitly:
+
+```datalog
+import entity_state
+```
+
 ### C. Defining Data: Types and Relations
 
 Data in DDlog is structured using types and stored in relations.

--- a/src/ddlog/entity_state.dl
+++ b/src/ddlog/entity_state.dl
@@ -1,18 +1,9 @@
 import types
 
-// --- Entity State Relations ---
-relation MaxFloor(x: GCoord, y: GCoord, z_max: GCoord)
-MaxFloor(x, y, z_max) :-
-    FloorHeightAt(x, y, z),
-    var z_max = z.group_by((x, y)).max().
-
-relation IsUnsupported(entity: EntityID)
-IsUnsupported(entity) :-
-    Position(entity, x, y, z),
-    MaxFloor(x, y, z_floor),
-    z > z_floor + grace_distance().
-
-relation IsStanding(entity: EntityID)
-IsStanding(entity) :-
-    Position(entity, _, _, _),
-    not IsUnsupported(entity).
+// --- Entity *input* state shared by multiple subsystems ---
+input relation Position(entity: EntityID,
+                        x: GCoord, y: GCoord, z: GCoord)
+input relation Velocity(entity: EntityID,
+                        vx: GCoord, vy: GCoord, vz: GCoord)
+// Mass of an entity in kilograms; must be positive to avoid divide by zero
+input relation Mass(entity: EntityID, kg: GCoord)

--- a/src/ddlog/geometry.dl
+++ b/src/ddlog/geometry.dl
@@ -1,4 +1,8 @@
 import types
+import entity_state
+import constants
+import fp
+import souffle_lib
 
 // --- World Geometry Relations ---
 input relation Block(id: BlockID, x: signed<32>, y: signed<32>, z: signed<32>)
@@ -41,3 +45,20 @@ FloorHeightAt(x, y, z_out) :-
     HighestBlockAt(x_grid, y_grid, block, z_grid),
     not BlockSlope(block, _, _),
     var z_out = (z_grid as GCoord) + 1.0.
+
+// --- Derived convenience relations ---
+relation MaxFloor(x: GCoord, y: GCoord, z_max: GCoord)
+MaxFloor(x, y, z_max) :-
+    FloorHeightAt(x, y, z),
+    var z_max = z.group_by((x, y)).max().
+
+relation IsUnsupported(entity: EntityID)
+IsUnsupported(entity) :-
+    Position(entity, x, y, z),
+    MaxFloor(x, y, z_floor),
+    z > z_floor + grace_distance().
+
+relation IsStanding(entity: EntityID)
+IsStanding(entity) :-
+    Position(entity, _, _, _),
+    not IsUnsupported(entity).

--- a/src/ddlog/physics.dl
+++ b/src/ddlog/physics.dl
@@ -1,10 +1,9 @@
 import types
+import entity_state
+import constants
+import geometry
 
 // --- Entity Position Relations ---
-input relation Position(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
-input relation Velocity(entity: EntityID, vx: GCoord, vy: GCoord, vz: GCoord)
-// Mass of an entity in kilograms; must be positive to avoid divide by zero
-input relation Mass(entity: EntityID, kg: GCoord)
 input stream Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
 output relation NewPosition(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
 output relation NewVelocity(entity: EntityID, nvx: GCoord, nvy: GCoord, nvz: GCoord)


### PR DESCRIPTION
## Summary
- centralise `Position`, `Velocity` and `Mass` in `entity_state.dl`
- make geometry and physics import this state module
- pull standing/unsupported helpers into `geometry.dl`
- document the shared-state pattern in the DDlog guide

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make build-support-run` *(fails: body of the rule yields a stream relation)*

------
https://chatgpt.com/codex/tasks/task_e_6857d29ea29c83229437eb0a51fbda2b

## Summary by Sourcery

Centralize shared entity state definitions into a dedicated module and update subsystems to import it, while consolidating helpers and documenting the pattern

Enhancements:
- Introduce entity_state.dl module defining Position, Velocity, and Mass input relations
- Modify geometry.dl and physics.dl to import the centralized entity_state module
- Move standing and unsupported helpers into geometry.dl

Documentation:
- Add a new “Shared input state modules” section to the DDlog guide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added guidance on organising shared input state modules to avoid import cycles and clarify best practices for module boundaries.

- **New Features**
  - Introduced shared input relations for entity position, velocity, and mass to be used across multiple subsystems.

- **Refactor**
  - Moved calculation of entity support status (standing/unsupported) and maximum floor height from a shared module to the geometry subsystem.
  - Updated subsystem imports to use the new shared input state module, improving modularity and reducing duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->