### PR TITLE
Add cargo cache step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         run: make ddlog-stubs
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
+      # Cache ~/.cargo and target/
+      - uses: Swatinem/rust-cache@v2
       - name: Setup DDlog
         uses: ./.github/actions/setup-ddlog
       - name: Build ddlog inferencer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         run: make ddlog-stubs
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
-      # Cache ~/.cargo and target/
-      - uses: Swatinem/rust-cache@v2
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
       - name: Setup DDlog
         uses: ./.github/actions/setup-ddlog
       - name: Build ddlog inferencer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Rust
         uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
       - name: Setup DDlog
         uses: ./.github/actions/setup-ddlog
       - name: Build ddlog inferencer


### PR DESCRIPTION
## Summary
- cache Cargo and target directories in CI to speed up builds

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685c84a8b88c8322bac90ffb65f8f926

## Summary by Sourcery

CI:
- Add a step in GitHub Actions to cache ~/.cargo and target/ using Swatinem/rust-cache@v2