### PR TITLE
Sort DDlog commands by operation type

### DIFF
--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -177,12 +177,42 @@ pub fn extract_entity(
 #[cfg(feature = "ddlog")]
 pub fn sort_cmds(cmds: &mut [differential_datalog::record::UpdCmd]) {
     use differential_datalog::record::UpdCmd;
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    #[repr(u8)]
+    enum CmdPriority {
+        Insert,
+        InsertOrUpdate,
+        Delete,
+        DeleteKey,
+        Modify,
+    }
+
     cmds.sort_by_key(|cmd| match cmd {
-        UpdCmd::Insert(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 0),
-        UpdCmd::InsertOrUpdate(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 1),
-        UpdCmd::Delete(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 2),
-        UpdCmd::DeleteKey(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 3),
-        UpdCmd::Modify(rel, _, new) => (rel.as_id(), extract_entity(rel, new), 4),
+        UpdCmd::Insert(rel, rec) => (
+            rel.as_id(),
+            extract_entity(rel, rec),
+            CmdPriority::Insert as u8,
+        ),
+        UpdCmd::InsertOrUpdate(rel, rec) => (
+            rel.as_id(),
+            extract_entity(rel, rec),
+            CmdPriority::InsertOrUpdate as u8,
+        ),
+        UpdCmd::Delete(rel, rec) => (
+            rel.as_id(),
+            extract_entity(rel, rec),
+            CmdPriority::Delete as u8,
+        ),
+        UpdCmd::DeleteKey(rel, rec) => (
+            rel.as_id(),
+            extract_entity(rel, rec),
+            CmdPriority::DeleteKey as u8,
+        ),
+        UpdCmd::Modify(rel, _, new) => (
+            rel.as_id(),
+            extract_entity(rel, new),
+            CmdPriority::Modify as u8,
+        ),
     });
 }
 

--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -178,11 +178,11 @@ pub fn extract_entity(
 pub fn sort_cmds(cmds: &mut [differential_datalog::record::UpdCmd]) {
     use differential_datalog::record::UpdCmd;
     cmds.sort_by_key(|cmd| match cmd {
-        UpdCmd::Insert(rel, rec)
-        | UpdCmd::InsertOrUpdate(rel, rec)
-        | UpdCmd::Delete(rel, rec)
-        | UpdCmd::DeleteKey(rel, rec) => (rel.as_id(), extract_entity(rel, rec)),
-        UpdCmd::Modify(rel, _, new) => (rel.as_id(), extract_entity(rel, new)),
+        UpdCmd::Insert(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 0),
+        UpdCmd::InsertOrUpdate(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 1),
+        UpdCmd::Delete(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 2),
+        UpdCmd::DeleteKey(rel, rec) => (rel.as_id(), extract_entity(rel, rec), 3),
+        UpdCmd::Modify(rel, _, new) => (rel.as_id(), extract_entity(rel, new), 4),
     });
 }
 

--- a/tests/ddlog_sort.rs
+++ b/tests/ddlog_sort.rs
@@ -221,6 +221,54 @@ fn commands_sorted_by_rel_and_entity() {
     ],
     vec!["insert", "delete", "insert", "insert", "delete"],
 )]
+#[case(
+    "modify_ordering",
+    vec![
+        UpdCmd::Modify(
+            RelIdentifier::RelId(Relations::entity_state_Position as usize),
+            es::Position {
+                entity: 1,
+                x: OrderedFloat(0.0),
+                y: OrderedFloat(0.0),
+                z: OrderedFloat(0.0),
+            }
+            .into_record(),
+            es::Position {
+                entity: 1,
+                x: OrderedFloat(1.0),
+                y: OrderedFloat(1.0),
+                z: OrderedFloat(1.0),
+            }
+            .into_record(),
+        ),
+        UpdCmd::Insert(
+            RelIdentifier::RelId(Relations::entity_state_Position as usize),
+            es::Position {
+                entity: 1,
+                x: OrderedFloat(0.0),
+                y: OrderedFloat(0.0),
+                z: OrderedFloat(0.0),
+            }
+            .into_record(),
+        ),
+        UpdCmd::Delete(
+            RelIdentifier::RelId(Relations::entity_state_Position as usize),
+            es::Position {
+                entity: 1,
+                x: OrderedFloat(0.0),
+                y: OrderedFloat(0.0),
+                z: OrderedFloat(0.0),
+            }
+            .into_record(),
+        ),
+    ],
+    vec![
+        (Relations::entity_state_Position as usize, 1),
+        (Relations::entity_state_Position as usize, 1),
+        (Relations::entity_state_Position as usize, 1),
+    ],
+    vec!["insert", "delete", "modify"],
+)]
 fn test_sorting_scenarios(
     #[case] _name: &str,
     #[case] mut cmds: Vec<UpdCmd>,

--- a/tests/ddlog_sort.rs
+++ b/tests/ddlog_sort.rs
@@ -158,7 +158,7 @@ fn commands_sorted_by_rel_and_entity() {
         (Relations::entity_state_Target as usize, 5),
         (Relations::entity_state_Target as usize, 5),
     ],
-    vec!["delete", "insert", "insert", "delete"],
+    vec!["insert", "delete", "insert", "delete"],
 )]
 #[case(
     "mixed_operations",


### PR DESCRIPTION
## Summary
- ensure `sort_cmds` also sorts by update kind
- adjust tests for deterministic Insert/Delete ordering

## Testing
- `make test`
- `make test-ddlog` *(fails: process abort signal)*

------
https://chatgpt.com/codex/tasks/task_e_6861898f271c8322b97f8199663df32b

## Summary by Sourcery

Enforce deterministic ordering of DDlog commands by including operation type in the sort key and update tests to reflect the new ordering

Enhancements:
- Sort DDlog commands by operation type as part of the sort key for deterministic ordering

Tests:
- Adjust DDlog command sorting tests to expect the new insert/delete ordering