### PR TITLE
Fix physics Force relation

### DIFF
--- a/docs/bdd-strategies-for-differential-datalog-rulesets.md
+++ b/docs/bdd-strategies-for-differential-datalog-rulesets.md
@@ -165,11 +165,11 @@ We introduce relations to track velocity and represent transient forces.
 // Tracks velocity at the start of a tick, fed back from the previous tick's output.
 input relation Velocity(entity: EntityID, vx: GCoord, vy: GCoord, vz: GCoord)
 
-// --- New Ephemeral Input Stream ---
+// --- New Per-Tick Input Relation ---
 // Represents instantaneous forces applied to entities for a single tick.
-// These are force inputs (not direct accelerations); acceleration is computed as
-// force divided by mass.
-input stream Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
+// The host engine overwrites this relation every frame. These are force inputs
+// (not direct accelerations); acceleration is computed as force divided by mass.
+input relation Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
 
 // --- New Output Relation ---
 // The calculated velocity at the end of a tick.

--- a/docs/lille-physics-engine-design.md
+++ b/docs/lille-physics-engine-design.md
@@ -170,11 +170,11 @@ input relation Velocity(entity: EntityID, vx: GCoord, vy: GCoord, vz: GCoord)
 // Mass values should be positive; non-positive entries are ignored.
 input relation Mass(entity: EntityID, kg: GCoord)
 
-// --- New Ephemeral Input Stream ---
+// --- New Per-Tick Input Relation ---
 // Represents instantaneous forces applied to entities for a single tick.
-// These are force inputs (not direct accelerations); acceleration is computed as
-// force divided by mass.
-input stream Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
+// The host engine overwrites this relation every frame. These are force inputs
+// (not direct accelerations); acceleration is computed as force divided by mass.
+input relation Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
 
 // --- New Output Relation ---
 // The calculated velocity at the end of a tick.

--- a/src/ddlog/physics.dl
+++ b/src/ddlog/physics.dl
@@ -4,7 +4,9 @@ import constants
 import geometry
 
 // --- Entity Position Relations ---
-input stream Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
+// `Force` captures all momentary forces acting on an entity during the
+// current tick. The host application should replace this relation each frame.
+input relation Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
 output relation NewPosition(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
 output relation NewVelocity(entity: EntityID, nvx: GCoord, nvy: GCoord, nvz: GCoord)
 // --- Dynamics ---


### PR DESCRIPTION
## Summary
- define `Force` as an input relation instead of a stream in `physics.dl`
- document per-tick `Force` usage in physics design docs and BDD guide

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6857e13457508322a1be6f184c10029d