### PR TITLE
Add DBSP sequence diagram

### DIFF
--- a/docs/declarative-world-inference-with-dbsp-and-rust.md
+++ b/docs/declarative-world-inference-with-dbsp-and-rust.md
@@ -204,7 +204,7 @@ the data flow each tick.
    the `NewPosition` output stream and updates the `Transform` component of the
    corresponding entities in the ECS.
 
-The following sequence diagram summarises how the application constructs and
+The following sequence diagram summarizes how the application constructs and
 drives the circuit each tick.
 
 ```mermaid


### PR DESCRIPTION
## Summary
- update world inference doc with a sequence diagram showing how the app drives the DBSP circuit
- quote the DBSP Engine label so the Mermaid diagram parses correctly

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`
- `make test-ddlog` *(fails: No rule to make target)*
- `make nixie`


------
https://chatgpt.com/codex/tasks/task_e_686d6fef32d083229d10c94c46edb19e

## Summary by Sourcery

Add a sequence diagram to the declarative world inference documentation to illustrate how the application interacts with the DBSP circuit each tick.

Documentation:
- Insert a Mermaid sequence diagram detailing the message flow between App, DbspCircuit, and "DBSP Engine".
- Quote the DBSP Engine label in the diagram to ensure correct Mermaid parsing.