### PR TITLE
Refactor ddlog_handle tests with rstest fixture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ assets/
 src/ddlog/constants.dl
 constants.rs
 generated/lille_ddlog/
+/targets

--- a/tests/ddlog_handle.rs
+++ b/tests/ddlog_handle.rs
@@ -7,21 +7,10 @@ use serial_test::serial;
 use std::sync::atomic::Ordering;
 
 #[fixture]
-fn reset_stop_calls() {
+fn handle_and_initial_count() -> (DdlogHandle, usize) {
     STOP_CALLS.store(0, Ordering::SeqCst);
-}
-
-#[fixture]
-fn ddlog_handle() -> DdlogHandle {
-    DdlogHandle::default()
-}
-
-#[fixture]
-fn handle_and_initial_count(
-    ddlog_handle: DdlogHandle,
-    _reset_stop_calls: (),
-) -> (DdlogHandle, usize) {
-    (ddlog_handle, STOP_CALLS.load(Ordering::SeqCst))
+    let handle = DdlogHandle::default();
+    (handle, STOP_CALLS.load(Ordering::SeqCst))
 }
 
 #[cfg(not(feature = "ddlog"))]

--- a/tests/ddlog_handle.rs
+++ b/tests/ddlog_handle.rs
@@ -3,28 +3,38 @@
 use differential_datalog::api::STOP_CALLS;
 use lille::DdlogHandle;
 use rstest::{fixture, rstest};
+use serial_test::serial;
 use std::sync::atomic::Ordering;
 
 #[fixture]
-fn handle_and_initial_count() -> (DdlogHandle, usize) {
-    (DdlogHandle::default(), STOP_CALLS.load(Ordering::SeqCst))
+fn ddlog_handle() -> DdlogHandle {
+    DdlogHandle::default()
+}
+
+#[fixture]
+fn initial_stop_calls() -> usize {
+    STOP_CALLS.store(0, Ordering::SeqCst);
+    0
 }
 
 #[cfg(not(feature = "ddlog"))]
 #[rstest]
+#[serial]
 fn dropping_handle_does_not_call_stop_without_feature(
-    handle_and_initial_count: (DdlogHandle, usize),
+    ddlog_handle: DdlogHandle,
+    initial_stop_calls: usize,
 ) {
-    let (handle, initial) = handle_and_initial_count;
-    assert_eq!(STOP_CALLS.load(Ordering::SeqCst), initial);
-    drop(handle);
-    assert_eq!(STOP_CALLS.load(Ordering::SeqCst), initial);
+    assert_eq!(initial_stop_calls, 0);
+    assert_eq!(STOP_CALLS.load(Ordering::SeqCst), 0);
+    drop(ddlog_handle);
+    assert_eq!(STOP_CALLS.load(Ordering::SeqCst), 0);
 }
 
 #[cfg(feature = "ddlog")]
 #[rstest]
-fn dropping_handle_stops_program(handle_and_initial_count: (DdlogHandle, usize)) {
-    let (handle, initial) = handle_and_initial_count;
-    drop(handle);
-    assert_eq!(STOP_CALLS.load(Ordering::SeqCst), initial + 1);
+#[serial]
+fn dropping_handle_stops_program(ddlog_handle: DdlogHandle, initial_stop_calls: usize) {
+    assert_eq!(initial_stop_calls, 0);
+    drop(ddlog_handle);
+    assert_eq!(STOP_CALLS.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
## Summary
- deduplicate ddlog handle tests using an rstest fixture

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: ddlog compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68600c4504948322bf8765b8fd38b063

## Summary by Sourcery

Refactor ddlog_handle tests to deduplicate setup using an rstest fixture

Enhancements:
- Introduce a `handle_and_initial_count` rstest fixture to supply a default `DdlogHandle` and its initial `STOP_CALLS` count

Tests:
- Convert `dropping_handle_does_not_call_stop_without_feature` and `dropping_handle_stops_program` tests to use the rstest fixture and replace `#[test]` with `#[rstest]`