### PR TITLE
Centralize glam and ordered-float versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 [dependencies]
 hashbrown = "0.14"  # High performance HashMap implementation
 clap = { version = "4.4", features = ["derive"] }  # Command line argument parsing
-glam = "0.24"  # Linear algebra for games
+glam = { workspace = true }  # Linear algebra for games
 bevy = { version = "0.12", default-features = false, features = ["bevy_asset","bevy_core_pipeline","bevy_render","bevy_sprite","bevy_text","png"] }
 log = "0.4"  # Structured logging facade
 env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
@@ -28,10 +28,14 @@ color-eyre = "0.6"
 [workspace]
 members = ["build_support", "test_utils"]
 
+[workspace.dependencies]
+glam = "0.24"
+ordered-float = "2"
+
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["ron"] }
 rstest = "0.18.0"
 regex = "1"
 once_cell = "1"
 approx = "0.5"
-ordered-float = "2"
+ordered-float = { workspace = true }


### PR DESCRIPTION
## Summary
- share glam and ordered-float versions across the workspace via `[workspace.dependencies]`

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685b2e36c26883228ff955f0b3c05977

## Summary by Sourcery

Centralize the version requirements for glam and ordered-float in the workspace manifest and update crate references to use workspace dependencies

Enhancements:
- Centralize glam and ordered-float versions into the workspace dependencies section

Build:
- Update root Cargo.toml to reference glam and ordered-float via workspace dependencies