### PR TITLE
Fix path assert messages

### DIFF
--- a/tests/generated_ddlog.rs
+++ b/tests/generated_ddlog.rs
@@ -9,17 +9,26 @@ fn generated_ddlog_crate_present() {
         "Directory {:?} missing",
         base.canonicalize().unwrap_or(base.clone())
     );
+    let lib_rs = base.join("lib.rs");
     assert!(
-        base.join("lib.rs").is_file(),
-        "generated/lille_ddlog/lib.rs missing"
+        lib_rs.is_file(),
+        "File {:?} missing",
+        lib_rs.canonicalize().unwrap_or_else(|_| lib_rs.clone())
     );
     let ddlog_subcrate = base.join("differential_datalog");
     assert!(
         ddlog_subcrate.is_dir(),
-        "differential_datalog subcrate missing"
+        "Directory {:?} missing",
+        ddlog_subcrate
+            .canonicalize()
+            .unwrap_or_else(|_| ddlog_subcrate.clone())
     );
+    let ddlog_lib = ddlog_subcrate.join("lib.rs");
     assert!(
-        ddlog_subcrate.join("lib.rs").is_file(),
-        "differential_datalog/lib.rs missing"
+        ddlog_lib.is_file(),
+        "File {:?} missing",
+        ddlog_lib
+            .canonicalize()
+            .unwrap_or_else(|_| ddlog_lib.clone())
     );
 }


### PR DESCRIPTION
## Summary
- show canonical paths in DDlog generation tests

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c4c4468cc83229008e7e9b6667f25

## Summary by Sourcery

Improve test diagnostics by including canonical paths in path assertion messages for generated DDlog crate tests

Enhancements:
- Refactor test assertions to canonicalize and display absolute file and directory paths on failure
- Introduce local variables for repeated file path expressions in generated_ddlog tests