### PR TITLE
Fix DDlog command ordering bug

### DIFF
--- a/src/ddlog_handle.rs
+++ b/src/ddlog_handle.rs
@@ -180,11 +180,11 @@ pub fn sort_cmds(cmds: &mut [differential_datalog::record::UpdCmd]) {
     #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     #[repr(u8)]
     enum CmdPriority {
+        DeleteKey,
+        Delete,
+        Modify,
         Insert,
         InsertOrUpdate,
-        Delete,
-        DeleteKey,
-        Modify,
     }
 
     cmds.sort_by_key(|cmd| match cmd {


### PR DESCRIPTION
## Summary
- ensure delete commands are prioritized before inserts

## Testing
- `make lint`
- `make test`
- `make test-ddlog` *(fails: unsafe precondition in differential-dataflow)*

------
https://chatgpt.com/codex/tasks/task_e_6861cc26916c832292d588700b2e715d