### PR TITLE
Implement initial dbsp_circuit skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 color-eyre = "0.6"
 ordered-float = { workspace = true }
+dbsp = "0.98"
 
 [build-dependencies]
 build_support = { path = "build_support" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 color-eyre = "0.6"
 ordered-float = { workspace = true }
+size-of = { version = "0.1", package = "feldera-size-of", features = ["ordered-float"] }
+rkyv = { version = "0.7", default-features = false, features = ["std", "size_64", "validation", "uuid"] }
 dbsp = "0.98"
 
 [build-dependencies]
@@ -27,7 +29,7 @@ members = ["build_support", "test_utils"]
 
 [workspace.dependencies]
 glam = "0.24"
-ordered-float = "2"
+ordered-float = { version = "3", features = ["serde", "rkyv_64"] }
 
 [dev-dependencies]
 insta = { version = "1.38.0", default-features = false, features = ["ron"] }

--- a/src/components.rs
+++ b/src/components.rs
@@ -18,7 +18,26 @@ pub enum UnitType {
 #[derive(Component, Debug, Deref, DerefMut, Serialize)]
 pub struct Target(pub Vec2);
 
-#[derive(Component, Debug, Clone, Serialize)]
+use rkyv::{Archive, Deserialize, Serialize as RkyvSerialize};
+use size_of::SizeOf;
+
+#[derive(
+    Archive,
+    RkyvSerialize,
+    Deserialize,
+    Component,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Default,
+    SizeOf,
+)]
+#[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
 pub struct Block {
     pub id: i64,
     pub x: i32,

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -39,27 +39,7 @@ pub struct Position {
     pub z: OrderedFloat<f64>,
 }
 
-#[derive(
-    Archive,
-    Serialize,
-    Deserialize,
-    Clone,
-    Debug,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Ord,
-    Hash,
-    Default,
-    SizeOf,
-)]
-#[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
-pub struct NewPosition {
-    pub entity: i64,
-    pub x: OrderedFloat<f64>,
-    pub y: OrderedFloat<f64>,
-    pub z: OrderedFloat<f64>,
-}
+pub type NewPosition = Position;
 
 #[derive(
     Archive,
@@ -107,7 +87,7 @@ impl DbspCircuit {
                             z: *z,
                         });
 
-                let new_pos = positions.map(|p| NewPosition {
+                let new_pos = positions.map(|p| Position {
                     entity: p.entity,
                     x: p.x,
                     y: p.y,

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -136,7 +136,7 @@ impl DbspCircuit {
     /// Input ZSets accumulate records across [`DbspCircuit::step`] calls.
     /// Call this method after each frame, once outputs have been processed,
     /// to prevent stale data from affecting subsequent computations.
-    pub fn clear_inputs(&self) {
+    pub fn clear_inputs(&mut self) {
         self.position_in.clear_input();
         self.block_in.clear_input();
     }

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -1,0 +1,73 @@
+use dbsp::{
+    operator::Max, typed_batch::OrdZSet, CircuitHandle, OutputHandle, RootCircuit, ZSetHandle,
+};
+
+use crate::components::Block;
+use crate::GRAVITY_PULL;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Position {
+    pub entity: i64,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct NewPosition {
+    pub entity: i64,
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct HighestBlockAt {
+    pub x: i32,
+    pub y: i32,
+    pub z: i32,
+}
+
+pub struct DbspCircuit {
+    circuit: CircuitHandle,
+    pub position_in: ZSetHandle<Position>,
+    pub block_in: ZSetHandle<Block>,
+    pub new_position_out: OutputHandle<OrdZSet<NewPosition>>,
+    pub highest_block_out: OutputHandle<OrdZSet<HighestBlockAt>>,
+}
+
+impl DbspCircuit {
+    pub fn new() -> Result<Self, dbsp::Error> {
+        let (circuit, (position_in, block_in, new_position_out, highest_block_out)) =
+            RootCircuit::build(|circuit| {
+                let (positions, position_in) = circuit.add_input_zset::<Position>();
+                let (blocks, block_in) = circuit.add_input_zset::<Block>();
+
+                let highest = blocks
+                    .map_index(|b| ((b.x, b.y), b.z))
+                    .aggregate(Max)
+                    .map(|((x, y), z)| HighestBlockAt { x, y, z });
+
+                let new_pos = positions.map(|p| NewPosition {
+                    entity: p.entity,
+                    x: p.x,
+                    y: p.y,
+                    z: p.z + GRAVITY_PULL,
+                });
+
+                Ok((position_in, block_in, new_pos.output(), highest.output()))
+            })?;
+
+        Ok(Self {
+            circuit,
+            position_in,
+            block_in,
+            new_position_out,
+            highest_block_out,
+        })
+    }
+
+    pub fn step(&mut self) -> Result<(), dbsp::Error> {
+        self.circuit.step()
+    }
+}

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -1,10 +1,11 @@
-//! Declarative DBSP circuit implementing simple physics rules.
+//! DBSP-based world inference engine.
 //!
-//! This module houses the core dataflow logic that infers game state from
-//! declarative inputs.  The circuit exposes handles for inserting `Position`
-//! and `Block` records and yields streams such as `NewPosition` and
-//! `HighestBlockAt`.  Each input is incremental; callers should clear the
-//! handles between steps to avoid stale data accumulating in the circuit.
+//! This module defines [`DbspCircuit`], the authoritative dataflow program for
+//! Lille's game world. Callers feed [`Position`] and [`Block`] records into the
+//! circuit, call [`DbspCircuit::step`], then read [`NewPosition`] and
+//! [`HighestBlockAt`] outputs. Input collections persist across steps—invoke
+//! [`DbspCircuit::clear_inputs`] after each frame to prevent stale data from
+//! affecting subsequent computations.
 
 use dbsp::{
     operator::Max, typed_batch::OrdZSet, CircuitHandle, OutputHandle, RootCircuit, ZSetHandle,
@@ -130,7 +131,11 @@ impl DbspCircuit {
         &self.highest_block_out
     }
 
-    /// Clear all input collections to avoid stale data between steps.
+    /// Clears all input collections.
+    ///
+    /// Input ZSets accumulate records across [`DbspCircuit::step`] calls.
+    /// Call this method after each frame, once outputs have been processed,
+    /// to prevent stale data from affecting subsequent computations.
     pub fn clear_inputs(&self) {
         self.position_in.clear_input();
         self.block_in.clear_input();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod actor;
 pub mod components;
 pub mod constants;
+pub mod dbsp_circuit;
 pub mod ddlog_sync;
 pub mod entity;
 pub mod logging;
@@ -14,6 +15,7 @@ pub use constants::*;
 // Re-export commonly used items
 pub use actor::Actor;
 pub use components::{DdlogId, Health, Target, UnitType};
+pub use dbsp_circuit::{DbspCircuit, HighestBlockAt, NewPosition, Position};
 pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};
 pub use entity::{BadGuy, Entity};
 pub use logging::init as init_logging;

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,0 +1,8 @@
+use lille::dbsp_circuit::DbspCircuit;
+
+/// Create a new `DbspCircuit` for tests.
+///
+/// Panics if the circuit cannot be constructed.
+pub fn new_circuit() -> DbspCircuit {
+    DbspCircuit::new().expect("failed to build DBSP circuit")
+}

--- a/tests/dbsp_highest_block.rs
+++ b/tests/dbsp_highest_block.rs
@@ -3,10 +3,8 @@
 //! This module validates that the circuit correctly computes the highest block
 //! at each `(x, y)` coordinate pair from multiple input blocks.
 
-use lille::{
-    components::Block,
-    dbsp_circuit::{DbspCircuit, HighestBlockAt},
-};
+use lille::{components::Block, dbsp_circuit::HighestBlockAt};
+mod common;
 use rstest::rstest;
 
 fn b(id: i64, x: i32, y: i32, z: i32) -> Block {
@@ -19,7 +17,7 @@ fn hb(x: i32, y: i32, z: i32) -> HighestBlockAt {
 
 #[test]
 fn test_highest_block_aggregation() {
-    let mut circuit = DbspCircuit::new().expect("Failed to create DBSP circuit");
+    let mut circuit = common::new_circuit();
 
     circuit.block_in().push(
         Block {
@@ -65,7 +63,7 @@ fn test_highest_block_aggregation() {
 #[case::duplicate_same_height(vec![b(1,1,1,5), b(2,1,1,5)], vec![hb(1,1,5)])]
 #[case::mixed(vec![b(1,0,0,3), b(2,0,0,1), b(3,0,1,4)], vec![hb(0,0,3), hb(0,1,4)])]
 fn highest_block_cases(#[case] blocks: Vec<Block>, #[case] expected: Vec<HighestBlockAt>) {
-    let mut circuit = DbspCircuit::new().expect("Failed to create DBSP circuit");
+    let mut circuit = common::new_circuit();
     for blk in blocks {
         circuit.block_in().push(blk, 1);
     }

--- a/tests/dbsp_highest_block.rs
+++ b/tests/dbsp_highest_block.rs
@@ -7,7 +7,7 @@ use lille::{
 fn test_highest_block_aggregation() {
     let mut circuit = DbspCircuit::new().unwrap();
 
-    circuit.block_in.push(
+    circuit.block_in().push(
         Block {
             id: 0,
             x: 10,
@@ -16,7 +16,7 @@ fn test_highest_block_aggregation() {
         },
         1,
     );
-    circuit.block_in.push(
+    circuit.block_in().push(
         Block {
             id: 1,
             x: 10,
@@ -25,7 +25,7 @@ fn test_highest_block_aggregation() {
         },
         1,
     );
-    circuit.block_in.push(
+    circuit.block_in().push(
         Block {
             id: 2,
             x: 15,
@@ -37,7 +37,7 @@ fn test_highest_block_aggregation() {
 
     circuit.step().unwrap();
 
-    let output = circuit.highest_block_out.consolidate();
+    let output = circuit.highest_block_out().consolidate();
     let mut vals: Vec<HighestBlockAt> = output.iter().map(|(hb, _, _)| hb.clone()).collect();
     vals.sort_by_key(|h| (h.x, h.y));
     assert_eq!(vals.len(), 2);

--- a/tests/dbsp_highest_block.rs
+++ b/tests/dbsp_highest_block.rs
@@ -7,6 +7,15 @@ use lille::{
     components::Block,
     dbsp_circuit::{DbspCircuit, HighestBlockAt},
 };
+use rstest::rstest;
+
+fn b(id: i64, x: i32, y: i32, z: i32) -> Block {
+    Block { id, x, y, z }
+}
+
+fn hb(x: i32, y: i32, z: i32) -> HighestBlockAt {
+    HighestBlockAt { x, y, z }
+}
 
 #[test]
 fn test_highest_block_aggregation() {
@@ -48,4 +57,29 @@ fn test_highest_block_aggregation() {
     assert_eq!(vals.len(), 2);
     assert!(vals.contains(&HighestBlockAt { x: 10, y: 20, z: 8 }));
     assert!(vals.contains(&HighestBlockAt { x: 15, y: 25, z: 3 }));
+}
+
+#[rstest]
+#[case::empty(vec![], vec![])]
+#[case::single(vec![b(1, 0, 0, 2)], vec![hb(0, 0, 2)])]
+#[case::duplicate_same_height(vec![b(1,1,1,5), b(2,1,1,5)], vec![hb(1,1,5)])]
+#[case::mixed(vec![b(1,0,0,3), b(2,0,0,1), b(3,0,1,4)], vec![hb(0,0,3), hb(0,1,4)])]
+fn highest_block_cases(#[case] blocks: Vec<Block>, #[case] expected: Vec<HighestBlockAt>) {
+    let mut circuit = DbspCircuit::new().expect("Failed to create DBSP circuit");
+    for blk in blocks {
+        circuit.block_in().push(blk, 1);
+    }
+    circuit.step().expect("Failed to step DBSP circuit");
+
+    let mut vals: Vec<HighestBlockAt> = circuit
+        .highest_block_out()
+        .consolidate()
+        .iter()
+        .map(|(hb, _, _)| hb.clone())
+        .collect();
+    vals.sort_by_key(|h| (h.x, h.y));
+
+    let mut expected_sorted = expected;
+    expected_sorted.sort_by_key(|h| (h.x, h.y));
+    assert_eq!(vals, expected_sorted);
 }

--- a/tests/dbsp_highest_block.rs
+++ b/tests/dbsp_highest_block.rs
@@ -1,0 +1,46 @@
+use lille::{
+    components::Block,
+    dbsp_circuit::{DbspCircuit, HighestBlockAt},
+};
+
+#[test]
+fn test_highest_block_aggregation() {
+    let mut circuit = DbspCircuit::new().unwrap();
+
+    circuit.block_in.push(
+        Block {
+            id: 0,
+            x: 10,
+            y: 20,
+            z: 5,
+        },
+        1,
+    );
+    circuit.block_in.push(
+        Block {
+            id: 1,
+            x: 10,
+            y: 20,
+            z: 8,
+        },
+        1,
+    );
+    circuit.block_in.push(
+        Block {
+            id: 2,
+            x: 15,
+            y: 25,
+            z: 3,
+        },
+        1,
+    );
+
+    circuit.step().unwrap();
+
+    let output = circuit.highest_block_out.consolidate();
+    let mut vals: Vec<HighestBlockAt> = output.iter().map(|(hb, _, _)| hb.clone()).collect();
+    vals.sort_by_key(|h| (h.x, h.y));
+    assert_eq!(vals.len(), 2);
+    assert!(vals.contains(&HighestBlockAt { x: 10, y: 20, z: 8 }));
+    assert!(vals.contains(&HighestBlockAt { x: 15, y: 25, z: 3 }));
+}

--- a/tests/dbsp_highest_block.rs
+++ b/tests/dbsp_highest_block.rs
@@ -1,3 +1,8 @@
+//! Tests for the highest block aggregation functionality in the DBSP circuit.
+//!
+//! This module validates that the circuit correctly computes the highest block
+//! at each `(x, y)` coordinate pair from multiple input blocks.
+
 use lille::{
     components::Block,
     dbsp_circuit::{DbspCircuit, HighestBlockAt},
@@ -5,7 +10,7 @@ use lille::{
 
 #[test]
 fn test_highest_block_aggregation() {
-    let mut circuit = DbspCircuit::new().unwrap();
+    let mut circuit = DbspCircuit::new().expect("Failed to create DBSP circuit");
 
     circuit.block_in().push(
         Block {
@@ -35,7 +40,7 @@ fn test_highest_block_aggregation() {
         1,
     );
 
-    circuit.step().unwrap();
+    circuit.step().expect("Failed to step DBSP circuit");
 
     let output = circuit.highest_block_out().consolidate();
     let mut vals: Vec<HighestBlockAt> = output.iter().map(|(hb, _, _)| hb.clone()).collect();

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -1,8 +1,13 @@
+//! Physics behaviour-driven development tests using the DBSP circuit.
+//!
+//! This module tests physics rules such as gravity effects on entity positions
+//! through the declarative dataflow circuit.
+
 use lille::dbsp_circuit::{DbspCircuit, NewPosition, Position};
 
 #[test]
 fn entity_falls_due_to_gravity() {
-    let mut circuit = DbspCircuit::new().unwrap();
+    let mut circuit = DbspCircuit::new().expect("Failed to create DBSP circuit");
 
     circuit.position_in().push(
         Position {
@@ -13,11 +18,11 @@ fn entity_falls_due_to_gravity() {
         },
         1,
     );
-    circuit.step().unwrap();
+    circuit.step().expect("Failed to step DBSP circuit");
 
     let output = circuit.new_position_out().consolidate();
     let results: Vec<NewPosition> = output.iter().map(|(p, _, _)| p.clone()).collect();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].entity, 1);
-    assert!(results[0].z.into_inner() < 1.0);
+    assert_eq!(results[0].z.into_inner(), 1.0 + lille::GRAVITY_PULL);
 }

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -1,69 +1,23 @@
-//! Behaviour-driven tests for physics-related systems.
-//! Uses `rstest` to script scenarios covering entity transitions.
-use bevy::prelude::*;
-use insta::assert_ron_snapshot;
-use lille::{
-    apply_ddlog_deltas_system, cache_state_for_ddlog_system,
-    components::{Block, BlockSlope, DdlogId, Health, UnitType},
-    init_world_handle_system,
-    world_handle::WorldHandle,
-};
-use rstest::rstest;
+use lille::dbsp_circuit::{DbspCircuit, NewPosition, Position};
 
-fn setup_app() -> App {
-    let mut app = App::new();
-    app.add_plugins(MinimalPlugins);
-    app.add_systems(Startup, init_world_handle_system);
-    app
-}
+#[test]
+fn entity_falls_due_to_gravity() {
+    let mut circuit = DbspCircuit::new().unwrap();
 
-#[rstest]
-fn entity_transitions_between_standing_and_falling() {
-    // GIVEN a block at z=0 and an entity standing on it
-    let mut app = setup_app();
-    app.add_systems(
-        Update,
-        (cache_state_for_ddlog_system, apply_ddlog_deltas_system).chain(),
+    circuit.position_in.push(
+        Position {
+            entity: 1,
+            x: 0.0,
+            y: 0.0,
+            z: 1.0,
+        },
+        1,
     );
-    let block_entity = app
-        .world
-        .spawn_empty()
-        .insert(Block {
-            id: 1,
-            x: 0,
-            y: 0,
-            z: 0,
-        })
-        .id();
-    app.world.entity_mut(block_entity).insert(BlockSlope {
-        block_id: 1,
-        grad_x: 0.0,
-        grad_y: 0.0,
-    });
-    app.world.spawn((
-        DdlogId(1),
-        Health(100),
-        UnitType::Civvy { fraidiness: 0.0 },
-        Transform::from_xyz(0.5, 0.5, 1.0),
-    ));
+    circuit.step().unwrap();
 
-    app.update(); // initial sync
-    {
-        let ddlog = app.world.resource::<WorldHandle>();
-        assert!(ddlog.deltas.is_empty());
-    }
-
-    // WHEN the block is lowered so the entity is above the floor
-    app.world.entity_mut(block_entity).insert(Block {
-        id: 1,
-        x: 0,
-        y: 0,
-        z: -1,
-    });
-    app.update();
-
-    // THEN the entity should have fallen
-    let ddlog = app.world.resource::<WorldHandle>();
-    assert!(ddlog.deltas[0].z < 1.0);
-    assert_ron_snapshot!("falling_delta", &ddlog.deltas);
+    let output = circuit.new_position_out.consolidate();
+    let results: Vec<NewPosition> = output.iter().map(|(p, _, _)| p.clone()).collect();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].entity, 1);
+    assert!(results[0].z < 1.0);
 }

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -4,7 +4,7 @@ use lille::dbsp_circuit::{DbspCircuit, NewPosition, Position};
 fn entity_falls_due_to_gravity() {
     let mut circuit = DbspCircuit::new().unwrap();
 
-    circuit.position_in.push(
+    circuit.position_in().push(
         Position {
             entity: 1,
             x: 0.0.into(),
@@ -15,7 +15,7 @@ fn entity_falls_due_to_gravity() {
     );
     circuit.step().unwrap();
 
-    let output = circuit.new_position_out.consolidate();
+    let output = circuit.new_position_out().consolidate();
     let results: Vec<NewPosition> = output.iter().map(|(p, _, _)| p.clone()).collect();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].entity, 1);

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -7,9 +7,9 @@ fn entity_falls_due_to_gravity() {
     circuit.position_in.push(
         Position {
             entity: 1,
-            x: 0.0,
-            y: 0.0,
-            z: 1.0,
+            x: 0.0.into(),
+            y: 0.0.into(),
+            z: 1.0.into(),
         },
         1,
     );
@@ -19,5 +19,5 @@ fn entity_falls_due_to_gravity() {
     let results: Vec<NewPosition> = output.iter().map(|(p, _, _)| p.clone()).collect();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].entity, 1);
-    assert!(results[0].z < 1.0);
+    assert!(results[0].z.into_inner() < 1.0);
 }

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -3,11 +3,13 @@
 //! This module tests physics rules such as gravity effects on entity positions
 //! through the declarative dataflow circuit.
 
-use lille::dbsp_circuit::{DbspCircuit, NewPosition, Position};
+use approx::assert_relative_eq;
+use lille::dbsp_circuit::{NewPosition, Position};
+mod common;
 
 #[test]
 fn entity_falls_due_to_gravity() {
-    let mut circuit = DbspCircuit::new().expect("Failed to create DBSP circuit");
+    let mut circuit = common::new_circuit();
 
     circuit.position_in().push(
         Position {
@@ -24,5 +26,5 @@ fn entity_falls_due_to_gravity() {
     let results: Vec<NewPosition> = output.iter().map(|(p, _, _)| p.clone()).collect();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].entity, 1);
-    assert_eq!(results[0].z.into_inner(), 1.0 + lille::GRAVITY_PULL);
+    assert_relative_eq!(results[0].z.into_inner(), 1.0 + lille::GRAVITY_PULL);
 }


### PR DESCRIPTION
## Summary
- start adding dbsp support
- expose new structs and minimal tests

## Testing
- `make fmt`
- `make markdownlint`
- `make lint` *(fails: could not compile `lille`)*

------
https://chatgpt.com/codex/tasks/task_e_686c4c57c52c83228a390554d348e9c8

## Summary by Sourcery

Implement an initial DBSP-based circuit skeleton for Lille's game world inference engine, adding core types and a `DbspCircuit` API for gravitational and highest-block computations.

New Features:
- Introduce `DbspCircuit` module with input/output handles and methods for stepping and clearing inputs.
- Define `Position`, `NewPosition`, and `HighestBlockAt` types for circuit dataflow I/O.

Enhancements:
- Derive archival, serialization, and sizing traits for `Block` using rkyv and size-of.
- Refactor existing physics BDD tests to consume the new DBSP circuit instead of DDlog.

Build:
- Add `dbsp`, `rkyv`, and `size-of` dependencies and upgrade `ordered-float` for serialization support.

Tests:
- Add unit tests for gravity-driven position updates.
- Add parametrized tests for highest-block aggregation and a `common` helper for circuit setup.