### PR TITLE
Fix DDlog Update alias usage

### DIFF
--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -8,7 +8,7 @@ use crate::components::{Block, BlockSlope, UnitType};
 use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 
 #[cfg(feature = "ddlog")]
-use lille_ddlog::api::{self, DDValue, HDDlog, Update};
+use lille_ddlog::api::{self, DDValue, HDDlog, Update as DdlogUpdate};
 
 const GRACE_DISTANCE_F32: f32 = GRACE_DISTANCE as f32;
 const GRAVITY_PULL_F32: f32 = GRAVITY_PULL as f32;
@@ -169,7 +169,7 @@ impl DdlogHandle {
             let mut upds = Vec::new();
             for (&id, ent) in self.entities.iter() {
                 match DDValue::from(&(id, ent)) {
-                    Ok(val) => upds.push(Update {
+                    Ok(val) => upds.push(DdlogUpdate {
                         relid: Relations::Position as usize,
                         weight: 1,
                         value: val,

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -7,7 +7,7 @@ use crate::components::{Block, BlockSlope, DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 
 #[cfg(feature = "ddlog")]
-use lille_ddlog::api::{DDValue, Update};
+use lille_ddlog::api::{DDValue, Update as DdlogUpdate};
 
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
@@ -60,7 +60,7 @@ pub fn push_state_to_ddlog_system(
         let mut upds = Vec::new();
         for (&id, ent) in ddlog.entities.iter() {
             match DDValue::from(&(id, ent)) {
-                Ok(val) => upds.push(Update {
+                Ok(val) => upds.push(DdlogUpdate {
                     relid: Relations::Position as usize,
                     weight: 1,
                     value: val,


### PR DESCRIPTION
## Summary
- regenerate DDlog stubs
- alias `Update` as `DdlogUpdate`

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `cargo check --features ddlog`


------
https://chatgpt.com/codex/tasks/task_e_685c35e358a88322a4314ab1d11651b2

## Summary by Sourcery

Alias the DDlog Update type as DdlogUpdate throughout the codebase and update generated stubs to ensure correct type usage.

Bug Fixes:
- Fix incorrect usage of the DDlog Update type by aliasing it as DdlogUpdate.

Enhancements:
- Regenerate DDlog stubs to reflect updated type aliasing.