### PR TITLE
Fix ddlog lifetime bounds and add build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,4 +46,4 @@ nixie:
 # Generate, patch, and compile the DDlog inferencer
 build-inferencer: generated/ddlog_lille/lib.rs generated/ddlog_lille/patches/fix_static.patch
 	patch -N -p1 -d generated/ddlog_lille/lille_ddlog < generated/ddlog_lille/patches/fix_static.patch
-	RUSTFLAGS="-D warnings" cargo build --manifest-path generated/ddlog_lille/lille_ddlog/Cargo.toml
+	RUSTFLAGS="-D warnings" cargo build --manifest-path generated/ddlog_lille/lille_ddlog/Cargo.toml --target-dir targets/ddlog

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: all clean build test fmt build-support-run targets/ddlog/debug/lille generated/ddlog_lille/lib.rs test-ddlog lint markdownlint nixie build-inferencer
+.PHONY: all clean build fmt test lint \
+        build-support-run \
+        build-ddlog test-ddlog build-inferencer \
+        markdownlint nixie
 
 .ONESHELL:
 SHELL := bash
@@ -41,6 +44,6 @@ nixie:
 	find . -name '*.md' -print0 | xargs -0 nixie
 
 # Generate, patch, and compile the DDlog inferencer
-build-inferencer: generated/ddlog_lille/lib.rs
-	patch -p1 -d generated/ddlog_lille/lille_ddlog < generated/ddlog_lille/patches/fix_static.patch
+build-inferencer: generated/ddlog_lille/lib.rs generated/ddlog_lille/patches/fix_static.patch
+	patch -N -p1 -d generated/ddlog_lille/lille_ddlog < generated/ddlog_lille/patches/fix_static.patch
 	RUSTFLAGS="-D warnings" cargo build --manifest-path generated/ddlog_lille/lille_ddlog/Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean build test fmt build-support-run targets/ddlog/debug/lille generated/ddlog_lille/lib.rs test-ddlog lint markdownlint nixie
+.PHONY: all clean build test fmt build-support-run targets/ddlog/debug/lille generated/ddlog_lille/lib.rs test-ddlog lint markdownlint nixie build-inferencer
 
 .ONESHELL:
 SHELL := bash
@@ -39,3 +39,8 @@ markdownlint:
 
 nixie:
 	find . -name '*.md' -print0 | xargs -0 nixie
+
+# Generate, patch, and compile the DDlog inferencer
+build-inferencer: generated/ddlog_lille/lib.rs
+	patch -p1 -d generated/ddlog_lille/lille_ddlog < generated/ddlog_lille/patches/fix_static.patch
+	RUSTFLAGS="-D warnings" cargo build --manifest-path generated/ddlog_lille/lille_ddlog/Cargo.toml

--- a/generated/ddlog_lille/patches/fix_static.patch
+++ b/generated/ddlog_lille/patches/fix_static.patch
@@ -1,0 +1,14 @@
+*** Begin Patch
+*** Update File: differential_datalog/src/dataflow/consolidate.rs
+@@
+-    O: OrdOffset,
++    O: OrdOffset + 'static,
+@@
+-    O: OrdOffset,
++    O: OrdOffset + 'static,
+*** End Patch
+*** Update File: differential_datalog/src/dataflow/distinct.rs
+@@
+-    O: OrdOffset,
++    O: OrdOffset + 'static,
+*** End Patch


### PR DESCRIPTION
## Summary
- add patches to generated ddlog sources to compile with `'static` offset
- provide Makefile target to patch and build the DDlog inferencer

## Testing
- `make fmt`
- `make markdownlint`
- `make lint` *(fails: empty line after doc comment, clippy errors in generated code)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68593328cbdc8322b24da7166c5300b1

## Summary by Sourcery

Provide a new Makefile target for patching and compiling the DDlog inferencer and introduce a patch to fix 'static lifetime issues in generated DDlog code.

New Features:
- Add Makefile target to generate, patch, and build the DDlog inferencer

Bug Fixes:
- Apply patches to generated DDlog sources to enforce 'static lifetime bounds on offsets

Build:
- Expand .PHONY in Makefile to include new inferencer and related targets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Added new build targets to improve compilation and testing processes for the DDlog inferencer, including applying patches and enforcing stricter build warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->