### PR TITLE
Handle invalid font manifest dir

### DIFF
--- a/build_support/src/font.rs
+++ b/build_support/src/font.rs
@@ -113,7 +113,10 @@ pub fn download_font_with(
 ) -> Result<PathBuf> {
     let manifest_dir = manifest_dir.as_ref();
     let assets_dir = manifest_dir.join("assets");
-    fs::create_dir_all(&assets_dir)?;
+    if let Err(e) = fs::create_dir_all(&assets_dir) {
+        println!("cargo:warning=Failed to create assets directory: {e}");
+        return Ok(fallback_font_path());
+    }
     let font_path = assets_dir.join("FiraSans-Regular.ttf");
 
     if font_path.exists() {


### PR DESCRIPTION
## Summary
- treat errors creating the assets directory as recoverable

## Testing
- `make fmt`
- `make lint`
- `make test`
- `cargo test -p build_support --lib`
- `make test-ddlog` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_686c458c4ba88322ae556f5a4d1ef42a