### PR TITLE
Ensure UpdCmd sorting is exhaustive

### DIFF
--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -177,16 +177,10 @@ pub fn extract_entity(
 #[cfg(feature = "ddlog")]
 pub fn sort_cmds(cmds: &mut [differential_datalog::record::UpdCmd]) {
     use differential_datalog::record::UpdCmd;
-    #[expect(
-        unreachable_patterns,
-        reason = "Support potential future UpdCmd variants"
-    )]
-    #[allow(unfulfilled_lint_expectations)]
     cmds.sort_by_key(|cmd| match cmd {
         UpdCmd::Insert(rel, rec) | UpdCmd::Delete(rel, rec) => {
             (rel.as_id(), extract_entity(rel, rec))
         }
-        _ => (usize::MAX, i64::MAX),
     });
 }
 


### PR DESCRIPTION
## Summary
- prevent future UpdCmd variants from silently sorting

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(failed: killed)*

------
https://chatgpt.com/codex/tasks/task_e_686176c0d1908322add4ae2b75eda9b7