### PR TITLE
Switch coverage to llvm-cov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
         run: cargo test
       - name: Test with DDlog
         run: make test-ddlog
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
       - name: Run coverage
-        run: cargo tarpaulin --out lcov
+        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN
         uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.1.1


### PR DESCRIPTION
## Summary
- swap tarpaulin for llvm-cov in CI

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c4b4659108322b4977156b314e844

## Summary by Sourcery

CI:
- Install and run cargo-llvm-cov with workspace-wide coverage and LCov output instead of cargo-tarpaulin