### PR TITLE
Process DDlog deltas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ glam = "0.24"
 ordered-float = "2"
 
 [dev-dependencies]
-insta = { version = "1.38.0", features = ["ron"] }
+insta = { version = "1.38.0", default-features = false, features = ["ron"] }
 rstest = "0.18.0"
 regex = "1"
 once_cell = "1"

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -169,7 +169,7 @@ impl DdlogHandle {
     }
 
     #[cfg(feature = "ddlog")]
-    fn apply_ddlog_deltas(&mut self, changes: &DeltaMap) {
+    fn apply_ddlog_deltas(&mut self, changes: &DeltaMap<differential_datalog::record::DDValue>) {
         use differential_datalog::ddval::DDValConvert;
         use lille_ddlog::typedefs::physics::NewPosition as OutNewPos;
         self.deltas.clear();

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -169,6 +169,8 @@ impl DdlogHandle {
     pub fn step(&mut self) {
         #[cfg(feature = "ddlog")]
         if let Some(prog) = &mut self.prog {
+            #[allow(unused_imports)]
+            use differential_datalog::ddval::DDValConvert;
             use differential_datalog::record::{IntoRecord, RelIdentifier, UpdCmd};
             use lille_ddlog::{typedefs::entity_state::Position, Relations};
 
@@ -192,8 +194,43 @@ impl DdlogHandle {
                 let mut iter = cmds.into_iter();
                 if let Err(e) = prog.apply_updates_dynamic(&mut iter) {
                     log::error!("DDlog apply_updates failed: {e}");
-                } else if let Err(e) = prog.transaction_commit_dump_changes_dynamic() {
-                    log::error!("DDlog commit failed: {e}");
+                } else {
+                    match prog.transaction_commit_dump_changes_dynamic() {
+                        Ok(changes) => {
+                            use lille_ddlog::typedefs::physics::NewPosition as OutNewPos;
+
+                            self.deltas.clear();
+                            if let Some(delta) =
+                                changes.try_get_rel(Relations::physics_NewPosition as usize)
+                            {
+                                for (val, weight) in delta {
+                                    if *weight > 0 {
+                                        if let Some(out) = OutNewPos::try_from_ddvalue(val.clone())
+                                        {
+                                            let pos = Vec3::new(
+                                                out.x.into_inner(),
+                                                out.y.into_inner(),
+                                                out.z.into_inner(),
+                                            );
+                                            if let Some(ent) = self.entities.get_mut(&out.entity) {
+                                                ent.position = pos;
+                                            }
+                                            self.deltas.push(NewPosition {
+                                                entity: out.entity,
+                                                x: pos.x,
+                                                y: pos.y,
+                                                z: pos.z,
+                                            });
+                                        }
+                                    }
+                                }
+                            }
+                            return;
+                        }
+                        Err(e) => {
+                            log::error!("DDlog commit failed: {e}");
+                        }
+                    }
                 }
             }
         }

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -10,6 +10,8 @@ use crate::{GRACE_DISTANCE, GRAVITY_PULL};
 #[cfg(feature = "ddlog")]
 use differential_datalog::api::HDDlog;
 #[cfg(feature = "ddlog")]
+use differential_datalog::DeltaMap;
+#[cfg(feature = "ddlog")]
 #[allow(unused_imports)]
 use differential_datalog::{DDlog, DDlogDynamic};
 #[cfg(feature = "ddlog")]
@@ -167,7 +169,7 @@ impl DdlogHandle {
     }
 
     #[cfg(feature = "ddlog")]
-    fn apply_ddlog_deltas(&mut self, changes: &lille_ddlog::DeltaMap) {
+    fn apply_ddlog_deltas(&mut self, changes: &DeltaMap) {
         use differential_datalog::ddval::DDValConvert;
         use lille_ddlog::typedefs::physics::NewPosition as OutNewPos;
         self.deltas.clear();

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -53,6 +53,11 @@ pub mod api {
 
 pub use api::DeltaMap;
 
+// Provide a `valmap` module for compatibility with the real crate.
+pub mod valmap {
+    pub use crate::api::DeltaMap;
+}
+
 // --- `record` module stub ---
 pub mod record {
     use super::*;

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -6,8 +6,18 @@ use serde::{Deserialize, Serialize};
 
 // --- `api` module stub ---
 pub mod api {
+    use std::collections::BTreeMap;
     #[derive(Default, Clone, Debug)]
     pub struct DeltaMap;
+
+    impl DeltaMap {
+        pub fn try_get_rel(
+            &self,
+            _relid: usize,
+        ) -> Option<&BTreeMap<super::record::DDValue, isize>> {
+            None
+        }
+    }
 
     #[derive(Clone, Debug)]
     pub struct HDDlog;

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -7,10 +7,18 @@ use serde::{Deserialize, Serialize};
 // --- `api` module stub ---
 pub mod api {
     use std::collections::BTreeMap;
-    #[derive(Default, Clone, Debug)]
-    pub struct DeltaMap;
+    use std::marker::PhantomData;
 
-    impl DeltaMap {
+    #[derive(Clone, Debug)]
+    pub struct DeltaMap<V = super::record::DDValue>(PhantomData<V>);
+
+    impl<V> Default for DeltaMap<V> {
+        fn default() -> Self {
+            DeltaMap(PhantomData)
+        }
+    }
+
+    impl<V> DeltaMap<V> {
         pub fn try_get_rel(
             &self,
             _relid: usize,
@@ -38,10 +46,12 @@ pub mod api {
         }
 
         pub fn transaction_commit_dump_changes_dynamic(&mut self) -> Result<DeltaMap, String> {
-            Ok(DeltaMap)
+            Ok(DeltaMap::default())
         }
     }
 }
+
+pub use api::DeltaMap;
 
 // --- `record` module stub ---
 pub mod record {
@@ -81,6 +91,12 @@ pub mod ddval {
 
     pub trait DDValConvert {
         fn into_ddvalue(self) -> DDValue;
+        fn try_from_ddvalue(_val: DDValue) -> Option<Self>
+        where
+            Self: Sized,
+        {
+            None
+        }
     }
 }
 

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -47,8 +47,8 @@ pub mod api {
 
         pub fn transaction_commit_dump_changes_dynamic(
             &mut self,
-        ) -> Result<DeltaMap<super::record::DDValue>, String> {
-            Ok(DeltaMap::<super::record::DDValue>::default())
+        ) -> Result<std::collections::BTreeMap<usize, Vec<(super::record::Record, isize)>>, String> {
+            Ok(std::collections::BTreeMap::new())
         }
     }
 }
@@ -90,11 +90,17 @@ pub mod record {
         Insert(RelIdentifier, Record),
         Delete(RelIdentifier, Record),
     }
+
+    impl From<Record> for DDValue {
+        fn from(_rec: Record) -> Self {
+            DDValue(serde_json::Value::Null)
+        }
+    }
 }
 
 // --- `ddval` module stub ---
 pub mod ddval {
-    use super::record::DDValue;
+    pub use super::record::DDValue;
 
     pub trait DDValConvert {
         fn into_ddvalue(self) -> DDValue;

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -10,7 +10,7 @@ pub mod api {
     use std::marker::PhantomData;
 
     #[derive(Clone, Debug)]
-    pub struct DeltaMap<V = super::record::DDValue>(PhantomData<V>);
+    pub struct DeltaMap<V>(PhantomData<V>);
 
     impl<V> Default for DeltaMap<V> {
         fn default() -> Self {
@@ -45,8 +45,10 @@ pub mod api {
             Ok(())
         }
 
-        pub fn transaction_commit_dump_changes_dynamic(&mut self) -> Result<DeltaMap, String> {
-            Ok(DeltaMap::default())
+        pub fn transaction_commit_dump_changes_dynamic(
+            &mut self,
+        ) -> Result<DeltaMap<super::record::DDValue>, String> {
+            Ok(DeltaMap::<super::record::DDValue>::default())
         }
     }
 }

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -23,6 +23,51 @@ pub enum Relations {
     physics_NewVelocity,
 }
 
+pub mod physics {
+    use ordered_float::OrderedFloat;
+    use differential_datalog::ddval::DDValConvert;
+    use differential_datalog::record::{DDValue, IntoRecord, Record};
+
+    #[derive(Clone, Debug)]
+    pub struct NewPosition {
+        pub entity: i64,
+        pub x: OrderedFloat<f32>,
+        pub y: OrderedFloat<f32>,
+        pub z: OrderedFloat<f32>,
+    }
+
+    impl DDValConvert for NewPosition {
+        fn into_ddvalue(self) -> DDValue {
+            unimplemented!("stub into_ddvalue")
+        }
+    }
+
+    impl NewPosition {
+        pub fn try_from_ddvalue(_val: DDValue) -> Option<Self> {
+            None
+        }
+    }
+
+    impl IntoRecord for NewPosition {
+        fn into_record(self) -> Record {
+            unimplemented!("stub into_record")
+        }
+    }
+}
+
+pub mod types__physics {
+    pub use super::physics::NewPosition;
+}
+
+pub mod typedefs {
+    pub mod entity_state {
+        pub use crate::entity_state::Position;
+    }
+    pub mod physics {
+        pub use crate::physics::NewPosition;
+    }
+}
+
 pub mod entity_state {
     use ordered_float::OrderedFloat;
     use differential_datalog::ddval::DDValConvert;
@@ -51,12 +96,6 @@ pub mod entity_state {
 
 pub mod types__entity_state {
     pub use super::entity_state::Position;
-}
-
-pub mod typedefs {
-    pub mod entity_state {
-        pub use crate::entity_state::Position;
-    }
 }
 
 // Stub for the record module and Record enum

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -7,7 +7,7 @@
 pub use differential_datalog::api::{DeltaMap, HDDlog};
 
 pub fn run(_workers: usize, _do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
-    Ok((HDDlog, DeltaMap))
+    Ok((HDDlog, DeltaMap::default()))
 }
 
 // Stub for the Relations enum
@@ -23,52 +23,7 @@ pub enum Relations {
     physics_NewVelocity,
 }
 
-pub mod physics {
-    use ordered_float::OrderedFloat;
-    use differential_datalog::ddval::DDValConvert;
-    use differential_datalog::record::{DDValue, IntoRecord, Record};
-
-    #[derive(Clone, Debug)]
-    pub struct NewPosition {
-        pub entity: i64,
-        pub x: OrderedFloat<f32>,
-        pub y: OrderedFloat<f32>,
-        pub z: OrderedFloat<f32>,
-    }
-
-    impl DDValConvert for NewPosition {
-        fn into_ddvalue(self) -> DDValue {
-            unimplemented!("stub into_ddvalue")
-        }
-    }
-
-    impl NewPosition {
-        pub fn try_from_ddvalue(_val: DDValue) -> Option<Self> {
-            None
-        }
-    }
-
-    impl IntoRecord for NewPosition {
-        fn into_record(self) -> Record {
-            unimplemented!("stub into_record")
-        }
-    }
-}
-
-pub mod types__physics {
-    pub use super::physics::NewPosition;
-}
-
-pub mod typedefs {
-    pub mod entity_state {
-        pub use crate::entity_state::Position;
-    }
-    pub mod physics {
-        pub use crate::physics::NewPosition;
-    }
-}
-
-pub mod entity_state {
+pub mod shared {
     use ordered_float::OrderedFloat;
     use differential_datalog::ddval::DDValConvert;
     use differential_datalog::record::{DDValue, IntoRecord, Record};
@@ -87,6 +42,12 @@ pub mod entity_state {
         }
     }
 
+    impl Position {
+        pub fn try_from_ddvalue(_val: DDValue) -> Option<Self> {
+            None
+        }
+    }
+
     impl IntoRecord for Position {
         fn into_record(self) -> Record {
             unimplemented!("stub into_record")
@@ -94,8 +55,29 @@ pub mod entity_state {
     }
 }
 
+pub mod physics {
+    pub use crate::shared::Position as NewPosition;
+}
+
+pub mod types__physics {
+    pub use crate::shared::Position as NewPosition;
+}
+
+pub mod typedefs {
+    pub mod entity_state {
+        pub use crate::shared::Position;
+    }
+    pub mod physics {
+        pub use crate::shared::Position as NewPosition;
+    }
+}
+
+pub mod entity_state {
+    pub use crate::shared::Position;
+}
+
 pub mod types__entity_state {
-    pub use super::entity_state::Position;
+    pub use crate::shared::Position;
 }
 
 // Stub for the record module and Record enum

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -26,6 +26,13 @@ pub enum Relations {
     physics_NewVelocity,
 }
 
+pub fn relval_from_record(
+    _relation: Relations,
+    _record: &differential_datalog::record::Record,
+) -> Result<differential_datalog::record::DDValue, String> {
+    Ok(differential_datalog::record::DDValue::default())
+}
+
 pub mod shared {
     use ordered_float::OrderedFloat;
     use differential_datalog::ddval::DDValConvert;

--- a/stubs/lille_ddlog/lib.rs
+++ b/stubs/lille_ddlog/lib.rs
@@ -6,8 +6,11 @@
 // Stub for the top-level items in the generated crate
 pub use differential_datalog::api::{DeltaMap, HDDlog};
 
-pub fn run(_workers: usize, _do_store: bool) -> Result<(HDDlog, DeltaMap), String> {
-    Ok((HDDlog, DeltaMap::default()))
+pub fn run(
+    _workers: usize,
+    _do_store: bool,
+) -> Result<(HDDlog, DeltaMap<differential_datalog::record::DDValue>), String> {
+    Ok((HDDlog, DeltaMap::<differential_datalog::record::DDValue>::default()))
 }
 
 // Stub for the Relations enum


### PR DESCRIPTION
## Summary
- handle physics_NewPosition relation updates from DDlog
- extend DDlog stubs for compatibility
- disable default features of insta

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: build interrupted or missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685da3ac187c8322872921458d583e40

## Summary by Sourcery

Extend DDlog integration by processing NewPosition deltas and updating stub libraries for compatibility, while streamlining the DDlog transaction flow and adjusting dependency features

New Features:
- Apply physics_NewPosition deltas from DDlog to update entity positions
- Augment DDlog stub crates to support DeltaMap, valmap, relval_from_record, and DDValConvert compatibility

Enhancements:
- Refactor step() to build update commands via iterator and integrate delta handling into the DDlog transaction flow

Build:
- Disable default features for insta in Cargo.toml