### PR TITLE
Improve stop stub

### DIFF
--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -137,7 +137,8 @@ pub mod api {
         }
 
         fn stop(&mut self) -> Result<(), String> {
-            self.clone().stop()
+            STOP_CALLS.fetch_add(1, Ordering::SeqCst);
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
## Summary
- fix DDlogDynamic `stop` stub to increment counter directly

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: slice::get_unchecked requires that the index is within the slice)*

------
https://chatgpt.com/codex/tasks/task_e_686068e488648322a2d8dee2d6701a5b

## Summary by Sourcery

Bug Fixes:
- Prevent infinite recursion in stop stub by replacing recursive call with a counter increment.