### PR TITLE
Fix DDlog constant naming

### DIFF
--- a/build_support/src/constants.rs
+++ b/build_support/src/constants.rs
@@ -180,10 +180,12 @@ pub fn generate_code_from_constants(parsed: &Value, fmts: &Formats) -> String {
         code.push_str("import types\n\n");
     }
     let mut append = |k: &str, v: &Value| {
-        // Always emit UPPER_CASE constant names regardless of target language.
-        // DDlog typically uses lower_snake case for variables, but our
-        // generated constants are exported functions so casing is flexible.
-        let name = k.to_uppercase();
+        // Use UPPER_CASE names for Rust constants but keep the original key
+        // for DDlog so the functions match the TOML identifiers verbatim.
+        let name = match fmts.flavor {
+            FormatFlavor::Ddlog => k.to_string(),
+            FormatFlavor::Rust => k.to_uppercase(),
+        };
         match v {
             Value::Integer(i) => code.push_str(&fill2(fmts.int_fmt, name, i)),
             Value::Float(f) => {

--- a/build_support/tests/constants.rs
+++ b/build_support/tests/constants.rs
@@ -362,7 +362,7 @@ fn generates_ddlog_functions() {
     let toml_str = "value = 5";
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert!(code.contains("function VALUE()"));
+    assert!(code.contains("function value()"));
     assert!(code.contains("{ 5 }"));
 }
 
@@ -371,7 +371,7 @@ fn generates_ddlog_float_function() {
     let toml_str = "pi = 3.14";
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert!(code.contains("function PI()"));
+    assert!(code.contains("function pi()"));
     assert!(code.contains("{ 3.14 }"));
 }
 
@@ -380,7 +380,7 @@ fn generates_ddlog_string_function() {
     let toml_str = r#"greeting = "hello \"world\"""#;
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert!(code.contains("function GREETING()"));
+    assert!(code.contains("function greeting()"));
     assert!(code.contains("{ \"hello \\\"world\\\"\" }"));
 }
 
@@ -392,7 +392,7 @@ fn generates_ddlog_boolean_functions_absent() {
     "#;
     let parsed: toml::Value = toml_str.parse().unwrap();
     let code = generate_code_from_constants(&parsed, &DL_FMTS);
-    assert_all_absent(&code, &["function FLAG_TRUE()", "function FLAG_FALSE()"]);
+    assert_all_absent(&code, &["function flag_true()", "function flag_false()"]);
 }
 
 #[test]
@@ -409,9 +409,9 @@ fn generates_ddlog_nested_functions() {
     assert_all_present(
         &code,
         &[
-            "function INNER_INT()",
+            "function inner_int()",
             "{ 10 }",
-            "function DEEPER_STR()",
+            "function deeper_str()",
             "{ \"deep\" }",
         ],
     );
@@ -429,11 +429,11 @@ fn generates_ddlog_edge_case_functions() {
     assert_all_present(
         &code,
         &[
-            "function EMPTY_STR()",
+            "function empty_str()",
             "{ \"\" }",
-            "function LARGE_INT()",
+            "function large_int()",
             "{ 9223372036854775807 }",
-            "function SPECIAL()",
+            "function special()",
             "line\\nwith\\tspecial❤",
         ],
     );


### PR DESCRIPTION
## Summary
- keep original casing for DDlog constant names
- update tests to check lowercase names for DDlog

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: unresolved import `differential_datalog::api::STOP_CALLS`)*

------
https://chatgpt.com/codex/tasks/task_e_68601a16eb8c8322936788c95602bbe8

## Summary by Sourcery

Preserve original TOML key casing for DDlog constant functions and update tests to match the new behavior

Bug Fixes:
- Fix DDlog constant functions to use the original key casing instead of uppercasing

Tests:
- Update constant generation tests to expect original-case function names for DDlog constants