### PR TITLE
Fix doctest prelude imports

### DIFF
--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -12,7 +12,7 @@
 //! Examples in this module use the following imports:
 //!
 //! ```rust,no_run
-//! use lille::prelude::*;
+//! # use lille::prelude::*;
 //! ```
 
 use dbsp::{


### PR DESCRIPTION
## Summary
- hide prelude import in the module-level doctest for `DbspCircuit`

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68704fdb46d4832299dd24e4658c32b5