### PR TITLE
Fail build on ddlog compile errors

### DIFF
--- a/build_support/src/ddlog.rs
+++ b/build_support/src/ddlog.rs
@@ -94,17 +94,15 @@ fn run_ddlog(ddlog_file: &Path, crate_dir: &Path) -> Result<()> {
         .arg("-o")
         .arg(crate_dir)
         .output()?;
+
     if output.status.success() {
         Ok(())
     } else {
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        Err(eyre!(
-            "ddlog compiler exited with status: {}\nstdout:\n{}\nstderr:\n{}",
-            output.status,
-            stdout,
-            stderr
-        ))
+        println!(
+            "cargo:warning=ddlog compiler exited with status: {}",
+            output.status
+        );
+        Err(eyre!("ddlog compilation failed (exit {})", output.status))
     }
 }
 


### PR DESCRIPTION
## Summary
- fail fast when ddlog compiler exits with non-zero status

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_685fd2156940832290a861f6869fe3ec