### PR TITLE
Normalize physics constant keys

### DIFF
--- a/build_support/src/constants.rs
+++ b/build_support/src/constants.rs
@@ -180,11 +180,10 @@ pub fn generate_code_from_constants(parsed: &Value, fmts: &Formats) -> String {
         code.push_str("import types\n\n");
     }
     let mut append = |k: &str, v: &Value| {
-        let name = if matches!(fmts.flavor, FormatFlavor::Ddlog) {
-            k.to_lowercase()
-        } else {
-            k.to_uppercase()
-        };
+        // Always emit UPPER_CASE constant names regardless of target language.
+        // DDlog typically uses lower_snake case for variables, but our
+        // generated constants are exported functions so casing is flexible.
+        let name = k.to_uppercase();
         match v {
             Value::Integer(i) => code.push_str(&fill2(fmts.int_fmt, name, i)),
             Value::Float(f) => {

--- a/build_support/tests/constants.rs
+++ b/build_support/tests/constants.rs
@@ -1,6 +1,7 @@
 //! Tests for the `build_support` constants generator.
 //! Ensures generated code is syntactically valid and handles edge cases.
-use build_support::constants::{generate_code_from_constants, DL_FMTS, RUST_FMTS};
+use build_support::constants::{generate_code_from_constants, Formats, DL_FMTS, RUST_FMTS};
+use rstest::rstest;
 use test_utils::{assert_all_absent, assert_all_present, assert_valid_rust_syntax};
 
 #[test]
@@ -162,8 +163,12 @@ fn handles_arrays() {
     assert!(code.starts_with("// @generated"));
 }
 
-#[test]
-fn handles_case_conversion_and_naming() {
+/// Ensures that key names with various casing styles are converted to
+/// `UPPER_CASE` in the generated output.
+#[rstest]
+#[case(&RUST_FMTS)]
+#[case(&DL_FMTS)]
+fn handles_case_conversion_and_naming(#[case] fmts: &Formats) {
     let toml_str = r#"
         [naming]
         camelCase = "value1"
@@ -176,9 +181,20 @@ fn handles_case_conversion_and_naming() {
         with_special-chars_and123 = "value8"
     "#;
     let parsed: toml::Value = toml_str.parse().unwrap();
-    let code = generate_code_from_constants(&parsed, &RUST_FMTS);
+    let code = generate_code_from_constants(&parsed, fmts);
 
-    assert!(code.starts_with("// @generated"));
+    for name in [
+        "CAMELCASE",
+        "SNAKE_CASE",
+        "KEBAB-CASE",
+        "PASCALCASE",
+        "LOWERCASE",
+        "UPPERCASE",
+        "MIXED123NUMBERS",
+        "WITH_SPECIAL-CHARS_AND123",
+    ] {
+        assert!(code.contains(name), "Missing {name} in generated output");
+    }
 }
 
 #[test]
@@ -346,7 +362,7 @@ fn generates_ddlog_functions() {
     let toml_str = "value = 5";
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert!(code.contains("function value()"));
+    assert!(code.contains("function VALUE()"));
     assert!(code.contains("{ 5 }"));
 }
 
@@ -355,7 +371,7 @@ fn generates_ddlog_float_function() {
     let toml_str = "pi = 3.14";
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert!(code.contains("function pi()"));
+    assert!(code.contains("function PI()"));
     assert!(code.contains("{ 3.14 }"));
 }
 
@@ -364,7 +380,7 @@ fn generates_ddlog_string_function() {
     let toml_str = r#"greeting = "hello \"world\"""#;
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert!(code.contains("function greeting()"));
+    assert!(code.contains("function GREETING()"));
     assert!(code.contains("{ \"hello \\\"world\\\"\" }"));
 }
 
@@ -376,7 +392,7 @@ fn generates_ddlog_boolean_functions_absent() {
     "#;
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert_all_absent(&code, &["function flag_true()", "function flag_false()"]);
+    assert_all_absent(&code, &["function FLAG_TRUE()", "function FLAG_FALSE()"]);
 }
 
 #[test]
@@ -393,9 +409,9 @@ fn generates_ddlog_nested_functions() {
     assert_all_present(
         &code,
         &[
-            "function inner_int()",
+            "function INNER_INT()",
             "{ 10 }",
-            "function deeper_str()",
+            "function DEEPER_STR()",
             "{ \"deep\" }",
         ],
     );
@@ -413,11 +429,11 @@ fn generates_ddlog_edge_case_functions() {
     assert_all_present(
         &code,
         &[
-            "function empty_str()",
+            "function EMPTY_STR()",
             "{ \"\" }",
-            "function large_int()",
+            "function LARGE_INT()",
             "{ 9223372036854775807 }",
-            "function special()",
+            "function SPECIAL()",
             "line\\nwith\\tspecial❤",
         ],
     );

--- a/constants.toml
+++ b/constants.toml
@@ -1,10 +1,19 @@
 [physics]
-GRACE_DISTANCE = 0.1
-GROUND_FRICTION = 0.1
-AIR_FRICTION = 0.02
-TERMINAL_VELOCITY = 2.0
-GRAVITY_PULL = -1.0
-DELTA_TIME = 1.0
-DEFAULT_MASS = 70.0
-FEAR_RADIUS_MULTIPLIER = 2.0
-FEAR_THRESHOLD = 0.2
+# Distance buffer before an entity is considered falling (metres)
+grace_distance = 0.1
+# Maximum horizontal deceleration while on the ground (m/s per tick)
+ground_friction = 0.1
+# Maximum horizontal deceleration while airborne (m/s per tick)
+air_friction = 0.02
+# Maximum falling speed (m/s)
+terminal_velocity = 2.0
+# Constant downward acceleration applied each tick (m/s^2)
+gravity_pull = -1.0
+# Length of a single physics tick (seconds)
+delta_time = 1.0
+# Default mass for entities lacking an explicit value (kg)
+default_mass = 70.0
+# Multiplier for the fear radius based on actor fraidiness and baddie meanness
+fear_radius_multiplier = 2.0
+# Minimum fear level to trigger fleeing behavior
+fear_threshold = 0.2


### PR DESCRIPTION
## Summary
- use snake_case keys in `constants.toml`
- document units for each constant
- ensure codegen converts names to UPPER_CASE for Rust and DDlog
- add tests with rstest to verify case conversion

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: ddlog tests fail to run)*

------
https://chatgpt.com/codex/tasks/task_e_685fd27ac1f0832286c1772d97fedeb3

## Summary by Sourcery

Normalize physics constant naming and improve generation and validation processes

Enhancements:
- Switch physics constant keys in constants.toml from UPPER_CASE to snake_case with accompanying unit comments
- Update code generation to always emit constant names in UPPER_CASE for both Rust and DDlog targets

Documentation:
- Add inline unit annotations for each physics constant in constants.toml

Tests:
- Replace single test with a parameterized rstest to validate case conversion across Rust and DDlog formats
- Update DDlog-specific tests to expect UPPER_CASE function names