### PR TITLE
Change DDlog constant naming

### DIFF
--- a/build_support/src/constants.rs
+++ b/build_support/src/constants.rs
@@ -180,10 +180,12 @@ pub fn generate_code_from_constants(parsed: &Value, fmts: &Formats) -> String {
         code.push_str("import types\n\n");
     }
     let mut append = |k: &str, v: &Value| {
-        // Always emit UPPER_CASE constant names regardless of target language.
-        // DDlog typically uses lower_snake case for variables, but our
-        // generated constants are exported functions so casing is flexible.
-        let name = k.to_uppercase();
+        // Uppercase constant names for Rust but keep the original key for other
+        // formats. DDlog function names can retain their original casing.
+        let name = match fmts.flavor {
+            FormatFlavor::Rust => k.to_uppercase(),
+            _ => k.to_string(),
+        };
         match v {
             Value::Integer(i) => code.push_str(&fill2(fmts.int_fmt, name, i)),
             Value::Float(f) => {


### PR DESCRIPTION
## Summary
- keep original names when generating DDlog constants
- adjust tests for new DDlog naming behaviour

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: unresolved import `STOP_CALLS`)*

------
https://chatgpt.com/codex/tasks/task_e_686019e0ffb08322a52fa2b2c5225286

## Summary by Sourcery

Preserve original constant key names for non-Rust formats while retaining uppercase conversion for Rust output, and update tests to match the new naming behavior.

Enhancements:
- Retain original key casing when generating constants for DDlog and other non-Rust formats
- Continue uppercasing constant names only for Rust output in the code generator

Tests:
- Adjust constant-naming tests to validate preserved casing for non-Rust output formats