### PR TITLE
Add ddlog test instructions and placeholder test

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,21 @@ project can be formatted and linted without running the DDlog compiler. The
 `ddlog-stubs` Makefile target copies these stubs from the `stubs/` directory
 into `generated/`. When the `generated/lille_ddlog/lib.rs` target is built, the
 stubs are replaced by the actual inferencer generated from the DDlog ruleset.
+
+## Running tests with DDlog
+
+Before executing any tests that use the `ddlog` feature, build the inferencer
+crate so that the generated sources are available:
+
+```bash
+make generated/lille_ddlog/lib.rs
+```
+
+This command produces `generated/lille_ddlog/lib.rs` and the nested
+`differential_datalog` crate. Afterwards run:
+
+```bash
+make test-ddlog
+```
+
+which invokes `cargo test --features ddlog` with the compiled crate.

--- a/tests/generated_ddlog.rs
+++ b/tests/generated_ddlog.rs
@@ -1,0 +1,20 @@
+#[cfg(feature = "ddlog")]
+#[test]
+fn generated_ddlog_crate_present() {
+    use std::path::Path;
+    let base = Path::new("generated").join("lille_ddlog");
+    assert!(base.exists(), "generated/lille_ddlog directory missing");
+    assert!(
+        base.join("lib.rs").is_file(),
+        "generated/lille_ddlog/lib.rs missing"
+    );
+    let ddlog_subcrate = base.join("differential_datalog");
+    assert!(
+        ddlog_subcrate.is_dir(),
+        "differential_datalog subcrate missing"
+    );
+    assert!(
+        ddlog_subcrate.join("lib.rs").is_file(),
+        "differential_datalog/lib.rs missing"
+    );
+}


### PR DESCRIPTION
## Summary
- document generating the DDlog crate before running tests with the `ddlog` feature
- add a small test that verifies the generated DDlog crate exists

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make nixie`
- `make test`
- `make test-ddlog` *(fails: unresolved imports in ddlog build)*

------
https://chatgpt.com/codex/tasks/task_e_685c350e66b48322a373aac3557f54a0