### PR TITLE
Align DDlog integration with updated API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,9 @@ management. Contributors should follow these best practices when working on the
 project:
 
 01. **Run `make fmt`, `make markdownlint`, and `make lint`** before committing
-    to ensure consistent code style and catch common mistakes.
+    to ensure consistent code style and catch common mistakes. After formatting
+    and linting, execute **`make test`** and **`make test-ddlog`** to validate
+    both standard and DDlog-enabled builds.
 02. **Write unit tests** for new functionality. Run `make test` in the root
     crate to ensure all tests pass.
 03. **Document public APIs** using Rustdoc comments (`///`) so documentation can

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -10,12 +10,6 @@ use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 #[cfg(feature = "ddlog")]
 use differential_datalog::api::HDDlog;
 #[cfg(feature = "ddlog")]
-use differential_datalog::ddval::DDValConvert;
-#[cfg(feature = "ddlog")]
-use differential_datalog::program::Update as DdlogUpdate;
-#[cfg(feature = "ddlog")]
-use differential_datalog::record::UpdCmd;
-#[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
 use differential_datalog::{DDlog, DDlogDynamic};
 #[cfg(feature = "ddlog")]
@@ -175,9 +169,10 @@ impl DdlogHandle {
     pub fn step(&mut self) {
         #[cfg(feature = "ddlog")]
         if let Some(prog) = &mut self.prog {
-            use lille_ddlog::{entity_state::Position, Relations};
+            use differential_datalog::record::{IntoRecord, RelIdentifier, UpdCmd};
+            use lille_ddlog::{typedefs::entity_state::Position, Relations};
 
-            let mut upds = Vec::new();
+            let mut cmds = Vec::new();
             for (&id, ent) in self.entities.iter() {
                 let record = Position {
                     entity: id,
@@ -185,17 +180,16 @@ impl DdlogHandle {
                     y: OrderedFloat(ent.position.y),
                     z: OrderedFloat(ent.position.z),
                 };
-                upds.push(DdlogUpdate::Insert {
-                    relid: Relations::entity_state_Position as usize,
-                    v: record.into_ddvalue(),
-                });
+                cmds.push(UpdCmd::Insert(
+                    RelIdentifier::RelId(Relations::entity_state_Position as usize),
+                    record.into_record(),
+                ));
             }
 
             if let Err(e) = prog.transaction_start() {
                 log::error!("DDlog transaction_start failed: {e}");
             } else {
-                let commands: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
-                let mut iter = commands.into_iter();
+                let mut iter = cmds.into_iter();
                 if let Err(e) = prog.apply_updates_dynamic(&mut iter) {
                     log::error!("DDlog apply_updates failed: {e}");
                 } else if let Err(e) = prog.transaction_commit_dump_changes_dynamic() {

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -10,6 +10,8 @@ use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 #[cfg(feature = "ddlog")]
 use differential_datalog::api::HDDlog;
 #[cfg(feature = "ddlog")]
+use differential_datalog::ddval::DDValConvert;
+#[cfg(feature = "ddlog")]
 use differential_datalog::program::Update as DdlogUpdate;
 #[cfg(feature = "ddlog")]
 use differential_datalog::record::UpdCmd;
@@ -172,28 +174,29 @@ impl DdlogHandle {
 
     pub fn step(&mut self) {
         #[cfg(feature = "ddlog")]
-        if let Some(prog) = &self.prog {
-            use lille_ddlog::{record::Record, Relations};
+        if let Some(prog) = &mut self.prog {
+            use lille_ddlog::{entity_state::Position, Relations};
 
-            let mut upds: Vec<DdlogUpdate> = Vec::new();
+            let mut upds = Vec::new();
             for (&id, ent) in self.entities.iter() {
-                let record = Record::Position {
+                let record = Position {
                     entity: id,
                     x: OrderedFloat(ent.position.x),
                     y: OrderedFloat(ent.position.y),
                     z: OrderedFloat(ent.position.z),
                 };
                 upds.push(DdlogUpdate::Insert {
-                    relid: Relations::Position as usize,
-                    v: record.into(),
+                    relid: Relations::entity_state_Position as usize,
+                    v: record.into_ddvalue(),
                 });
             }
 
             if let Err(e) = prog.transaction_start() {
                 log::error!("DDlog transaction_start failed: {e}");
             } else {
-                let cmds: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
-                if let Err(e) = prog.apply_updates_dynamic(&mut cmds.into_iter()) {
+                let commands: Vec<UpdCmd> = upds.into_iter().map(Into::into).collect();
+                let mut iter = commands.into_iter();
+                if let Err(e) = prog.apply_updates_dynamic(&mut iter) {
                     log::error!("DDlog apply_updates failed: {e}");
                 } else if let Err(e) = prog.transaction_commit_dump_changes_dynamic() {
                     log::error!("DDlog commit failed: {e}");

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -41,15 +41,27 @@ pub mod record {
     pub struct DDValue(serde_json::Value);
 
     #[derive(Clone, Debug)]
-    pub enum UpdCmd {
-        Insert(usize, DDValue),
-        Delete(usize, DDValue),
+    pub struct Record;
+
+    #[derive(Clone, Debug)]
+    pub enum RelIdentifier {
+        RelId(usize),
     }
 
-    impl From<super::program::Update> for UpdCmd {
-        fn from(_upd: super::program::Update) -> Self {
-            unimplemented!("stub for From<Update> for UpdCmd")
+    pub trait IntoRecord {
+        fn into_record(self) -> Record;
+    }
+
+    impl IntoRecord for Record {
+        fn into_record(self) -> Record {
+            self
         }
+    }
+
+    #[derive(Clone, Debug)]
+    pub enum UpdCmd {
+        Insert(RelIdentifier, Record),
+        Delete(RelIdentifier, Record),
     }
 }
 

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -1,61 +1,13 @@
-pub mod record {
-    use serde::{Deserialize, Serialize};
-    use serde_json::Value;
+//! Stub file for differential_datalog crate.
+#![allow(dead_code)]
+#![allow(warnings)]
+#![allow(clippy::all)]
+use serde::{Deserialize, Serialize};
 
-    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-    pub struct DDValue(pub Value);
-
-    impl DDValue {
-        pub fn from<T: Serialize>(val: &T) -> Result<Self, serde_json::Error> {
-            Ok(Self(serde_json::to_value(val)?))
-        }
-    }
-
-    pub use crate::program::UpdCmd;
-}
-
-pub mod program {
-    use super::record::DDValue;
-
-    #[derive(Clone, Debug)]
-    pub enum Update<R = DDValue> {
-        Insert { relid: usize, v: R },
-        Delete { relid: usize, v: R },
-    }
-
-    #[derive(Clone, Debug)]
-    pub enum UpdCmd {
-        Insert { relid: usize, val: DDValue },
-        Delete { relid: usize, val: DDValue },
-    }
-
-    impl<R: Into<DDValue>> From<Update<R>> for UpdCmd {
-        fn from(upd: Update<R>) -> Self {
-            match upd {
-                Update::Insert { relid, v } => UpdCmd::Insert { relid, val: v.into() },
-                Update::Delete { relid, v } => UpdCmd::Delete { relid, val: v.into() },
-            }
-        }
-    }
-
+// --- `api` module stub ---
+pub mod api {
     #[derive(Default, Clone, Debug)]
     pub struct DeltaMap;
-
-    pub trait DDlog {}
-    pub trait DDlogDynamic {}
-}
-
-pub mod ddval {
-    pub use super::record::DDValue;
-}
-
-pub use record::DDValue;
-pub use program::{DeltaMap, Update, UpdCmd, DDlog, DDlogDynamic};
-
-pub use api::run;
-
-pub mod api {
-    use super::program::{DeltaMap, UpdCmd};
 
     #[derive(Clone, Debug)]
     pub struct HDDlog;
@@ -65,30 +17,69 @@ pub mod api {
             Ok(())
         }
 
-        pub fn apply_updates<I>(&self, _updates: &mut I) -> Result<(), String>
+        pub fn apply_updates_dynamic<I>(
+            &mut self,
+            _updates: I,
+        ) -> Result<(), String>
         where
-            I: Iterator<Item = UpdCmd>,
+            I: IntoIterator<Item = super::record::UpdCmd>,
         {
             Ok(())
         }
 
-        pub fn apply_updates_dynamic<I>(&self, updates: &mut I) -> Result<(), String>
-        where
-            I: Iterator<Item = UpdCmd>,
-        {
-            self.apply_updates(updates)
-        }
-
-        pub fn transaction_commit_dump_changes(&self) -> Result<DeltaMap, String> {
+        pub fn transaction_commit_dump_changes_dynamic(&mut self) -> Result<DeltaMap, String> {
             Ok(DeltaMap)
         }
-
-        pub fn transaction_commit_dump_changes_dynamic(&self) -> Result<DeltaMap, String> {
-            self.transaction_commit_dump_changes()
-        }
-    }
-
-    pub fn run(_workers: usize, _do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
-        Err("unimplemented".to_string())
     }
 }
+
+// --- `record` module stub ---
+pub mod record {
+    use super::*;
+
+    #[derive(Clone, Debug, Default, Serialize, Deserialize)]
+    pub struct DDValue(serde_json::Value);
+
+    #[derive(Clone, Debug)]
+    pub enum UpdCmd {
+        Insert(usize, DDValue),
+        Delete(usize, DDValue),
+    }
+
+    impl From<super::program::Update> for UpdCmd {
+        fn from(_upd: super::program::Update) -> Self {
+            unimplemented!("stub for From<Update> for UpdCmd")
+        }
+    }
+}
+
+// --- `ddval` module stub ---
+pub mod ddval {
+    use super::record::DDValue;
+
+    pub trait DDValConvert {
+        fn into_ddvalue(self) -> DDValue;
+    }
+}
+
+pub use ddval::DDValConvert;
+
+// --- `program` module stub ---
+pub mod program {
+    use super::record::DDValue;
+
+    #[derive(Clone, Debug)]
+    pub enum Update {
+        Insert { relid: usize, v: DDValue },
+        Delete { relid: usize, v: DDValue },
+    }
+
+    pub trait DDlog {
+        // Stub trait
+    }
+    pub trait DDlogDynamic: DDlog {
+        // Stub trait
+    }
+}
+
+pub use program::{DDlog, DDlogDynamic};

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -1,65 +1,70 @@
 //! Stub file for lille-ddlog crate.
-//! This file is replaced during the build process with generated DDlog code.
-//! It exists to satisfy Cargo's dependency resolution during formatting and other operations.
+#![allow(dead_code, unused_variables)]
+#![allow(warnings)]
+#![allow(clippy::all)]
 
-#![allow(dead_code)]
+// Stub for the top-level items in the generated crate
+pub use differential_datalog::api::{DeltaMap, HDDlog};
 
-// Minimal stub API mirroring the expected interface of generated DDlog code.
+pub fn run(_workers: usize, _do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
+    Ok((HDDlog, DeltaMap))
+}
 
-pub mod api {
-    pub use differential_datalog::api::HDDlog;
-    pub use differential_datalog::{DDlog, DDlogDynamic};
-    pub use differential_datalog::program::{Update, DeltaMap};
-    pub use differential_datalog::ddval::DDValue;
+// Stub for the Relations enum
+#[allow(clippy::upper_case_acronyms)]
+#[derive(Copy, Clone, Debug)]
+#[allow(non_camel_case_types)]
+pub enum Relations {
+    entity_state_Position,
+    entity_state_Velocity,
+    entity_state_Mass,
+    physics_Force,
+    physics_NewPosition,
+    physics_NewVelocity,
+}
 
-    pub fn run(workers: usize, do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
-        differential_datalog::api::run(workers, do_store).map_err(|e| e.to_string())
+pub mod entity_state {
+    use ordered_float::OrderedFloat;
+    use differential_datalog::ddval::DDValConvert;
+    use differential_datalog::record::DDValue;
+
+    #[derive(Clone, Debug)]
+    pub struct Position {
+        pub entity: i64,
+        pub x: OrderedFloat<f32>,
+        pub y: OrderedFloat<f32>,
+        pub z: OrderedFloat<f32>,
+    }
+
+    impl DDValConvert for Position {
+        fn into_ddvalue(self) -> DDValue {
+            unimplemented!("stub into_ddvalue")
+        }
     }
 }
 
-pub use api::run;
-
-#[allow(clippy::upper_case_acronyms)]
-#[derive(Copy, Clone, Debug)]
-pub enum Relations {
-    Position,
-    Velocity,
-    Mass,
-    Force,
-    NewPosition,
-    NewVelocity,
+pub mod types__entity_state {
+    pub use super::entity_state::Position;
 }
 
-#[allow(non_upper_case_globals)]
-pub mod relations {
-    pub const Position: usize = 0;
-    pub const Velocity: usize = 1;
-    pub const Mass: usize = 2;
-    pub const Force: usize = 3;
-    pub const NewPosition: usize = 4;
-    pub const NewVelocity: usize = 5;
-}
-
-use ordered_float::OrderedFloat;
-use serde::Serialize;
-use differential_datalog::ddval::DDValue;
-
-#[derive(Clone, Debug, Serialize)]
-pub enum Record {
-    Position {
-        entity: i64,
-        x: OrderedFloat<f32>,
-        y: OrderedFloat<f32>,
-        z: OrderedFloat<f32>,
-    },
-}
-
+// Stub for the record module and Record enum
 pub mod record {
-    pub use super::Record;
-}
+    use differential_datalog::record::DDValue;
+    use serde::Serialize;
 
-impl From<Record> for DDValue {
-    fn from(rec: Record) -> Self {
-        DDValue::from(&rec).unwrap_or_default()
+    #[derive(Clone, Debug, Serialize)]
+    pub enum Record {
+        Position {
+            entity: i64,
+            x: ordered_float::OrderedFloat<f32>,
+            y: ordered_float::OrderedFloat<f32>,
+            z: ordered_float::OrderedFloat<f32>,
+        },
+    }
+
+    impl From<Record> for DDValue {
+        fn from(rec: Record) -> Self {
+            unimplemented!("stub for From<Record> for DDValue")
+        }
     }
 }

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -26,7 +26,7 @@ pub enum Relations {
 pub mod entity_state {
     use ordered_float::OrderedFloat;
     use differential_datalog::ddval::DDValConvert;
-    use differential_datalog::record::DDValue;
+    use differential_datalog::record::{DDValue, IntoRecord, Record};
 
     #[derive(Clone, Debug)]
     pub struct Position {
@@ -41,10 +41,22 @@ pub mod entity_state {
             unimplemented!("stub into_ddvalue")
         }
     }
+
+    impl IntoRecord for Position {
+        fn into_record(self) -> Record {
+            unimplemented!("stub into_record")
+        }
+    }
 }
 
 pub mod types__entity_state {
     pub use super::entity_state::Position;
+}
+
+pub mod typedefs {
+    pub mod entity_state {
+        pub use crate::entity_state::Position;
+    }
 }
 
 // Stub for the record module and Record enum


### PR DESCRIPTION
## Summary
- use updated DDlog imports and structs when applying updates
- rework stubs to match DDlog crate layout
- document running `make test-ddlog` in AGENTS guidelines

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(failed: unresolved import in `lille_ddlog`)*

------
https://chatgpt.com/codex/tasks/task_e_685cef4b10008322837f34f6c4bf8df7

## Summary by Sourcery

Align the DDlog integration with the updated API by restructuring stub modules, updating call sites to the new module paths and function signatures, and enhancing documentation

Enhancements:
- Rework DDlog stub modules to match the updated differential_datalog crate layout and APIs
- Update ddlog_handle and ddlog_sync to use the new entity_state::Position type, into_ddvalue conversion, and revised apply_updates_dynamic signature
- Rename Relations enum variants to the new entity_state_* naming scheme and simplify the run stub to always return Ok
- Add permissive allow annotations (dead_code, warnings, clippy) in stub files

Documentation:
- Document in AGENTS.md that contributors should run `make test-ddlog` alongside standard checks