### PR TITLE
Fail on DDlog errors when running build-support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,10 @@ fmt-check: ddlog-stubs
 $(GENERATED_SRC):
 	mkdir -p '$(GENERATED_SRC)'
 
+BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR ?= true
+
 build-support-run: ddlog-stubs
-        BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR=true ./scripts/build_support_runner.sh
+       BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR=$(BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR) ./scripts/build_support_runner.sh
 
 # Copy prebuilt DDlog stubs into the generated directory
 ddlog-stubs: $(GENERATED_SRC)

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(GENERATED_SRC):
 	mkdir -p '$(GENERATED_SRC)'
 
 build-support-run: ddlog-stubs
-	./scripts/build_support_runner.sh
+        BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR=true ./scripts/build_support_runner.sh
 
 # Copy prebuilt DDlog stubs into the generated directory
 ddlog-stubs: $(GENERATED_SRC)

--- a/README.md
+++ b/README.md
@@ -83,9 +83,14 @@ the font, and compiling the DDlog ruleset when available. The helper does not
 output "No such file or directory" errors when locating `constants.toml`, though
 compilation may still fail if the DDlog compiler is missing.
 
-The `build-support-run` Makefile target exports
-`BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR=true` so that any DDlog build errors abort
-the run. Unset this variable to continue with the fallback stub crate instead.
+The `build-support-run` Makefile target sets
+`BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR=true` by default so that any DDlog build
+errors abort the run. Override the variable with an empty value to continue with
+the fallback stub crate instead, e.g.:
+
+```bash
+BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR= make build-support-run
+```
 
 ## DDlog stubs
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ the font, and compiling the DDlog ruleset when available. The helper does not
 output "No such file or directory" errors when locating `constants.toml`, though
 compilation may still fail if the DDlog compiler is missing.
 
+The `build-support-run` Makefile target exports
+`BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR=true` so that any DDlog build errors abort
+the run. Unset this variable to continue with the fallback stub crate instead.
+
 ## DDlog stubs
 
 The `generated/lille_ddlog` directory is populated with placeholder code so the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 // Re-export commonly used items
 pub use actor::Actor;
 pub use components::{DdlogId, Health, Target, UnitType};
+#[cfg(feature = "ddlog")]
+pub use ddlog_handle::STOP_CALLS;
 pub use ddlog_handle::{init_ddlog_system, DdlogHandle};
 pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};
 pub use entity::{BadGuy, Entity};

--- a/tests/ddlog_handle.rs
+++ b/tests/ddlog_handle.rs
@@ -16,11 +16,11 @@ fn dropping_handle_does_not_call_stop_without_feature() {
 #[cfg(feature = "ddlog")]
 #[test]
 fn dropping_handle_stops_program() {
-    use differential_datalog::api::STOP_CALLS;
+    use lille::{DdlogHandle, STOP_CALLS};
     use std::sync::atomic::Ordering;
 
     let initial_count = STOP_CALLS.load(Ordering::SeqCst);
-    let handle = lille::DdlogHandle::default();
+    let handle = DdlogHandle::default();
     drop(handle);
     assert_eq!(STOP_CALLS.load(Ordering::SeqCst), initial_count + 1);
 }


### PR DESCRIPTION
## Summary
- make `build-support-run` fail when DDlog compilation fails
- document the new behaviour in the readme

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: ddlog stub panics)*

------
https://chatgpt.com/codex/tasks/task_e_686012bc3a148322b50c4817da3f997d

## Summary by Sourcery

Enable optional failure on DDlog build errors by exporting BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR in the build-support-run target and document the behavior in the README.

Enhancements:
- Make the build-support-run command abort on DDlog compilation errors.

Build:
- Set BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR=true in the build-support-run Makefile target.

Documentation:
- Document the BUILD_SUPPORT_FAIL_ON_DDLOG_ERROR environment variable in the README.