### PR TITLE
Fix compile issues in DDlog integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 color-eyre = "0.6"
+ordered-float = { workspace = true }
 
 [dependencies.lille-ddlog]
 path = "generated/lille_ddlog"

--- a/docs/ddlog-world-inference.md
+++ b/docs/ddlog-world-inference.md
@@ -286,6 +286,7 @@ fn push_state_to_ddlog_system(
     // EventReader for player commands
     mut player_commands: EventReader<PlayerCommand>,
 ) {
+    use differential_datalog::program::UpdCmd;
     let mut ddlog = ddlog_handle.0.lock().unwrap();
     ddlog.transaction_start().unwrap();
 
@@ -328,7 +329,8 @@ fn push_state_to_ddlog_system(
         // e.g., changes.push(DDlogRecord::insert("Command", ...));
     }
 
-    ddlog.apply_updates_dynamic(&mut changes.into_iter()).unwrap();
+    let mut cmds: Vec<UpdCmd> = changes.into_iter().map(Into::into).collect();
+    ddlog.apply_updates_dynamic(&mut cmds.into_iter()).unwrap();
 }
 
 // System to apply DDlog's computed changes back to the ECS

--- a/docs/ddlog-world-inference.md
+++ b/docs/ddlog-world-inference.md
@@ -328,7 +328,7 @@ fn push_state_to_ddlog_system(
         // e.g., changes.push(DDlogRecord::insert("Command", ...));
     }
 
-    ddlog.apply_updates(&mut changes.into_iter()).unwrap();
+    ddlog.apply_updates_dynamic(&mut changes.into_iter()).unwrap();
 }
 
 // System to apply DDlog's computed changes back to the ECS
@@ -338,7 +338,7 @@ fn apply_ddlog_deltas_system(
     mut query: Query<(&mut Transform, &mut Health)>,
 ) {
     let mut ddlog = ddlog_handle.0.lock().unwrap();
-    let changes = ddlog.transaction_commit_dump_changes().unwrap();
+    let changes = ddlog.transaction_commit_dump_changes_dynamic().unwrap();
 
     // Apply NewPosition changes
     for rec in changes.get_records("NewPosition") {

--- a/docs/differential-datalog-with-rust.md
+++ b/docs/differential-datalog-with-rust.md
@@ -951,6 +951,8 @@ fn main() -> Result<(), String> {
     // ddlog_api.insert_edge(1, 2)?;
     // ddlog_api.insert_edge(2, 3)?;
     println!("Inserted edges: 0->1, 1->2, 2->3");
+    // let mut cmds: Vec<UpdCmd> = updates.into_iter().map(Into::into).collect();
+    // ddlog_api.apply_updates_dynamic(&mut cmds.into_iter())?;
 
     // ddlog_api.transaction_commit_dump_changes_dynamic()?;
     println!("Committed transaction 1.");

--- a/docs/differential-datalog-with-rust.md
+++ b/docs/differential-datalog-with-rust.md
@@ -952,7 +952,7 @@ fn main() -> Result<(), String> {
     // ddlog_api.insert_edge(2, 3)?;
     println!("Inserted edges: 0->1, 1->2, 2->3");
 
-    // ddlog_api.transaction_commit_dump_changes()?;
+    // ddlog_api.transaction_commit_dump_changes_dynamic()?;
     println!("Committed transaction 1.");
 
     // At this point, the `print_reachable_updates` callback would have been invoked
@@ -967,7 +967,7 @@ Starting transaction 2...");
     // ddlog_api.insert_edge(0, 4)?; // Add a new branch
     println!("Inserted edges: 3->0 (cycle), 0->4");
 
-    // ddlog_api.transaction_commit_dump_changes()?;
+    // ddlog_api.transaction_commit_dump_changes_dynamic()?;
     println!("Committed transaction 2.");
     
     // The callback would again show new Reachable paths, including those

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -8,9 +8,14 @@ use crate::components::{Block, BlockSlope, UnitType};
 use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 
 #[cfg(feature = "ddlog")]
-use differential_datalog::api::{DDValue, HDDlog, Update as DdlogUpdate};
+use differential_datalog::api::HDDlog;
 #[cfg(feature = "ddlog")]
-use differential_datalog::ddlog::{DDlog, DDlogDynamic};
+use differential_datalog::ddval::DDValue;
+#[cfg(feature = "ddlog")]
+use differential_datalog::program::Update as DdlogUpdate;
+#[cfg(feature = "ddlog")]
+#[allow(unused_imports)]
+use differential_datalog::{DDlog, DDlogDynamic};
 
 const GRACE_DISTANCE_F32: f32 = GRACE_DISTANCE as f32;
 const GRAVITY_PULL_F32: f32 = GRAVITY_PULL as f32;
@@ -55,7 +60,7 @@ pub struct DdlogHandle {
 impl Default for DdlogHandle {
     fn default() -> Self {
         #[cfg(feature = "ddlog")]
-        let prog = match lille_ddlog::api::run(1, false) {
+        let prog = match lille_ddlog::run(1, false) {
             Ok((p, _)) => Some(p),
             Err(e) => {
                 log::error!("failed to start DDlog: {e}");

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -8,7 +8,9 @@ use crate::components::{Block, BlockSlope, UnitType};
 use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 
 #[cfg(feature = "ddlog")]
-use differential_datalog::api::{self, DDValue, HDDlog, Update as DdlogUpdate};
+use differential_datalog::api::{DDValue, HDDlog, Update as DdlogUpdate};
+#[cfg(feature = "ddlog")]
+use differential_datalog::ddlog::{DDlog, DDlogDynamic};
 
 const GRACE_DISTANCE_F32: f32 = GRACE_DISTANCE as f32;
 const GRAVITY_PULL_F32: f32 = GRAVITY_PULL as f32;
@@ -53,7 +55,7 @@ pub struct DdlogHandle {
 impl Default for DdlogHandle {
     fn default() -> Self {
         #[cfg(feature = "ddlog")]
-        let prog = match api::run(1, false) {
+        let prog = match lille_ddlog::api::run(1, false) {
             Ok((p, _)) => Some(p),
             Err(e) => {
                 log::error!("failed to start DDlog: {e}");
@@ -182,9 +184,9 @@ impl DdlogHandle {
 
             if let Err(e) = prog.transaction_start() {
                 log::error!("DDlog transaction_start failed: {e}");
-            } else if let Err(e) = prog.apply_updates(&mut upds.into_iter()) {
+            } else if let Err(e) = prog.apply_updates_dynamic(&mut upds.into_iter()) {
                 log::error!("DDlog apply_updates failed: {e}");
-            } else if let Err(e) = prog.transaction_commit_dump_changes() {
+            } else if let Err(e) = prog.transaction_commit_dump_changes_dynamic() {
                 log::error!("DDlog commit failed: {e}");
             }
         }

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -176,9 +176,8 @@ impl DdlogHandle {
             let mut upds = Vec::new();
             for (&id, ent) in self.entities.iter() {
                 match DDValue::from(&(id, ent)) {
-                    Ok(val) => upds.push(DdlogUpdate {
+                    Ok(val) => upds.push(DdlogUpdate::Insert {
                         relid: Relations::Position as usize,
-                        weight: 1,
                         value: val,
                     }),
                     Err(e) => {

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -10,9 +10,9 @@ use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 #[cfg(feature = "ddlog")]
 use differential_datalog::api::HDDlog;
 #[cfg(feature = "ddlog")]
-use differential_datalog::program::UpdCmd;
-#[cfg(feature = "ddlog")]
 use differential_datalog::program::Update as DdlogUpdate;
+#[cfg(feature = "ddlog")]
+use differential_datalog::record::UpdCmd;
 #[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
 use differential_datalog::{DDlog, DDlogDynamic};
@@ -173,9 +173,9 @@ impl DdlogHandle {
     pub fn step(&mut self) {
         #[cfg(feature = "ddlog")]
         if let Some(prog) = &self.prog {
-            use lille_ddlog::{relations::Position, Record};
+            use lille_ddlog::{record::Record, Relations};
 
-            let mut upds = Vec::new();
+            let mut upds: Vec<DdlogUpdate> = Vec::new();
             for (&id, ent) in self.entities.iter() {
                 let record = Record::Position {
                     entity: id,
@@ -184,8 +184,8 @@ impl DdlogHandle {
                     z: OrderedFloat(ent.position.z),
                 };
                 upds.push(DdlogUpdate::Insert {
-                    relid: Position,
-                    rec: record,
+                    relid: Relations::Position as usize,
+                    v: record.into(),
                 });
             }
 

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -7,9 +7,12 @@ use crate::components::{Block, BlockSlope, DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 
 #[cfg(feature = "ddlog")]
-use differential_datalog::ddlog::{DDlog, DDlogDynamic};
+use differential_datalog::ddval::DDValue;
 #[cfg(feature = "ddlog")]
-use lille_ddlog::api::{DDValue, Update as DdlogUpdate};
+use differential_datalog::program::Update as DdlogUpdate;
+#[cfg(feature = "ddlog")]
+#[allow(unused_imports)]
+use differential_datalog::{DDlog, DDlogDynamic};
 #[cfg(feature = "ddlog")]
 use lille_ddlog::Relations;
 

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -7,9 +7,9 @@ use crate::components::{Block, BlockSlope, DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 
 #[cfg(feature = "ddlog")]
-use differential_datalog::program::UpdCmd;
-#[cfg(feature = "ddlog")]
 use differential_datalog::program::Update as DdlogUpdate;
+#[cfg(feature = "ddlog")]
+use differential_datalog::record::UpdCmd;
 #[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
 use differential_datalog::{DDlog, DDlogDynamic};
@@ -62,9 +62,9 @@ pub fn push_state_to_ddlog_system(
 
     #[cfg(feature = "ddlog")]
     {
-        use lille_ddlog::{relations::Position, Record};
+        use lille_ddlog::{record::Record, Relations};
 
-        let mut upds = Vec::new();
+        let mut upds: Vec<DdlogUpdate> = Vec::new();
         for (&id, ent) in ddlog.entities.iter() {
             let record = Record::Position {
                 entity: id,
@@ -73,8 +73,8 @@ pub fn push_state_to_ddlog_system(
                 z: OrderedFloat(ent.position.z),
             };
             upds.push(DdlogUpdate::Insert {
-                relid: Position,
-                rec: record,
+                relid: Relations::Position as usize,
+                v: record.into(),
             });
         }
         if let Some(prog) = ddlog.prog.as_mut() {

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -7,7 +7,11 @@ use crate::components::{Block, BlockSlope, DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 
 #[cfg(feature = "ddlog")]
+use differential_datalog::ddlog::{DDlog, DDlogDynamic};
+#[cfg(feature = "ddlog")]
 use lille_ddlog::api::{DDValue, Update as DdlogUpdate};
+#[cfg(feature = "ddlog")]
+use lille_ddlog::Relations;
 
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
@@ -55,8 +59,6 @@ pub fn push_state_to_ddlog_system(
 
     #[cfg(feature = "ddlog")]
     if let Some(prog) = &ddlog.prog {
-        use lille_ddlog::Relations;
-
         let mut upds = Vec::new();
         for (&id, ent) in ddlog.entities.iter() {
             match DDValue::from(&(id, ent)) {
@@ -71,7 +73,7 @@ pub fn push_state_to_ddlog_system(
 
         if let Err(e) = prog.transaction_start() {
             log::error!("DDlog transaction_start failed: {e}");
-        } else if let Err(e) = prog.apply_updates(&mut upds.into_iter()) {
+        } else if let Err(e) = prog.apply_updates_dynamic(&mut upds.into_iter()) {
             log::error!("DDlog apply_updates failed: {e}");
         }
     }

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -65,9 +65,8 @@ pub fn push_state_to_ddlog_system(
         let mut upds = Vec::new();
         for (&id, ent) in ddlog.entities.iter() {
             match DDValue::from(&(id, ent)) {
-                Ok(val) => upds.push(DdlogUpdate {
+                Ok(val) => upds.push(DdlogUpdate::Insert {
                     relid: Relations::Position as usize,
-                    weight: 1,
                     value: val,
                 }),
                 Err(e) => log::error!("failed to encode entity {id}: {e}"),

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -7,14 +7,14 @@ use crate::components::{Block, BlockSlope, DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 
 #[cfg(feature = "ddlog")]
-use differential_datalog::ddval::DDValue;
+use differential_datalog::program::UpdCmd;
 #[cfg(feature = "ddlog")]
 use differential_datalog::program::Update as DdlogUpdate;
 #[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
 use differential_datalog::{DDlog, DDlogDynamic};
 #[cfg(feature = "ddlog")]
-use lille_ddlog::Relations;
+use ordered_float::OrderedFloat;
 
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
@@ -61,22 +61,31 @@ pub fn push_state_to_ddlog_system(
     ddlog.slopes = slopes;
 
     #[cfg(feature = "ddlog")]
-    if let Some(prog) = &ddlog.prog {
+    {
+        use lille_ddlog::{relations::Position, Record};
+
         let mut upds = Vec::new();
         for (&id, ent) in ddlog.entities.iter() {
-            match DDValue::from(&(id, ent)) {
-                Ok(val) => upds.push(DdlogUpdate::Insert {
-                    relid: Relations::Position as usize,
-                    value: val,
-                }),
-                Err(e) => log::error!("failed to encode entity {id}: {e}"),
-            }
+            let record = Record::Position {
+                entity: id,
+                x: OrderedFloat(ent.position.x),
+                y: OrderedFloat(ent.position.y),
+                z: OrderedFloat(ent.position.z),
+            };
+            upds.push(DdlogUpdate::Insert {
+                relid: Position,
+                rec: record,
+            });
         }
-
-        if let Err(e) = prog.transaction_start() {
-            log::error!("DDlog transaction_start failed: {e}");
-        } else if let Err(e) = prog.apply_updates_dynamic(&mut upds.into_iter()) {
-            log::error!("DDlog apply_updates failed: {e}");
+        if let Some(prog) = ddlog.prog.as_mut() {
+            if let Err(e) = prog.transaction_start() {
+                log::error!("DDlog transaction_start failed: {e}");
+            } else {
+                let cmds: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
+                if let Err(e) = prog.apply_updates_dynamic(&mut cmds.into_iter()) {
+                    log::error!("DDlog apply_updates failed: {e}");
+                }
+            }
         }
     }
 }

--- a/stubs/lille_ddlog/Cargo.toml
+++ b/stubs/lille_ddlog/Cargo.toml
@@ -10,3 +10,4 @@ path = "lib.rs"
 serde = { version = "^1.0.0", features = ["derive"] }
 serde_json = "^1.0.0"
 differential_datalog = { path = "differential_datalog" }
+ordered-float = { workspace = true, features = ["serde"] }

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -1,4 +1,4 @@
-pub mod api {
+pub mod record {
     use serde::{Deserialize, Serialize};
     use serde_json::Value;
 
@@ -10,6 +10,10 @@ pub mod api {
             Ok(Self(serde_json::to_value(val)?))
         }
     }
+}
+
+pub mod program {
+    use super::record::DDValue;
 
     #[derive(Clone, Debug)]
     pub struct Update {
@@ -20,6 +24,22 @@ pub mod api {
 
     #[derive(Default, Clone, Debug)]
     pub struct DeltaMap;
+
+    pub trait DDlog {}
+    pub trait DDlogDynamic {}
+}
+
+pub mod ddval {
+    pub use super::record::DDValue;
+}
+
+pub use record::DDValue;
+pub use program::{DeltaMap, Update, DDlog, DDlogDynamic};
+
+pub use api::run;
+
+pub mod api {
+    use super::program::{DeltaMap, Update};
 
     #[derive(Clone, Debug)]
     pub struct HDDlog;
@@ -36,8 +56,19 @@ pub mod api {
             Ok(())
         }
 
+        pub fn apply_updates_dynamic<I>(&self, updates: &mut I) -> Result<(), String>
+        where
+            I: Iterator<Item = Update>,
+        {
+            self.apply_updates(updates)
+        }
+
         pub fn transaction_commit_dump_changes(&self) -> Result<DeltaMap, String> {
             Ok(DeltaMap)
+        }
+
+        pub fn transaction_commit_dump_changes_dynamic(&self) -> Result<DeltaMap, String> {
+            self.transaction_commit_dump_changes()
         }
     }
 

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -10,6 +10,8 @@ pub mod record {
             Ok(Self(serde_json::to_value(val)?))
         }
     }
+
+    pub use crate::program::UpdCmd;
 }
 
 pub mod program {
@@ -17,8 +19,8 @@ pub mod program {
 
     #[derive(Clone, Debug)]
     pub enum Update<R = DDValue> {
-        Insert { relid: usize, rec: R },
-        Delete { relid: usize, rec: R },
+        Insert { relid: usize, v: R },
+        Delete { relid: usize, v: R },
     }
 
     #[derive(Clone, Debug)]
@@ -30,8 +32,8 @@ pub mod program {
     impl<R: Into<DDValue>> From<Update<R>> for UpdCmd {
         fn from(upd: Update<R>) -> Self {
             match upd {
-                Update::Insert { relid, rec } => UpdCmd::Insert { relid, val: rec.into() },
-                Update::Delete { relid, rec } => UpdCmd::Delete { relid, val: rec.into() },
+                Update::Insert { relid, v } => UpdCmd::Insert { relid, val: v.into() },
+                Update::Delete { relid, v } => UpdCmd::Delete { relid, val: v.into() },
             }
         }
     }

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -16,10 +16,9 @@ pub mod program {
     use super::record::DDValue;
 
     #[derive(Clone, Debug)]
-    pub struct Update {
-        pub relid: usize,
-        pub weight: isize,
-        pub value: DDValue,
+    pub enum Update {
+        Insert { relid: usize, value: DDValue },
+        Delete { relid: usize, value: DDValue },
     }
 
     #[derive(Default, Clone, Debug)]

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -54,6 +54,10 @@ pub enum Record {
     },
 }
 
+pub mod record {
+    pub use super::Record;
+}
+
 impl From<Record> for DDValue {
     fn from(rec: Record) -> Self {
         DDValue::from(&rec).unwrap_or_default()

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -7,12 +7,17 @@
 // Minimal stub API mirroring the expected interface of generated DDlog code.
 
 pub mod api {
-    pub use differential_datalog::api::{DDValue, DeltaMap, HDDlog, Update};
+    pub use differential_datalog::api::HDDlog;
+    pub use differential_datalog::{DDlog, DDlogDynamic};
+    pub use differential_datalog::program::{Update, DeltaMap};
+    pub use differential_datalog::ddval::DDValue;
 
     pub fn run(workers: usize, do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
         differential_datalog::api::run(workers, do_store).map_err(|e| e.to_string())
     }
 }
+
+pub use api::run;
 
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Debug)]

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -29,3 +29,33 @@ pub enum Relations {
     NewPosition,
     NewVelocity,
 }
+
+#[allow(non_upper_case_globals)]
+pub mod relations {
+    pub const Position: usize = 0;
+    pub const Velocity: usize = 1;
+    pub const Mass: usize = 2;
+    pub const Force: usize = 3;
+    pub const NewPosition: usize = 4;
+    pub const NewVelocity: usize = 5;
+}
+
+use ordered_float::OrderedFloat;
+use serde::Serialize;
+use differential_datalog::ddval::DDValue;
+
+#[derive(Clone, Debug, Serialize)]
+pub enum Record {
+    Position {
+        entity: i64,
+        x: OrderedFloat<f32>,
+        y: OrderedFloat<f32>,
+        z: OrderedFloat<f32>,
+    },
+}
+
+impl From<Record> for DDValue {
+    fn from(rec: Record) -> Self {
+        DDValue::from(&rec).unwrap_or_default()
+    }
+}


### PR DESCRIPTION
## Summary
- integrate DDlog traits
- call generated DDlog runtime
- use dynamic update APIs

## Testing
- `make lint` *(fails: could not find `ddlog` module and missing DDlog traits)*
- `make test-ddlog` *(fails: unresolved imports for `api` and traits)*

------
https://chatgpt.com/codex/tasks/task_e_685c64ea65708322bd81a2a27300e6f5

## Summary by Sourcery

Use DDlog dynamic APIs and correct import paths to resolve compilation errors in the DDlog integration

Bug Fixes:
- Fix unresolved imports and missing DDlog traits by updating module paths

Enhancements:
- Switch to dynamic update methods (apply_updates_dynamic and transaction_commit_dump_changes_dynamic)
- Import the DDlogDynamic trait and adjust run invocation to use the lille_ddlog::api crate
- Remove unused Relations import from ddlog_sync.rs