### PR TITLE
Add default config for ddlog error handling

### DIFF
--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -27,6 +27,7 @@ mod build_options {
     pub struct BuildOptions {
         /// If `true`, a failure to compile DDlog code causes [`build_with_options`]
         /// to return an error. When `false`, DDlog errors are logged but ignored.
+        #[ortho_config(default = false)]
         pub fail_on_ddlog_error: bool,
 
         /// Destination directory for the generated `ddlog_lille` crate.


### PR DESCRIPTION
## Summary
- document the default value of `fail_on_ddlog_error` in `BuildOptions`

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6858c0c6631c8322bf1472bd20e4f01d