### PR TITLE
Remove outdated ddlog testing step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,7 @@ project:
 
 01. **Run `make fmt`, `make markdownlint`, and `make lint`** before committing
     to ensure consistent code style and catch common mistakes. After formatting
-    and linting, execute **`make test`** and **`make test-ddlog`** to validate
-    both standard and DDlog-enabled builds.
+    and linting, execute **`make test`** to validate the build.
 02. **Write unit tests** for new functionality. Run `make test` in the root
     crate to ensure all tests pass.
 03. **Document public APIs** using Rustdoc comments (`///`) so documentation can


### PR DESCRIPTION
## Summary
- drop `make test-ddlog` from contributor guidelines

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686d88d3c78c83229e05c6747f4ed753

## Summary by Sourcery

Documentation:
- Drop `make test-ddlog` instruction from AGENTS.md to streamline the testing instructions