### PR TITLE
Expose STOP_CALLS counter for DdlogHandle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,5 @@ approx = "0.5"
 ordered-float = { workspace = true }
 serial_test = "3.2"
 differential_datalog = { path = "generated/lille_ddlog/differential_datalog" }
+mockall = "0.13.1"
+mockall_double = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,4 +48,3 @@ ordered-float = { workspace = true }
 serial_test = "3.2"
 differential_datalog = { path = "generated/lille_ddlog/differential_datalog" }
 mockall = "0.13.1"
-mockall_double = "0.3.1"

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -35,14 +35,14 @@ pub trait DdlogApi: Send + Sync {
 #[cfg(feature = "ddlog")]
 impl DdlogApi for HDDlog {
     fn transaction_start(&mut self) -> Result<(), String> {
-        <differential_datalog::api::HDDlog>::transaction_start(self)
+        <HDDlog as DDlogDynamic>::transaction_start(self)
     }
 
     fn apply_updates_dynamic(
         &mut self,
         updates: &mut dyn Iterator<Item = differential_datalog::record::UpdCmd>,
     ) -> Result<(), String> {
-        <differential_datalog::api::HDDlog>::apply_updates_dynamic(self, updates)
+        <HDDlog as DDlogDynamic>::apply_updates_dynamic(self, updates)
     }
 
     fn transaction_commit_dump_changes_dynamic(
@@ -51,11 +51,11 @@ impl DdlogApi for HDDlog {
         std::collections::BTreeMap<usize, Vec<(differential_datalog::record::Record, isize)>>,
         String,
     > {
-        <differential_datalog::api::HDDlog>::transaction_commit_dump_changes_dynamic(self)
+        <HDDlog as DDlogDynamic>::transaction_commit_dump_changes_dynamic(self)
     }
 
     fn stop(self: Box<Self>) -> Result<(), String> {
-        <differential_datalog::api::HDDlog>::stop(*self)
+        <HDDlog as DDlogDynamic>::stop(&*self)
     }
 }
 use std::sync::atomic::AtomicUsize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 // Re-export commonly used items
 pub use actor::Actor;
 pub use components::{DdlogId, Health, Target, UnitType};
-pub use ddlog_handle::STOP_CALLS;
 pub use ddlog_handle::{init_ddlog_system, DdlogHandle};
 pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};
 pub use entity::{BadGuy, Entity};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 // Re-export commonly used items
 pub use actor::Actor;
 pub use components::{DdlogId, Health, Target, UnitType};
-#[cfg(feature = "ddlog")]
 pub use ddlog_handle::STOP_CALLS;
 pub use ddlog_handle::{init_ddlog_system, DdlogHandle};
 pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -95,48 +95,48 @@ pub mod api {
     }
 
     impl super::program::DDlogDynamic for HDDlog {
-        fn transaction_start(&self) -> Result<(), String> {
+        fn transaction_start(&mut self) -> Result<(), String> {
             self.transaction_start()
         }
 
         fn transaction_commit_dump_changes_dynamic(
-            &self,
+            &mut self,
         ) -> Result<std::collections::BTreeMap<usize, Vec<(Record, isize)>>, String> {
             Ok(std::collections::BTreeMap::new())
         }
 
-        fn transaction_commit(&self) -> Result<(), String> {
+        fn transaction_commit(&mut self) -> Result<(), String> {
             Ok(())
         }
 
-        fn transaction_rollback(&self) -> Result<(), String> {
+        fn transaction_rollback(&mut self) -> Result<(), String> {
             Ok(())
         }
 
         fn apply_updates_dynamic(
-            &self,
+            &mut self,
             _upds: &mut dyn Iterator<Item = UpdCmd>,
         ) -> Result<(), String> {
             Ok(())
         }
 
-        fn clear_relation(&self, _table: usize) -> Result<(), String> {
+        fn clear_relation(&mut self, _table: usize) -> Result<(), String> {
             Ok(())
         }
 
         fn query_index_dynamic(
-            &self,
+            &mut self,
             _index: usize,
             _key: &Record,
         ) -> Result<Vec<Record>, String> {
             Ok(Vec::new())
         }
 
-        fn dump_index_dynamic(&self, _index: usize) -> Result<Vec<Record>, String> {
+        fn dump_index_dynamic(&mut self, _index: usize) -> Result<Vec<Record>, String> {
             Ok(Vec::new())
         }
 
-        fn stop(&self) -> Result<(), String> {
+        fn stop(&mut self) -> Result<(), String> {
             self.clone().stop()
         }
     }
@@ -232,20 +232,20 @@ pub mod program {
         fn dump_index(&self, index: usize) -> Result<BTreeSet<DDValue>, String>;
     }
     pub trait DDlogDynamic: DDlog {
-        fn transaction_start(&self) -> Result<(), String>;
+        fn transaction_start(&mut self) -> Result<(), String>;
         fn transaction_commit_dump_changes_dynamic(
-            &self,
+            &mut self,
         ) -> Result<std::collections::BTreeMap<usize, Vec<(Record, isize)>>, String>;
-        fn transaction_commit(&self) -> Result<(), String>;
-        fn transaction_rollback(&self) -> Result<(), String>;
+        fn transaction_commit(&mut self) -> Result<(), String>;
+        fn transaction_rollback(&mut self) -> Result<(), String>;
         fn apply_updates_dynamic(
-            &self,
+            &mut self,
             upds: &mut dyn Iterator<Item = UpdCmd>,
         ) -> Result<(), String>;
-        fn clear_relation(&self, table: usize) -> Result<(), String>;
-        fn query_index_dynamic(&self, index: usize, key: &Record) -> Result<Vec<Record>, String>;
-        fn dump_index_dynamic(&self, index: usize) -> Result<Vec<Record>, String>;
-        fn stop(&self) -> Result<(), String>;
+        fn clear_relation(&mut self, table: usize) -> Result<(), String>;
+        fn query_index_dynamic(&mut self, index: usize, key: &Record) -> Result<Vec<Record>, String>;
+        fn dump_index_dynamic(&mut self, index: usize) -> Result<Vec<Record>, String>;
+        fn stop(&mut self) -> Result<(), String>;
     }
 }
 

--- a/tests/ddlog_handle.rs
+++ b/tests/ddlog_handle.rs
@@ -3,7 +3,7 @@
 #[cfg(not(feature = "ddlog"))]
 #[test]
 fn dropping_handle_does_not_call_stop_without_feature() {
-    use lille::{DdlogHandle, STOP_CALLS};
+    use lille::ddlog_handle::{DdlogHandle, STOP_CALLS};
     use std::sync::atomic::Ordering;
 
     let handle = DdlogHandle::default();
@@ -13,13 +13,47 @@ fn dropping_handle_does_not_call_stop_without_feature() {
 }
 
 #[cfg(feature = "ddlog")]
+use lille::ddlog_handle::DdlogApi;
+#[cfg(feature = "ddlog")]
+use mockall::mock;
+
+#[cfg(feature = "ddlog")]
+mock! {
+    pub Api {}
+    impl DdlogApi for Api {
+        fn transaction_start(&mut self) -> Result<(), String>;
+        fn apply_updates_dynamic(
+            &mut self,
+            updates: &mut dyn Iterator<Item = differential_datalog::record::UpdCmd>,
+        ) -> Result<(), String>;
+        fn transaction_commit_dump_changes_dynamic(
+            &mut self,
+        ) -> Result<
+            std::collections::BTreeMap<usize, Vec<(differential_datalog::record::Record, isize)>>,
+            String,
+        >;
+        fn stop(self: Box<Self>) -> Result<(), String>;
+    }
+}
+
+#[cfg(feature = "ddlog")]
 #[test]
 fn dropping_handle_stops_program() {
-    use lille::STOP_CALLS;
+    use hashbrown::HashMap;
+    use lille::ddlog_handle::{DdlogHandle, STOP_CALLS};
     use std::sync::atomic::Ordering;
 
     let initial_count = STOP_CALLS.load(Ordering::SeqCst);
-    let handle = DdlogHandle::default();
+    let mut mock_prog = MockApi::new();
+    mock_prog.expect_stop().times(1).returning(|| Ok(()));
+
+    let handle = DdlogHandle {
+        prog: Some(Box::new(mock_prog)),
+        blocks: Vec::new(),
+        slopes: HashMap::new(),
+        entities: HashMap::new(),
+        deltas: Vec::new(),
+    };
     drop(handle);
     assert_eq!(STOP_CALLS.load(Ordering::SeqCst), initial_count + 1);
 }

--- a/tests/ddlog_handle.rs
+++ b/tests/ddlog_handle.rs
@@ -3,8 +3,7 @@
 #[cfg(not(feature = "ddlog"))]
 #[test]
 fn dropping_handle_does_not_call_stop_without_feature() {
-    use differential_datalog::api::STOP_CALLS;
-    use lille::DdlogHandle;
+    use lille::{DdlogHandle, STOP_CALLS};
     use std::sync::atomic::Ordering;
 
     let handle = DdlogHandle::default();
@@ -16,7 +15,7 @@ fn dropping_handle_does_not_call_stop_without_feature() {
 #[cfg(feature = "ddlog")]
 #[test]
 fn dropping_handle_stops_program() {
-    use lille::{DdlogHandle, STOP_CALLS};
+    use lille::STOP_CALLS;
     use std::sync::atomic::Ordering;
 
     let initial_count = STOP_CALLS.load(Ordering::SeqCst);

--- a/tests/ddlog_handle.rs
+++ b/tests/ddlog_handle.rs
@@ -39,7 +39,6 @@ mock! {
 #[cfg(feature = "ddlog")]
 #[test]
 fn dropping_handle_stops_program() {
-    use hashbrown::HashMap;
     use lille::ddlog_handle::{DdlogHandle, STOP_CALLS};
     use std::sync::atomic::Ordering;
 
@@ -47,13 +46,7 @@ fn dropping_handle_stops_program() {
     let mut mock_prog = MockApi::new();
     mock_prog.expect_stop().times(1).returning(|| Ok(()));
 
-    let handle = DdlogHandle {
-        prog: Some(Box::new(mock_prog)),
-        blocks: Vec::new(),
-        slopes: HashMap::new(),
-        entities: HashMap::new(),
-        deltas: Vec::new(),
-    };
+    let handle = DdlogHandle::with_program(Box::new(mock_prog));
     drop(handle);
     assert_eq!(STOP_CALLS.load(Ordering::SeqCst), initial_count + 1);
 }


### PR DESCRIPTION
## Summary
- track successful HDDlog::stop calls in DdlogHandle
- re-export the counter from the `lille` crate
- update tests to read `STOP_CALLS` from `lille`

## Testing
- `make lint`
- `make test` *(fails: unused import)*
- `make test-ddlog` *(fails: panic in ddlog runtime)*

------
https://chatgpt.com/codex/tasks/task_e_686024ead7348322937a0b603531fd08

## Summary by Sourcery

Expose a global STOP_CALLS counter to track and expose successful HDDlog::stop calls in DdlogHandle, update drop logic to increment it, and revise tests to use the re-exported counter

New Features:
- Introduce STOP_CALLS AtomicUsize counter for tracking successful HDDlog::stop calls
- Re-export STOP_CALLS from the crate root for external access

Enhancements:
- Increment STOP_CALLS in DdlogHandle’s Drop implementation upon successful stop

Tests:
- Update tests to import STOP_CALLS from the lille crate and verify its behavior