### PR TITLE
Integrate ddlog step fallback with clean sync

### DIFF
--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -9,8 +9,6 @@ use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 #[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
 use differential_datalog::{DDlog, DDlogDynamic};
-#[cfg(feature = "ddlog")]
-use ordered_float::OrderedFloat;
 
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
@@ -58,32 +56,7 @@ pub fn push_state_to_ddlog_system(
 
     #[cfg(feature = "ddlog")]
     {
-        use differential_datalog::record::{IntoRecord, RelIdentifier, UpdCmd};
-        use lille_ddlog::{typedefs::entity_state::Position, Relations};
-
-        let mut cmds = Vec::new();
-        for (&id, ent) in ddlog.entities.iter() {
-            let record = Position {
-                entity: id,
-                x: OrderedFloat(ent.position.x),
-                y: OrderedFloat(ent.position.y),
-                z: OrderedFloat(ent.position.z),
-            };
-            cmds.push(UpdCmd::Insert(
-                RelIdentifier::RelId(Relations::entity_state_Position as usize),
-                record.into_record(),
-            ));
-        }
-        if let Some(prog) = ddlog.prog.as_mut() {
-            if let Err(e) = prog.transaction_start() {
-                log::error!("DDlog transaction_start failed: {e}");
-            } else {
-                let mut iter = cmds.into_iter();
-                if let Err(e) = prog.apply_updates_dynamic(&mut iter) {
-                    log::error!("DDlog apply_updates failed: {e}");
-                }
-            }
-        }
+        let _ = ddlog; // state sync only; transaction handled in DdlogHandle::step
     }
 }
 

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -6,8 +6,20 @@ use serde::{Deserialize, Serialize};
 
 // --- `api` module stub ---
 pub mod api {
+    use super::program::Update;
+    use std::collections::HashMap;
+
     #[derive(Default, Clone, Debug)]
-    pub struct DeltaMap;
+    pub struct DeltaMap(pub HashMap<usize, Vec<Update>>);
+
+    impl IntoIterator for DeltaMap {
+        type Item = (usize, Vec<Update>);
+        type IntoIter = std::collections::hash_map::IntoIter<usize, Vec<Update>>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.0.into_iter()
+        }
+    }
 
     #[derive(Clone, Debug)]
     pub struct HDDlog;
@@ -28,7 +40,7 @@ pub mod api {
         }
 
         pub fn transaction_commit_dump_changes_dynamic(&mut self) -> Result<DeltaMap, String> {
-            Ok(DeltaMap)
+            Ok(DeltaMap::default())
         }
     }
 }
@@ -38,7 +50,13 @@ pub mod record {
     use super::*;
 
     #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-    pub struct DDValue(serde_json::Value);
+    pub struct DDValue(pub serde_json::Value);
+
+    impl DDValue {
+        pub fn into_json(self) -> serde_json::Value {
+            self.0
+        }
+    }
 
     #[derive(Clone, Debug)]
     pub struct Record;

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -7,7 +7,7 @@
 pub use differential_datalog::api::{DeltaMap, HDDlog};
 
 pub fn run(_workers: usize, _do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
-    Ok((HDDlog, DeltaMap))
+    Ok((HDDlog, DeltaMap::default()))
 }
 
 // Stub for the Relations enum
@@ -56,6 +56,36 @@ pub mod types__entity_state {
 pub mod typedefs {
     pub mod entity_state {
         pub use crate::entity_state::Position;
+    }
+    pub mod physics {
+        pub use crate::physics::NewPosition;
+    }
+}
+
+pub mod physics {
+    use ordered_float::OrderedFloat;
+    use differential_datalog::ddval::DDValConvert;
+    use differential_datalog::record::{DDValue, IntoRecord, Record};
+    use serde::Deserialize;
+
+    #[derive(Clone, Debug, Deserialize)]
+    pub struct NewPosition {
+        pub entity: i64,
+        pub x: OrderedFloat<f32>,
+        pub y: OrderedFloat<f32>,
+        pub z: OrderedFloat<f32>,
+    }
+
+    impl DDValConvert for NewPosition {
+        fn into_ddvalue(self) -> DDValue {
+            unimplemented!("stub into_ddvalue")
+        }
+    }
+
+    impl IntoRecord for NewPosition {
+        fn into_record(self) -> Record {
+            unimplemented!("stub into_record")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- restructure `DdlogHandle::step` so transactions run only once
- strip DDlog calls from `push_state_to_ddlog_system`
- extend DDlog stubs with usable `DeltaMap`

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog`


------
https://chatgpt.com/codex/tasks/task_e_685d93760b58832288f4db8283034299

## Summary by Sourcery

Integrate fallback update processing into the DDlog handling pipeline and clean up state synchronization by restructuring transaction management and enhancing DDlog stubs.

Enhancements:
- Restructure DdlogHandle::step to handle transactions only once and apply fallback entity updates directly.
- Remove explicit DDlog calls from push_state_to_ddlog_system to delegate transaction logic to DdlogHandle::step.
- Extend DDlog stub API with a functional DeltaMap backed by a HashMap and add DDValue.into_json method.
- Introduce a NewPosition struct stub and corresponding typedefs in the physics module for use in fallback deltas.