### PR TITLE
Add sorting for DDlog commands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -117,6 +117,27 @@ sequenceDiagram
     deactivate DdlogHandle
 ```
 
+### Data relationships
+
+The following entity–relationship diagram summarises how records and update
+commands interact in the DDlog interface.
+
+```mermaid
+erDiagram
+    RECORD {
+        int entity
+    }
+    RELIDENTIFIER {
+        int id
+    }
+    UPDCMD {
+        Insert
+        Delete
+    }
+    UPDCMD ||--o{ RECORD : contains
+    UPDCMD ||--o{ RELIDENTIFIER : references
+```
+
 ## Future Considerations
 
 The architecture supports several potential extensions:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,7 +119,7 @@ sequenceDiagram
 
 ### Data relationships
 
-The following entity–relationship diagram summarises how records and update
+The following entity–relationship diagram summarizes how records and update
 commands interact in the DDlog interface.
 
 ```mermaid

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -77,13 +77,65 @@ pub trait RelIdentifierExt {
 
 #[cfg(feature = "ddlog")]
 impl RelIdentifierExt for differential_datalog::record::RelIdentifier {
-    #[allow(unreachable_patterns)]
+    #[expect(
+        unreachable_patterns,
+        reason = "Future-proof against additional RelIdentifier variants"
+    )]
+    #[allow(unfulfilled_lint_expectations)]
     fn as_id(&self) -> usize {
         match *self {
             differential_datalog::record::RelIdentifier::RelId(id) => id,
             _ => usize::MAX,
         }
     }
+}
+
+/// Trait for typed DDlog records that expose an `entity` field.
+#[cfg(feature = "ddlog")]
+trait HasEntity {
+    fn entity(&self) -> i64;
+}
+
+#[cfg(feature = "ddlog")]
+impl HasEntity for lille_ddlog::typedefs::entity_state::Position {
+    fn entity(&self) -> i64 {
+        self.entity
+    }
+}
+
+#[cfg(feature = "ddlog")]
+impl HasEntity for lille_ddlog::typedefs::entity_state::Target {
+    fn entity(&self) -> i64 {
+        self.entity
+    }
+}
+
+#[cfg(feature = "ddlog")]
+impl HasEntity for lille_ddlog::typedefs::entity_state::Fraidiness {
+    fn entity(&self) -> i64 {
+        self.entity
+    }
+}
+
+#[cfg(feature = "ddlog")]
+impl HasEntity for lille_ddlog::typedefs::entity_state::Meanness {
+    fn entity(&self) -> i64 {
+        self.entity
+    }
+}
+
+/// Helper to extract the entity from a record for a given relation.
+#[cfg(feature = "ddlog")]
+fn extract_entity_for_relation<
+    T: differential_datalog::ddval::DDValConvert + HasEntity + 'static,
+>(
+    relation: lille_ddlog::Relations,
+    rec: &differential_datalog::record::Record,
+) -> Option<i64> {
+    lille_ddlog::relval_from_record(relation, rec)
+        .ok()
+        .and_then(T::try_from_ddvalue)
+        .map(|val| val.entity())
 }
 
 /// Extracts the `entity` field from a DDlog record.
@@ -96,42 +148,24 @@ pub fn extract_entity(
     rel: &differential_datalog::record::RelIdentifier,
     rec: &differential_datalog::record::Record,
 ) -> i64 {
-    use differential_datalog::ddval::DDValConvert;
-    use lille_ddlog::{relval_from_record, typedefs::entity_state as es, Relations};
+    use lille_ddlog::{typedefs::entity_state as es, Relations};
 
-    let rel_id = rel.as_id();
-    #[allow(unreachable_patterns)]
-    match rel_id {
+    match rel.as_id() {
         id if id == Relations::entity_state_Position as usize => {
-            relval_from_record(Relations::entity_state_Position, rec)
-                .ok()
-                .and_then(<es::Position as DDValConvert>::try_from_ddvalue)
-                .map(|p| p.entity)
-                .unwrap_or(i64::MAX)
+            extract_entity_for_relation::<es::Position>(Relations::entity_state_Position, rec)
         }
         id if id == Relations::entity_state_Target as usize => {
-            relval_from_record(Relations::entity_state_Target, rec)
-                .ok()
-                .and_then(<es::Target as DDValConvert>::try_from_ddvalue)
-                .map(|t| t.entity)
-                .unwrap_or(i64::MAX)
+            extract_entity_for_relation::<es::Target>(Relations::entity_state_Target, rec)
         }
         id if id == Relations::entity_state_Fraidiness as usize => {
-            relval_from_record(Relations::entity_state_Fraidiness, rec)
-                .ok()
-                .and_then(<es::Fraidiness as DDValConvert>::try_from_ddvalue)
-                .map(|f| f.entity)
-                .unwrap_or(i64::MAX)
+            extract_entity_for_relation::<es::Fraidiness>(Relations::entity_state_Fraidiness, rec)
         }
         id if id == Relations::entity_state_Meanness as usize => {
-            relval_from_record(Relations::entity_state_Meanness, rec)
-                .ok()
-                .and_then(<es::Meanness as DDValConvert>::try_from_ddvalue)
-                .map(|m| m.entity)
-                .unwrap_or(i64::MAX)
+            extract_entity_for_relation::<es::Meanness>(Relations::entity_state_Meanness, rec)
         }
-        _ => i64::MAX,
+        _ => None,
     }
+    .unwrap_or(i64::MAX)
 }
 
 /// Sorts DDlog update commands by relation and entity identifiers.
@@ -140,7 +174,11 @@ pub fn extract_entity(
 #[cfg(feature = "ddlog")]
 pub fn sort_cmds(cmds: &mut [differential_datalog::record::UpdCmd]) {
     use differential_datalog::record::UpdCmd;
-    #[allow(unreachable_patterns)]
+    #[expect(
+        unreachable_patterns,
+        reason = "Support potential future UpdCmd variants"
+    )]
+    #[allow(unfulfilled_lint_expectations)]
     cmds.sort_by_key(|cmd| match cmd {
         UpdCmd::Insert(rel, rec) | UpdCmd::Delete(rel, rec) => {
             (rel.as_id(), extract_entity(rel, rec))

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -90,9 +90,12 @@ impl RelIdentifierExt for differential_datalog::record::RelIdentifier {
     }
 }
 
-/// Trait for typed DDlog records that expose an `entity` field.
+/// Trait for typed DDlog records that expose an `entity` identifier.
+///
+/// Implementers must return this identifier via [`HasEntity::entity`].
 #[cfg(feature = "ddlog")]
 trait HasEntity {
+    /// Returns the entity ID associated with the record.
     fn entity(&self) -> i64;
 }
 

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -158,7 +158,9 @@ pub mod record {
     pub struct DDValue(serde_json::Value);
 
     #[derive(Clone, Debug)]
-    pub struct Record;
+    pub struct Record {
+        pub entity: i64,
+    }
 
     #[derive(Clone, Debug)]
     pub enum RelIdentifier {

--- a/stubs/lille_ddlog/differential_datalog/lib.rs
+++ b/stubs/lille_ddlog/differential_datalog/lib.rs
@@ -158,9 +158,7 @@ pub mod record {
     pub struct DDValue(serde_json::Value);
 
     #[derive(Clone, Debug)]
-    pub struct Record {
-        pub entity: i64,
-    }
+    pub struct Record;
 
     #[derive(Clone, Debug)]
     pub enum RelIdentifier {

--- a/tests/ddlog_sort.rs
+++ b/tests/ddlog_sort.rs
@@ -1,23 +1,66 @@
 #[cfg(feature = "ddlog")]
-use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
+use differential_datalog::record::{IntoRecord, RelIdentifier, UpdCmd};
 #[cfg(feature = "ddlog")]
-use lille::ddlog_handle::{self, RelIdentifierExt};
+use lille::ddlog_handle::{self, extract_entity, RelIdentifierExt};
+#[cfg(feature = "ddlog")]
+use lille_ddlog::{typedefs::entity_state as es, Relations};
+#[cfg(feature = "ddlog")]
+use ordered_float::OrderedFloat;
 
 #[cfg(feature = "ddlog")]
 #[test]
 fn commands_sorted_by_rel_and_entity() {
     let mut cmds = vec![
-        UpdCmd::Insert(RelIdentifier::RelId(2), Record { entity: 5 }),
-        UpdCmd::Insert(RelIdentifier::RelId(1), Record { entity: 10 }),
-        UpdCmd::Insert(RelIdentifier::RelId(1), Record { entity: 3 }),
+        UpdCmd::Insert(
+            RelIdentifier::RelId(Relations::entity_state_Target as usize),
+            es::Target {
+                entity: 5,
+                tx: OrderedFloat(0.0),
+                ty: OrderedFloat(0.0),
+            }
+            .into_record(),
+        ),
+        UpdCmd::Insert(
+            RelIdentifier::RelId(Relations::entity_state_Position as usize),
+            es::Position {
+                entity: 10,
+                x: OrderedFloat(0.0),
+                y: OrderedFloat(0.0),
+                z: OrderedFloat(0.0),
+            }
+            .into_record(),
+        ),
+        UpdCmd::Insert(
+            RelIdentifier::RelId(Relations::entity_state_Position as usize),
+            es::Position {
+                entity: 3,
+                x: OrderedFloat(0.0),
+                y: OrderedFloat(0.0),
+                z: OrderedFloat(0.0),
+            }
+            .into_record(),
+        ),
     ];
 
     ddlog_handle::sort_cmds(cmds.as_mut_slice());
     let ids: Vec<(usize, i64)> = cmds
         .iter()
-        .map(|c| match c {
-            UpdCmd::Insert(r, rec) | UpdCmd::Delete(r, rec) => (r.as_id(), rec.entity),
+        .map(|c| {
+            #[allow(unreachable_patterns)]
+            match c {
+                UpdCmd::Insert(r, rec) | UpdCmd::Delete(r, rec) => {
+                    (r.as_id(), extract_entity(r, rec))
+                }
+                _ => (usize::MAX, i64::MAX),
+            }
         })
         .collect();
-    assert_eq!(ids, vec![(1, 3), (1, 10), (2, 5)]);
+    assert_eq!(
+        ids,
+        vec![
+            (Relations::entity_state_Position as usize, 3),
+            (Relations::entity_state_Position as usize, 10),
+            (Relations::entity_state_Target as usize, 5),
+        ]
+    );
 }

--- a/tests/ddlog_sort.rs
+++ b/tests/ddlog_sort.rs
@@ -46,7 +46,11 @@ fn commands_sorted_by_rel_and_entity() {
     let ids: Vec<(usize, i64)> = cmds
         .iter()
         .map(|c| {
-            #[allow(unreachable_patterns)]
+            #[expect(
+                unreachable_patterns,
+                reason = "Support potential future UpdCmd variants"
+            )]
+            #[allow(unfulfilled_lint_expectations)]
             match c {
                 UpdCmd::Insert(r, rec) | UpdCmd::Delete(r, rec) => {
                     (r.as_id(), extract_entity(r, rec))

--- a/tests/ddlog_sort.rs
+++ b/tests/ddlog_sort.rs
@@ -1,0 +1,23 @@
+#[cfg(feature = "ddlog")]
+use differential_datalog::record::{Record, RelIdentifier, UpdCmd};
+#[cfg(feature = "ddlog")]
+use lille::ddlog_handle::{self, RelIdentifierExt};
+
+#[cfg(feature = "ddlog")]
+#[test]
+fn commands_sorted_by_rel_and_entity() {
+    let mut cmds = vec![
+        UpdCmd::Insert(RelIdentifier::RelId(2), Record { entity: 5 }),
+        UpdCmd::Insert(RelIdentifier::RelId(1), Record { entity: 10 }),
+        UpdCmd::Insert(RelIdentifier::RelId(1), Record { entity: 3 }),
+    ];
+
+    ddlog_handle::sort_cmds(cmds.as_mut_slice());
+    let ids: Vec<(usize, i64)> = cmds
+        .iter()
+        .map(|c| match c {
+            UpdCmd::Insert(r, rec) | UpdCmd::Delete(r, rec) => (r.as_id(), rec.entity),
+        })
+        .collect();
+    assert_eq!(ids, vec![(1, 3), (1, 10), (2, 5)]);
+}


### PR DESCRIPTION
## Summary
- sort DDlog update commands to ensure deterministic order
- expose helper utilities for sorting and relation IDs
- expand stub record structure to include entity id
- test the command sorting logic

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test` *(failed: build cancelled)*
- `make test-ddlog` *(failed: build cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68606d204fac83229fc21fca6e9defb0

## Summary by Sourcery

Ensure deterministic ordering of DDlog update commands by introducing helper utilities, updating the stub record structure, and adding tests and documentation.

New Features:
- Add `sort_cmds` function to deterministically sort DDlog update commands by relation and entity IDs
- Introduce `RelIdentifierExt` trait to expose relation identifiers as `usize`

Enhancements:
- Expand stub `Record` structure to include an `entity` field

Documentation:
- Add an entity–relationship diagram to the DDlog interface documentation

Tests:
- Add a unit test to verify sorting logic for DDlog commands