### PR TITLE
Fix physics Force relation

### DIFF
--- a/docs/bdd-strategies-for-differential-datalog-rulesets.md
+++ b/docs/bdd-strategies-for-differential-datalog-rulesets.md
@@ -165,11 +165,11 @@ We introduce relations to track velocity and represent transient forces.
 // Tracks velocity at the start of a tick, fed back from the previous tick's output.
 input relation Velocity(entity: EntityID, vx: GCoord, vy: GCoord, vz: GCoord)
 
-// --- New Ephemeral Input Stream ---
+// --- New Per-Tick Input Relation ---
 // Represents instantaneous forces applied to entities for a single tick.
-// These are force inputs (not direct accelerations); acceleration is computed as
-// force divided by mass.
-input stream Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
+// The host engine overwrites this relation every frame. These are force inputs
+// (not direct accelerations); acceleration is computed as force divided by mass.
+input relation Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
 
 // --- New Output Relation ---
 // The calculated velocity at the end of a tick.
@@ -196,7 +196,7 @@ We collect all acceleration vectors acting on an entity for the current tick.
 ```prolog
 relation AppliedAcceleration(e, fx / mass, fy / mass, fz / mass) :-
     Force(e, fx, fy, fz),
-    (Mass(e, mass) or mass = DEFAULT_MASS),
+    (Mass{.entity = e, .kg = mass} or var mass = DEFAULT_MASS),
     mass > 0.0.
 relation GravitationalAcceleration(e, 0.0, 0.0, -GRAVITY_PULL) :- IsUnsupported(e).
 

--- a/docs/lille-physics-engine-design.md
+++ b/docs/lille-physics-engine-design.md
@@ -170,11 +170,11 @@ input relation Velocity(entity: EntityID, vx: GCoord, vy: GCoord, vz: GCoord)
 // Mass values should be positive; non-positive entries are ignored.
 input relation Mass(entity: EntityID, kg: GCoord)
 
-// --- New Ephemeral Input Stream ---
+// --- New Per-Tick Input Relation ---
 // Represents instantaneous forces applied to entities for a single tick.
-// These are force inputs (not direct accelerations); acceleration is computed as
-// force divided by mass.
-input stream Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
+// The host engine overwrites this relation every frame. These are force inputs
+// (not direct accelerations); acceleration is computed as force divided by mass.
+input relation Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
 
 // --- New Output Relation ---
 // The calculated velocity at the end of a tick.
@@ -201,7 +201,7 @@ We collect all acceleration vectors acting on an entity for the current tick.
 ```prolog
 relation AppliedAcceleration(e, fx / mass, fy / mass, fz / mass) :-
     Force(e, fx, fy, fz),
-    (Mass(e, mass) or mass = DEFAULT_MASS),
+    (Mass{.entity = e, .kg = mass} or var mass = DEFAULT_MASS),
     mass > 0.0.
 relation GravitationalAcceleration(e, 0.0, 0.0, -GRAVITY_PULL) :- IsUnsupported(e).
 

--- a/src/ddlog/physics.dl
+++ b/src/ddlog/physics.dl
@@ -4,14 +4,16 @@ import constants
 import geometry
 
 // --- Entity Position Relations ---
-input stream Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
+// `Force` captures all momentary forces acting on an entity during the
+// current tick. The host application should replace this relation each frame.
+input relation Force(entity: EntityID, fx: GCoord, fy: GCoord, fz: GCoord)
 output relation NewPosition(entity: EntityID, x: GCoord, y: GCoord, z: GCoord)
 output relation NewVelocity(entity: EntityID, nvx: GCoord, nvy: GCoord, nvz: GCoord)
 // --- Dynamics ---
 relation AppliedAcceleration(e: EntityID, ax: GCoord, ay: GCoord, az: GCoord)
 AppliedAcceleration(e, fx / mass, fy / mass, fz / mass) :-
     Force(e, fx, fy, fz),
-    (Mass(e, mass) or mass = default_mass()),
+    (Mass{.entity = e, .kg = mass} or var mass = default_mass()),
     mass > 0.0.
 
 relation GravitationalAcceleration(e: EntityID, ax: GCoord, ay: GCoord, az: GCoord)


### PR DESCRIPTION
## Summary
- define `Force` as an input relation instead of a stream in `physics.dl`
- document per-tick `Force` usage in physics design docs and BDD guide
- bind default mass using `var` syntax to satisfy ddlog compiler

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make build-support-run` *(fails: Unknown variable: mass)*

------
https://chatgpt.com/codex/tasks/task_e_6857e13457508322a1be6f184c10029d

## Summary by Sourcery

Convert Force from an ephemeral stream to a per-tick input relation, fix default mass binding to satisfy the DDlog compiler, and update documentation accordingly.

Bug Fixes:
- Bind default mass using DDlog’s var syntax to resolve the "Unknown variable: mass" compilation error.

Enhancements:
- Define Force as an input relation overwritten each frame instead of an input stream in the physics ruleset.

Documentation:
- Revise BDD guide and physics engine design docs to describe Force as a per-tick input relation and clarify its usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to clarify that the `Force` input is now a per-tick relation, overwritten each frame, rather than a stream.
  - Improved explanation and examples of mass retrieval using named fields for better clarity in pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->