### PR TITLE
Centralize DDlog transaction lifecycle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -109,6 +109,9 @@ The movement calculation considers:
 
 ### DDlog Transaction Flow
 
+The following sequence diagram illustrates how the game loop interacts with the
+DDlog system through the `DdlogHandle` during each simulation step:
+
 ```mermaid
 sequenceDiagram
     participant GameLoop

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,7 +107,7 @@ The movement calculation considers:
 - Command-line argument parsing for configuration
 - Visual debugging through density-based rendering
 
-### DDlog Transaction Flow
+### DDlog transaction flow
 
 The following sequence diagram illustrates how the game loop interacts with the
 DDlog system through the `DdlogHandle` during each simulation step:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,24 @@ The movement calculation considers:
 - Command-line argument parsing for configuration
 - Visual debugging through density-based rendering
 
+### DDlog Transaction Flow
+
+```mermaid
+sequenceDiagram
+    participant GameLoop
+    participant DdlogHandle
+    participant DDlogProgram
+
+    GameLoop->>DdlogHandle: step()
+    activate DdlogHandle
+    DdlogHandle->>DDlogProgram: transaction_start()
+    DdlogHandle->>DDlogProgram: stream cached state
+    DdlogHandle->>DDlogProgram: commit transaction
+    DDlogProgram-->>DdlogHandle: return deltas
+    DdlogHandle-->>GameLoop: apply deltas
+    deactivate DdlogHandle
+```
+
 ## Future Considerations
 
 The architecture supports several potential extensions:

--- a/docs/ddlog-world-inference.md
+++ b/docs/ddlog-world-inference.md
@@ -279,7 +279,7 @@ fn init_ddlog_system(mut commands: Commands) {
 }
 
 // System to push ECS state into DDlog input relations
-fn push_state_to_ddlog_system(
+fn cache_state_for_ddlog_system(
     ddlog_handle: Res<DdlogHandle>,
     // Query for all entities that should be in the logic simulation
     query: Query<(Entity, &Transform, &Health, &UnitType, Option<&Target>)>,
@@ -389,7 +389,7 @@ fn main() {
         .add_startup_system(init_ddlog_system)
         .add_systems(
             (
-                push_state_to_ddlog_system,
+                cache_state_for_ddlog_system,
                 apply_ddlog_deltas_system,
             )
             .chain() // Ensures they run in order

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -305,10 +305,11 @@ impl DdlogHandle {
 
     /// Advances the simulation by one tick.
     ///
-    /// When the `ddlog` feature is enabled, this function streams the current
-    /// entity state into the DDlog program and applies the resulting deltas. In
-    /// builds without DDlog, it falls back to a simplified Rust implementation
-    /// that directly updates positions.
+    /// When the `ddlog` feature is enabled, this method manages the full
+    /// lifecycle of a DDlog transaction. It streams the cached state from
+    /// [`DdlogHandle`] into the DDlog program, commits the transaction, and
+    /// applies any returned deltas. In builds without DDlog, it falls back to a
+    /// simplified Rust implementation that directly updates positions.
     pub fn step(&mut self) {
         #[cfg(feature = "ddlog")]
         {

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -308,8 +308,10 @@ impl DdlogHandle {
     /// When the `ddlog` feature is enabled, this method manages the full
     /// lifecycle of a DDlog transaction. It streams the cached state from
     /// [`DdlogHandle`] into the DDlog program, commits the transaction, and
-    /// applies any returned deltas. In builds without DDlog, it falls back to a
-    /// simplified Rust implementation that directly updates positions.
+    /// applies any returned deltas. Errors during `transaction_start`,
+    /// `apply_updates`, or the commit are logged and cause the method to exit
+    /// early without applying any deltas. In builds without DDlog, it falls back
+    /// to a simplified Rust implementation that directly updates positions.
     pub fn step(&mut self) {
         #[cfg(feature = "ddlog")]
         {

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -6,12 +6,6 @@ use hashbrown::HashMap;
 use crate::components::{Block, BlockSlope, DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 
-#[cfg(feature = "ddlog")]
-#[allow(unused_imports)]
-use differential_datalog::{DDlog, DDlogDynamic};
-#[cfg(feature = "ddlog")]
-use ordered_float::OrderedFloat;
-
 /// Pushes the current ECS state into DDlog.
 /// This implementation is a stub that simply logs the state.
 pub fn push_state_to_ddlog_system(
@@ -55,36 +49,6 @@ pub fn push_state_to_ddlog_system(
     ddlog.entities = new_entities;
     ddlog.blocks = blocks;
     ddlog.slopes = slopes;
-
-    #[cfg(feature = "ddlog")]
-    {
-        use differential_datalog::record::{IntoRecord, RelIdentifier, UpdCmd};
-        use lille_ddlog::{typedefs::entity_state::Position, Relations};
-
-        let mut cmds = Vec::new();
-        for (&id, ent) in ddlog.entities.iter() {
-            let record = Position {
-                entity: id,
-                x: OrderedFloat(ent.position.x),
-                y: OrderedFloat(ent.position.y),
-                z: OrderedFloat(ent.position.z),
-            };
-            cmds.push(UpdCmd::Insert(
-                RelIdentifier::RelId(Relations::entity_state_Position as usize),
-                record.into_record(),
-            ));
-        }
-        if let Some(prog) = ddlog.prog.as_mut() {
-            if let Err(e) = prog.transaction_start() {
-                log::error!("DDlog transaction_start failed: {e}");
-            } else {
-                let mut iter = cmds.into_iter();
-                if let Err(e) = prog.apply_updates_dynamic(&mut iter) {
-                    log::error!("DDlog apply_updates failed: {e}");
-                }
-            }
-        }
-    }
 }
 
 /// Applies the inferred movement deltas from the DDlog stub.

--- a/src/ddlog_sync.rs
+++ b/src/ddlog_sync.rs
@@ -6,9 +6,13 @@ use hashbrown::HashMap;
 use crate::components::{Block, BlockSlope, DdlogId, Health, Target, UnitType};
 use crate::ddlog_handle::{DdlogEntity, DdlogHandle};
 
-/// Pushes the current ECS state into DDlog.
-/// This implementation is a stub that simply logs the state.
-pub fn push_state_to_ddlog_system(
+/// Caches the current ECS state on [`DdlogHandle`].
+///
+/// This system no longer interacts with the DDlog runtime directly. It merely
+/// mirrors relevant component data into the [`DdlogHandle`] resource so that
+/// [`DdlogHandle::step`](crate::ddlog_handle::DdlogHandle::step) can process it
+/// later.
+pub fn cache_state_for_ddlog_system(
     mut ddlog: ResMut<DdlogHandle>,
     entity_query: Query<(&DdlogId, &Transform, &Health, &UnitType, Option<&Target>)>,
     block_query: Query<(&Block, Option<&BlockSlope>)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 pub use actor::Actor;
 pub use components::{DdlogId, Health, Target, UnitType};
 pub use ddlog_handle::{init_ddlog_system, DdlogHandle};
-pub use ddlog_sync::{apply_ddlog_deltas_system, push_state_to_ddlog_system};
+pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};
 pub use entity::{BadGuy, Entity};
 pub use logging::init as init_logging;
 pub use spawn_world::spawn_world_system;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 use clap::Parser;
 use color_eyre::eyre::Result;
 use lille::{
-    apply_ddlog_deltas_system, init_ddlog_system, init_logging, push_state_to_ddlog_system,
+    apply_ddlog_deltas_system, cache_state_for_ddlog_system, init_ddlog_system, init_logging,
     spawn_world_system,
 };
 
@@ -32,11 +32,11 @@ fn main() -> Result<()> {
         .add_systems(Startup, spawn_world_system.after(init_ddlog_system))
         .add_systems(
             Startup,
-            push_state_to_ddlog_system.after(spawn_world_system),
+            cache_state_for_ddlog_system.after(spawn_world_system),
         )
         .add_systems(
             Update,
-            (push_state_to_ddlog_system, apply_ddlog_deltas_system).chain(),
+            (cache_state_for_ddlog_system, apply_ddlog_deltas_system).chain(),
         )
         .run();
     Ok(())

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -4,8 +4,8 @@
 use bevy::prelude::*;
 use glam::Vec2;
 use lille::{
-    apply_ddlog_deltas_system, init_ddlog_system, push_state_to_ddlog_system, DdlogHandle, DdlogId,
-    Health, Target, UnitType,
+    apply_ddlog_deltas_system, cache_state_for_ddlog_system, init_ddlog_system, DdlogHandle,
+    DdlogId, Health, Target, UnitType,
 };
 use once_cell::sync::Lazy;
 use regex::Regex;
@@ -61,7 +61,7 @@ fn ddlog_app() -> App {
     app.add_systems(Startup, init_ddlog_system);
     app.add_systems(
         Update,
-        (push_state_to_ddlog_system, apply_ddlog_deltas_system).chain(),
+        (cache_state_for_ddlog_system, apply_ddlog_deltas_system).chain(),
     );
     app
 }

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -4,10 +4,10 @@
 use bevy::prelude::*;
 use insta::assert_ron_snapshot;
 use lille::{
-    apply_ddlog_deltas_system,
+    apply_ddlog_deltas_system, cache_state_for_ddlog_system,
     components::{Block, BlockSlope, DdlogId, Health, UnitType},
     ddlog_handle::DdlogHandle,
-    init_ddlog_system, push_state_to_ddlog_system,
+    init_ddlog_system,
 };
 use rstest::rstest;
 
@@ -24,7 +24,7 @@ fn entity_transitions_between_standing_and_falling() {
     let mut app = setup_app();
     app.add_systems(
         Update,
-        (push_state_to_ddlog_system, apply_ddlog_deltas_system).chain(),
+        (cache_state_for_ddlog_system, apply_ddlog_deltas_system).chain(),
     );
     let block_entity = app
         .world


### PR DESCRIPTION
## Summary
- remove direct DDlog API calls from `push_state_to_ddlog_system`
- document `DdlogHandle::step` as the single transaction manager

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: ddlog_moves_towards_target, ddlog_flees_from_baddie)*

------
https://chatgpt.com/codex/tasks/task_e_685f4055eee88322951383ba177ea998

## Summary by Sourcery

Centralize DDlog transaction management by removing direct API calls from push_state_to_ddlog_system and consolidating transaction lifecycle into DdlogHandle::step

Enhancements:
- Remove inline DDlog API calls from push_state_to_ddlog_system
- Centralize DDlog transaction lifecycle in DdlogHandle::step

Documentation:
- Document DdlogHandle::step as the single manager for DDlog transactions