### PR TITLE
Add sorting for DDlog commands

### DIFF
--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -158,7 +158,9 @@ pub mod record {
     pub struct DDValue(serde_json::Value);
 
     #[derive(Clone, Debug)]
-    pub struct Record;
+    pub struct Record {
+        pub entity: i64,
+    }
 
     #[derive(Clone, Debug)]
     pub enum RelIdentifier {

--- a/tests/ddlog_sort.rs
+++ b/tests/ddlog_sort.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "ddlog")]
+use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
+#[cfg(feature = "ddlog")]
+use lille::ddlog_handle::{self, RelIdentifierExt};
+
+#[cfg(feature = "ddlog")]
+#[test]
+fn commands_sorted_by_rel_and_entity() {
+    let mut cmds = vec![
+        UpdCmd::Insert(RelIdentifier::RelId(2), Record { entity: 5 }),
+        UpdCmd::Insert(RelIdentifier::RelId(1), Record { entity: 10 }),
+        UpdCmd::Insert(RelIdentifier::RelId(1), Record { entity: 3 }),
+    ];
+
+    ddlog_handle::sort_cmds(cmds.as_mut_slice());
+    let ids: Vec<(usize, i64)> = cmds
+        .iter()
+        .map(|c| match c {
+            UpdCmd::Insert(r, rec) | UpdCmd::Delete(r, rec) => (r.as_id(), rec.entity),
+        })
+        .collect();
+    assert_eq!(ids, vec![(1, 3), (1, 10), (2, 5)]);
+}


### PR DESCRIPTION
## Summary
- sort DDlog update commands to ensure deterministic order
- expose helper utilities for sorting and relation IDs
- expand stub record structure to include entity id
- test the command sorting logic

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test` *(failed: build cancelled)*
- `make test-ddlog` *(failed: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68606d204fac83229fc21fca6e9defb0

## Summary by Sourcery

Add deterministic sorting for DDlog update commands and supporting utilities

Enhancements:
- Introduce RelIdentifierExt trait and extract_entity function to retrieve relation and entity IDs from DDlog records
- Implement sort_cmds to order UpdCmd entries by relation ID and entity
- Expand stub Record struct to include an entity field for testing

Tests:
- Add a unit test verifying that DDlog update commands are sorted correctly by relation ID and entity