### PR TITLE
Fix DDlog concurrency panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ regex = "1"
 once_cell = "1"
 approx = "0.5"
 ordered-float = { workspace = true }
+serial_test = "3.2"

--- a/tests/ddlog.rs
+++ b/tests/ddlog.rs
@@ -10,6 +10,7 @@ use lille::{
 use once_cell::sync::Lazy;
 use regex::Regex;
 use rstest::{fixture, rstest};
+use serial_test::serial;
 use std::collections::HashSet;
 
 const DL_SRC: &str = concat!(
@@ -67,6 +68,7 @@ fn ddlog_app() -> App {
 }
 
 #[rstest]
+#[serial]
 fn ddlog_moves_towards_target(ddlog_app: App) {
     let mut app = ddlog_app;
     let _e = app
@@ -100,6 +102,7 @@ fn ddlog_moves_towards_target(ddlog_app: App) {
 /// ddlog_flees_from_baddie();
 /// ```
 #[rstest]
+#[serial]
 fn ddlog_flees_from_baddie(ddlog_app: App) {
     let mut app = ddlog_app;
     let _civvy = app


### PR DESCRIPTION
## Summary
- add `serial_test` dev dependency
- run DDlog tests serially

## Testing
- `make lint`
- `make test`
- `make test-ddlog` *(fails: stub implementation)*

------
https://chatgpt.com/codex/tasks/task_e_685fdba32e748322b0e487b60dc80839

## Summary by Sourcery

Prevent DDlog tests from panicking under concurrent execution by adding the serial_test crate as a dev dependency and marking tests to run sequentially.

Bug Fixes:
- Prevent DDlog tests from panicking due to concurrent execution.

Enhancements:
- Add serial_test as a development dependency to enable serial test execution.

Tests:
- Annotate DDlog tests with #[serial] to enforce sequential execution.