### PR TITLE
Fix section references in DDlog docs

### DIFF
--- a/docs/differential-datalog-with-rust.md
+++ b/docs/differential-datalog-with-rust.md
@@ -249,7 +249,7 @@ correctly set up:
   `$DDLOG_HOME`) have taken effect.
 - Run the command: `ddlog --version` This should print the installed DDlog
   version.
-- Alternatively, try compiling a very simple DDlog file (see Section III.D for
+- Alternatively, try compiling a very simple DDlog file (see Section III.E for
   an example) using the `ddlog` command. The tutorial documentation frequently
   refers to command-line interactions 3, implying the `ddlog` executable should
   be readily available and functional after a correct installation.
@@ -613,7 +613,7 @@ logic.3 This CLI is invaluable for:
 - Debugging rules and data transformations.
 - Understanding the incremental behavior of your program.
 
-To compile your `example.dl` (from Section III.D) for CLI use, you would
+To compile your `example.dl` (from Section III.E) for CLI use, you would
 typically run:
 
 ```bash


### PR DESCRIPTION
## Summary
- fix cross references to Section III.E
- run formatting and linting

## Testing
- `make lint`
- `make test`
- `make nixie`

------
https://chatgpt.com/codex/tasks/task_e_6857d2cae3108322a16642befd9246f4