### PR TITLE
Update DDlog API usage and stubs

### DIFF
--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -12,10 +12,10 @@ use differential_datalog::api::HDDlog;
 #[cfg(feature = "ddlog")]
 use differential_datalog::program::Update as DdlogUpdate;
 #[cfg(feature = "ddlog")]
-use differential_datalog::record::UpdCmd;
-#[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
-use differential_datalog::{DDlog, DDlogDynamic};
+use differential_datalog::program::{DDlog, DDlogDynamic};
+#[cfg(feature = "ddlog")]
+use differential_datalog::record::UpdCmd;
 #[cfg(feature = "ddlog")]
 use ordered_float::OrderedFloat;
 
@@ -172,7 +172,7 @@ impl DdlogHandle {
 
     pub fn step(&mut self) {
         #[cfg(feature = "ddlog")]
-        if let Some(prog) = &self.prog {
+        if let Some(prog) = &mut self.prog {
             use lille_ddlog::{record::Record, Relations};
 
             let mut upds: Vec<DdlogUpdate> = Vec::new();
@@ -192,8 +192,8 @@ impl DdlogHandle {
             if let Err(e) = prog.transaction_start() {
                 log::error!("DDlog transaction_start failed: {e}");
             } else {
-                let cmds: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
-                if let Err(e) = prog.apply_updates_dynamic(&mut cmds.into_iter()) {
+                let commands: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
+                if let Err(e) = prog.apply_updates_dynamic(&mut commands.into_iter()) {
                     log::error!("DDlog apply_updates failed: {e}");
                 } else if let Err(e) = prog.transaction_commit_dump_changes_dynamic() {
                     log::error!("DDlog commit failed: {e}");

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -9,10 +9,10 @@ use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 #[cfg(feature = "ddlog")]
 use differential_datalog::program::Update as DdlogUpdate;
 #[cfg(feature = "ddlog")]
-use differential_datalog::record::UpdCmd;
-#[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
-use differential_datalog::{DDlog, DDlogDynamic};
+use differential_datalog::program::{DDlog, DDlogDynamic};
+#[cfg(feature = "ddlog")]
+use differential_datalog::record::UpdCmd;
 #[cfg(feature = "ddlog")]
 use ordered_float::OrderedFloat;
 
@@ -77,12 +77,12 @@ pub fn push_state_to_ddlog_system(
                 v: record.into(),
             });
         }
-        if let Some(prog) = ddlog.prog.as_mut() {
+        if let Some(prog) = &mut ddlog.prog {
             if let Err(e) = prog.transaction_start() {
                 log::error!("DDlog transaction_start failed: {e}");
             } else {
-                let cmds: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
-                if let Err(e) = prog.apply_updates_dynamic(&mut cmds.into_iter()) {
+                let commands: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
+                if let Err(e) = prog.apply_updates_dynamic(&mut commands.into_iter()) {
                     log::error!("DDlog apply_updates failed: {e}");
                 }
             }

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -1,61 +1,11 @@
-pub mod record {
-    use serde::{Deserialize, Serialize};
-    use serde_json::Value;
+//! Stub file for differential_datalog crate.
+#![allow(dead_code)]
+use serde::{Deserialize, Serialize};
 
-    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-    pub struct DDValue(pub Value);
-
-    impl DDValue {
-        pub fn from<T: Serialize>(val: &T) -> Result<Self, serde_json::Error> {
-            Ok(Self(serde_json::to_value(val)?))
-        }
-    }
-
-    pub use crate::program::UpdCmd;
-}
-
-pub mod program {
-    use super::record::DDValue;
-
-    #[derive(Clone, Debug)]
-    pub enum Update<R = DDValue> {
-        Insert { relid: usize, v: R },
-        Delete { relid: usize, v: R },
-    }
-
-    #[derive(Clone, Debug)]
-    pub enum UpdCmd {
-        Insert { relid: usize, val: DDValue },
-        Delete { relid: usize, val: DDValue },
-    }
-
-    impl<R: Into<DDValue>> From<Update<R>> for UpdCmd {
-        fn from(upd: Update<R>) -> Self {
-            match upd {
-                Update::Insert { relid, v } => UpdCmd::Insert { relid, val: v.into() },
-                Update::Delete { relid, v } => UpdCmd::Delete { relid, val: v.into() },
-            }
-        }
-    }
-
+// --- `api` module stub ---
+pub mod api {
     #[derive(Default, Clone, Debug)]
     pub struct DeltaMap;
-
-    pub trait DDlog {}
-    pub trait DDlogDynamic {}
-}
-
-pub mod ddval {
-    pub use super::record::DDValue;
-}
-
-pub use record::DDValue;
-pub use program::{DeltaMap, Update, UpdCmd, DDlog, DDlogDynamic};
-
-pub use api::run;
-
-pub mod api {
-    use super::program::{DeltaMap, UpdCmd};
 
     #[derive(Clone, Debug)]
     pub struct HDDlog;
@@ -65,30 +15,51 @@ pub mod api {
             Ok(())
         }
 
-        pub fn apply_updates<I>(&self, _updates: &mut I) -> Result<(), String>
-        where
-            I: Iterator<Item = UpdCmd>,
-        {
+        pub fn apply_updates_dynamic(
+            &mut self,
+            _updates: &mut dyn Iterator<Item = super::record::UpdCmd>,
+        ) -> Result<(), String> {
             Ok(())
         }
 
-        pub fn apply_updates_dynamic<I>(&self, updates: &mut I) -> Result<(), String>
-        where
-            I: Iterator<Item = UpdCmd>,
-        {
-            self.apply_updates(updates)
-        }
-
-        pub fn transaction_commit_dump_changes(&self) -> Result<DeltaMap, String> {
+        pub fn transaction_commit_dump_changes_dynamic(&mut self) -> Result<DeltaMap, String> {
             Ok(DeltaMap)
         }
+    }
+}
 
-        pub fn transaction_commit_dump_changes_dynamic(&self) -> Result<DeltaMap, String> {
-            self.transaction_commit_dump_changes()
-        }
+// --- `record` module stub ---
+pub mod record {
+    use super::*;
+
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    pub struct DDValue(serde_json::Value);
+
+    #[derive(Clone, Debug)]
+    pub enum UpdCmd {
+        Insert(usize, DDValue),
     }
 
-    pub fn run(_workers: usize, _do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
-        Err("unimplemented".to_string())
+    impl From<super::program::Update> for UpdCmd {
+        fn from(_upd: super::program::Update) -> Self {
+            unimplemented!("stub for From<Update> for UpdCmd")
+        }
+    }
+}
+
+// --- `program` module stub ---
+pub mod program {
+    use super::record::DDValue;
+
+    #[derive(Clone, Debug)]
+    pub enum Update {
+        Insert { relid: usize, v: DDValue },
+    }
+
+    pub trait DDlog {
+        // Stub trait
+    }
+    pub trait DDlogDynamic: DDlog {
+        // Stub trait
     }
 }

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -1,24 +1,14 @@
 //! Stub file for lille-ddlog crate.
-//! This file is replaced during the build process with generated DDlog code.
-//! It exists to satisfy Cargo's dependency resolution during formatting and other operations.
+#![allow(dead_code, unused_variables)]
 
-#![allow(dead_code)]
+// Stub for the top-level items in the generated crate
+pub use differential_datalog::api::{DeltaMap, HDDlog};
 
-// Minimal stub API mirroring the expected interface of generated DDlog code.
-
-pub mod api {
-    pub use differential_datalog::api::HDDlog;
-    pub use differential_datalog::{DDlog, DDlogDynamic};
-    pub use differential_datalog::program::{Update, DeltaMap};
-    pub use differential_datalog::ddval::DDValue;
-
-    pub fn run(workers: usize, do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
-        differential_datalog::api::run(workers, do_store).map_err(|e| e.to_string())
-    }
+pub fn run(workers: usize, do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
+    Err("not implemented in stub".to_string())
 }
 
-pub use api::run;
-
+// Stub for the Relations enum
 #[allow(clippy::upper_case_acronyms)]
 #[derive(Copy, Clone, Debug)]
 pub enum Relations {
@@ -30,36 +20,24 @@ pub enum Relations {
     NewVelocity,
 }
 
-#[allow(non_upper_case_globals)]
-pub mod relations {
-    pub const Position: usize = 0;
-    pub const Velocity: usize = 1;
-    pub const Mass: usize = 2;
-    pub const Force: usize = 3;
-    pub const NewPosition: usize = 4;
-    pub const NewVelocity: usize = 5;
-}
-
-use ordered_float::OrderedFloat;
-use serde::Serialize;
-use differential_datalog::ddval::DDValue;
-
-#[derive(Clone, Debug, Serialize)]
-pub enum Record {
-    Position {
-        entity: i64,
-        x: OrderedFloat<f32>,
-        y: OrderedFloat<f32>,
-        z: OrderedFloat<f32>,
-    },
-}
-
+// Stub for the record module and Record enum
 pub mod record {
-    pub use super::Record;
-}
+    use differential_datalog::record::DDValue;
+    use serde::Serialize;
 
-impl From<Record> for DDValue {
-    fn from(rec: Record) -> Self {
-        DDValue::from(&rec).unwrap_or_default()
+    #[derive(Clone, Debug, Serialize)]
+    pub enum Record {
+        Position {
+            entity: i64,
+            x: ordered_float::OrderedFloat<f32>,
+            y: ordered_float::OrderedFloat<f32>,
+            z: ordered_float::OrderedFloat<f32>,
+        },
+    }
+
+    impl From<Record> for DDValue {
+        fn from(rec: Record) -> Self {
+            unimplemented!("stub for From<Record> for DDValue")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- update DDlog imports and transaction logic
- align main code with new `UpdCmd` and `Relations` APIs
- replace stub crates with new API layout

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685cef4b10008322837f34f6c4bf8df7

## Summary by Sourcery

Align internal stubs and client code with the revised DDlog API by overhauling module layouts, update command types, and transaction method signatures.

Enhancements:
- Restructure stub crates to match updated DDlog API with new `api`, `record`, and `program` modules and revised types (`DeltaMap`, `HDDlog`, `UpdCmd`, `Update`, `DDValue`, and `Relations`).
- Adapt DDlog client code in `DdlogHandle` and `ddlog_sync` to borrow `prog` mutably, rename update vectors to `commands`, and invoke the new `apply_updates_dynamic` and `transaction_commit_dump_changes_dynamic` methods.