### PR TITLE
Fix ddlog import paths

### DIFF
--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -8,7 +8,7 @@ use crate::components::{Block, BlockSlope, UnitType};
 use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 
 #[cfg(feature = "ddlog")]
-use differential_datalog::api::{self, DDValue, HDDlog, Update as DdlogUpdate};
+use differential_datalog::api::{self, ddval::DDValue, program::Update as DdlogUpdate, HDDlog};
 
 const GRACE_DISTANCE_F32: f32 = GRACE_DISTANCE as f32;
 const GRAVITY_PULL_F32: f32 = GRAVITY_PULL as f32;

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -2,21 +2,32 @@ pub mod api {
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
-    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-    pub struct DDValue(pub Value);
+    pub mod ddval {
+        use super::*;
 
-    impl DDValue {
-        pub fn from<T: Serialize>(val: &T) -> Result<Self, serde_json::Error> {
-            Ok(Self(serde_json::to_value(val)?))
+        #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+        pub struct DDValue(pub Value);
+
+        impl DDValue {
+            pub fn from<T: Serialize>(val: &T) -> Result<Self, serde_json::Error> {
+                Ok(Self(serde_json::to_value(val)?))
+            }
         }
     }
 
-    #[derive(Clone, Debug)]
-    pub struct Update {
-        pub relid: usize,
-        pub weight: isize,
-        pub value: DDValue,
+    pub mod program {
+        use super::ddval::DDValue;
+
+        #[derive(Clone, Debug)]
+        pub struct Update {
+            pub relid: usize,
+            pub weight: isize,
+            pub value: DDValue,
+        }
     }
+
+    pub use ddval::DDValue;
+    pub use program::Update;
 
     #[derive(Default, Clone, Debug)]
     pub struct DeltaMap;


### PR DESCRIPTION
## Summary
- fix differential_datalog import paths for generated crate
- update stub `differential_datalog` API to expose `ddval::DDValue` and `program::Update`

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c4d6e21d483229ce2b2285283643a

## Summary by Sourcery

Restructure the differential_datalog stub API to group DDValue and Update into dedicated modules, expose them via top-level re-exports, and update code imports accordingly.

Enhancements:
- Nest DDValue in a new ddval module and Update in a new program module within the stub API
- Re-export DDValue and Update at the top level of the differential_datalog stub
- Update ddlog_handle imports to reference ddval::DDValue and program::Update