### PR TITLE
Implement Drop for DDlog handle

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,6 +48,8 @@ avoidance.
   to Cargo's `OUT_DIR` to keep the project root clean. The download client uses
   the system's root certificates to verify TLS connections.
 - A `DdlogHandle` resource is inserted during startup to manage transactions.
+- The handle automatically stops the DDlog program when removed or when the
+  application exits.
 - `DefaultPlugins` are loaded with `LogPlugin` disabled, so the custom logger
   from `logging.rs` controls output.
 - The grid-based visualization system from the original code remains and will be

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -387,3 +387,14 @@ impl DdlogHandle {
         }
     }
 }
+
+impl Drop for DdlogHandle {
+    fn drop(&mut self) {
+        #[cfg(feature = "ddlog")]
+        if let Some(prog) = self.prog.take() {
+            if let Err(e) = prog.stop() {
+                log::error!("failed to stop DDlog: {e}");
+            }
+        }
+    }
+}

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -50,6 +50,10 @@ pub mod api {
         ) -> Result<std::collections::BTreeMap<usize, Vec<(super::record::Record, isize)>>, String> {
             Ok(std::collections::BTreeMap::new())
         }
+
+        pub fn stop(self) -> Result<(), String> {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure `HDDlog` stops when `DdlogHandle` is dropped
- stub out `stop` in the generated crate for clippy builds
- document automatic shutdown of DDlog handle

## Testing
- `make fmt`
- `make nixie`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: thread panicked in ddlog)*

------
https://chatgpt.com/codex/tasks/task_e_685ff7e716d483229b608e1fd4b33bfc