### PR TITLE
Add Bevy <-> DBSP loop with gravity test

### DIFF
--- a/src/components.rs
+++ b/src/components.rs
@@ -52,7 +52,7 @@ pub struct BlockSlope {
     pub grad_y: f32,
 }
 #[derive(Component, Debug, Clone, Default, Serialize)]
-pub struct Velocity {
+pub struct VelocityComp {
     pub vx: f32,
     pub vy: f32,
     pub vz: f32,

--- a/src/components.rs
+++ b/src/components.rs
@@ -51,3 +51,9 @@ pub struct BlockSlope {
     pub grad_x: f32,
     pub grad_y: f32,
 }
+#[derive(Component, Debug, Clone, Default, Serialize)]
+pub struct Velocity {
+    pub vx: f32,
+    pub vy: f32,
+    pub vz: f32,
+}

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -1,26 +1,58 @@
+//! Synchronization systems for integrating DBSP circuits with Bevy ECS.
+//!
+//! This module provides Bevy systems that feed ECS component state into the
+//! [`DbspCircuit`], step the circuit, and apply the resulting updates back to
+//! entities. Use [`init_dbsp_system`] once during startup, then run
+//! [`cache_state_for_dbsp_system`] and [`apply_dbsp_outputs_system`] each tick.
+
 use std::collections::HashMap;
 
 use bevy::prelude::*;
+use log::error;
 
 use crate::components::{Block, DdlogId, Velocity as VelocityComp};
 use crate::dbsp_circuit::{DbspCircuit, Position, Velocity};
 
+/// Non-send resource wrapping the [`DbspCircuit`].
+///
+/// This resource owns the circuit instance that performs all physics and game
+/// logic computations. It must live outside the ECS so that the DBSP runtime can
+/// maintain internal state across frames.
 pub struct DbspState {
     circuit: DbspCircuit,
 }
 
 impl Default for DbspState {
     fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DbspState {
+    /// Creates a new [`DbspState`] with an initialized circuit.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the DBSP circuit cannot be constructed.
+    pub fn new() -> Self {
         Self {
             circuit: DbspCircuit::new().expect("failed to build DBSP circuit"),
         }
     }
 }
 
+/// Initializes the [`DbspState`] resource in the provided [`World`].
+///
+/// Call this once during Bevy startup before running any DBSP synchronization
+/// systems.
 pub fn init_dbsp_system(world: &mut World) {
     world.insert_non_send_resource(DbspState::default());
 }
 
+/// Caches current ECS state into the DBSP circuit inputs.
+///
+/// This system gathers `Transform`, optional `Velocity`, and `Block` components
+/// and pushes them into the circuit's input handles.
 pub fn cache_state_for_dbsp_system(
     state: NonSendMut<DbspState>,
     entity_query: Query<(&DdlogId, &Transform, Option<&VelocityComp>)>,
@@ -54,18 +86,27 @@ pub fn cache_state_for_dbsp_system(
     }
 }
 
+/// Applies DBSP outputs back to ECS components.
+///
+/// Steps the circuit, reads new positions and velocities, and updates the
+/// corresponding entities. Output handles are drained afterwards to avoid
+/// reapplying stale data.
 pub fn apply_dbsp_outputs_system(
     mut state: NonSendMut<DbspState>,
-    mut query: Query<(Entity, &DdlogId, &mut Transform, Option<&mut VelocityComp>)>,
+    id_query: Query<(Entity, &DdlogId)>,
+    mut write_query: Query<(Entity, &mut Transform, Option<&mut VelocityComp>), With<DdlogId>>,
 ) {
-    state.circuit.step().expect("DBSP step failed");
+    if let Err(e) = state.circuit.step() {
+        error!("DBSP step failed: {e}");
+        return;
+    }
 
-    let id_map: HashMap<i64, Entity> = query.iter().map(|(e, id, _, _)| (id.0, e)).collect();
+    let id_map: HashMap<i64, Entity> = id_query.iter().map(|(e, id)| (id.0, e)).collect();
 
     let positions = state.circuit.new_position_out().consolidate();
     for (pos, _, _) in positions.iter() {
         if let Some(&entity) = id_map.get(&pos.entity) {
-            if let Ok((_, _, mut transform, _)) = query.get_mut(entity) {
+            if let Ok((_, mut transform, _)) = write_query.get_mut(entity) {
                 transform.translation.x = pos.x.into_inner() as f32;
                 transform.translation.y = pos.y.into_inner() as f32;
                 transform.translation.z = pos.z.into_inner() as f32;
@@ -76,13 +117,17 @@ pub fn apply_dbsp_outputs_system(
     let velocities = state.circuit.new_velocity_out().consolidate();
     for (vel, _, _) in velocities.iter() {
         if let Some(&entity) = id_map.get(&vel.entity) {
-            if let Ok((_, _, _, Some(mut v))) = query.get_mut(entity) {
+            if let Ok((_, _, Some(mut v))) = write_query.get_mut(entity) {
                 v.vx = vel.vx.into_inner() as f32;
                 v.vy = vel.vy.into_inner() as f32;
                 v.vz = vel.vz.into_inner() as f32;
             }
         }
     }
+
+    // Drain any remaining output so stale values are not reused.
+    let _ = state.circuit.new_position_out().take_from_all();
+    let _ = state.circuit.new_velocity_out().take_from_all();
 
     state.circuit.clear_inputs();
 }

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+
+use crate::components::{Block, DdlogId, Velocity as VelocityComp};
+use crate::dbsp_circuit::{DbspCircuit, Position, Velocity};
+
+pub struct DbspState {
+    circuit: DbspCircuit,
+}
+
+impl Default for DbspState {
+    fn default() -> Self {
+        Self {
+            circuit: DbspCircuit::new().expect("failed to build DBSP circuit"),
+        }
+    }
+}
+
+pub fn init_dbsp_system(world: &mut World) {
+    world.insert_non_send_resource(DbspState::default());
+}
+
+pub fn cache_state_for_dbsp_system(
+    state: NonSendMut<DbspState>,
+    entity_query: Query<(&DdlogId, &Transform, Option<&VelocityComp>)>,
+    block_query: Query<&Block>,
+) {
+    for block in &block_query {
+        state.circuit.block_in().push(block.clone(), 1);
+    }
+
+    for (id, transform, vel) in &entity_query {
+        state.circuit.position_in().push(
+            Position {
+                entity: id.0,
+                x: (transform.translation.x as f64).into(),
+                y: (transform.translation.y as f64).into(),
+                z: (transform.translation.z as f64).into(),
+            },
+            1,
+        );
+
+        let v = vel.map(|v| (v.vx, v.vy, v.vz)).unwrap_or_default();
+        state.circuit.velocity_in().push(
+            Velocity {
+                entity: id.0,
+                vx: (v.0 as f64).into(),
+                vy: (v.1 as f64).into(),
+                vz: (v.2 as f64).into(),
+            },
+            1,
+        );
+    }
+}
+
+pub fn apply_dbsp_outputs_system(
+    mut state: NonSendMut<DbspState>,
+    mut query: Query<(Entity, &DdlogId, &mut Transform, Option<&mut VelocityComp>)>,
+) {
+    state.circuit.step().expect("DBSP step failed");
+
+    let id_map: HashMap<i64, Entity> = query.iter().map(|(e, id, _, _)| (id.0, e)).collect();
+
+    let positions = state.circuit.new_position_out().consolidate();
+    for (pos, _, _) in positions.iter() {
+        if let Some(&entity) = id_map.get(&pos.entity) {
+            if let Ok((_, _, mut transform, _)) = query.get_mut(entity) {
+                transform.translation.x = pos.x.into_inner() as f32;
+                transform.translation.y = pos.y.into_inner() as f32;
+                transform.translation.z = pos.z.into_inner() as f32;
+            }
+        }
+    }
+
+    let velocities = state.circuit.new_velocity_out().consolidate();
+    for (vel, _, _) in velocities.iter() {
+        if let Some(&entity) = id_map.get(&vel.entity) {
+            if let Ok((_, _, _, Some(mut v))) = query.get_mut(entity) {
+                v.vx = vel.vx.into_inner() as f32;
+                v.vy = vel.vy.into_inner() as f32;
+                v.vz = vel.vz.into_inner() as f32;
+            }
+        }
+    }
+
+    state.circuit.clear_inputs();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod actor;
 pub mod components;
 pub mod constants;
 pub mod dbsp_circuit;
+pub mod dbsp_sync;
 pub mod ddlog_sync;
 pub mod entity;
 pub mod logging;
@@ -14,9 +15,10 @@ pub use constants::*;
 
 // Re-export commonly used items
 pub use actor::Actor;
-pub use components::{DdlogId, Health, Target, UnitType};
+pub use components::{DdlogId, Health, Target, UnitType, Velocity as VelocityComp};
 pub use dbsp_circuit::{DbspCircuit, HighestBlockAt, NewPosition, Position};
 pub use dbsp_circuit::{NewVelocity, Velocity};
+pub use dbsp_sync::{apply_dbsp_outputs_system, cache_state_for_dbsp_system, init_dbsp_system};
 pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};
 pub use entity::{BadGuy, Entity};
 pub use logging::init as init_logging;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,12 @@ pub use constants::*;
 
 // Re-export commonly used items
 pub use actor::Actor;
-pub use components::{DdlogId, Health, Target, UnitType, Velocity as VelocityComp};
+pub use components::{DdlogId, Health, Target, UnitType, VelocityComp};
 pub use dbsp_circuit::{DbspCircuit, HighestBlockAt, NewPosition, Position};
 pub use dbsp_circuit::{NewVelocity, Velocity};
-pub use dbsp_sync::{apply_dbsp_outputs_system, cache_state_for_dbsp_system, init_dbsp_system};
+pub use dbsp_sync::{
+    apply_dbsp_outputs_system, cache_state_for_dbsp_system, init_dbsp_system, DbspPlugin,
+};
 pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};
 pub use entity::{BadGuy, Entity};
 pub use logging::init as init_logging;
@@ -35,6 +37,7 @@ pub mod prelude {
 
     pub use crate::components::Block;
     pub use crate::DbspCircuit;
+    pub use crate::DbspPlugin;
     pub use crate::Velocity;
     pub use ordered_float::OrderedFloat;
 }

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -2,7 +2,7 @@
 //! Provides helper functions to create sprites and initialise game objects.
 use bevy::prelude::*;
 
-use crate::components::{DdlogId, Health, Target, UnitType, Velocity};
+use crate::components::{DdlogId, Health, Target, UnitType, VelocityComp};
 
 /// Creates a `SpriteBundle` with the specified colour and position.
 ///
@@ -62,7 +62,7 @@ pub fn spawn_world_system(mut commands: Commands) {
             Health(100),
             UnitType::Civvy { fraidiness: 1.0 },
             Target(Vec2::new(202.0, 200.0)),
-            Velocity::default(),
+            VelocityComp::default(),
         ));
     next_id += 1;
 
@@ -73,7 +73,7 @@ pub fn spawn_world_system(mut commands: Commands) {
             DdlogId(next_id),
             Health(100),
             UnitType::Baddie { meanness: 10.0 },
-            Velocity::default(),
+            VelocityComp::default(),
         ));
     next_id += 1;
     let _ = next_id;

--- a/src/spawn_world.rs
+++ b/src/spawn_world.rs
@@ -2,7 +2,7 @@
 //! Provides helper functions to create sprites and initialise game objects.
 use bevy::prelude::*;
 
-use crate::components::{DdlogId, Health, Target, UnitType};
+use crate::components::{DdlogId, Health, Target, UnitType, Velocity};
 
 /// Creates a `SpriteBundle` with the specified colour and position.
 ///
@@ -62,6 +62,7 @@ pub fn spawn_world_system(mut commands: Commands) {
             Health(100),
             UnitType::Civvy { fraidiness: 1.0 },
             Target(Vec2::new(202.0, 200.0)),
+            Velocity::default(),
         ));
     next_id += 1;
 
@@ -72,6 +73,7 @@ pub fn spawn_world_system(mut commands: Commands) {
             DdlogId(next_id),
             Health(100),
             UnitType::Baddie { meanness: 10.0 },
+            Velocity::default(),
         ));
     next_id += 1;
     let _ = next_id;

--- a/tests/bevy_dbsp_loop.rs
+++ b/tests/bevy_dbsp_loop.rs
@@ -1,8 +1,5 @@
 use bevy::prelude::*;
-use lille::{
-    apply_dbsp_outputs_system, cache_state_for_dbsp_system, init_dbsp_system, DdlogId,
-    VelocityComp as Velocity, GRAVITY_PULL,
-};
+use lille::{DbspPlugin, DdlogId, VelocityComp, GRAVITY_PULL};
 
 /// Verifies that the ECS-DBSP round trip applies gravity to entity position and
 /// velocity.
@@ -10,19 +7,14 @@ use lille::{
 #[test]
 fn ecs_dbsp_round_trip_applies_gravity() {
     let mut app = App::new();
-    app.add_plugins(MinimalPlugins)
-        .add_systems(Startup, init_dbsp_system)
-        .add_systems(
-            Update,
-            (cache_state_for_dbsp_system, apply_dbsp_outputs_system).chain(),
-        );
+    app.add_plugins(MinimalPlugins).add_plugins(DbspPlugin);
 
     let entity = app
         .world
         .spawn((
             DdlogId(1),
             Transform::from_xyz(0.0, 0.0, 1.0),
-            Velocity::default(),
+            VelocityComp::default(),
         ))
         .id();
 
@@ -31,6 +23,6 @@ fn ecs_dbsp_round_trip_applies_gravity() {
     let transform = app.world.get::<Transform>(entity).unwrap();
     assert!((transform.translation.z - (1.0 + GRAVITY_PULL as f32)).abs() < f32::EPSILON);
 
-    let vel = app.world.get::<Velocity>(entity).unwrap();
+    let vel = app.world.get::<VelocityComp>(entity).unwrap();
     assert!((vel.vz - GRAVITY_PULL as f32).abs() < f32::EPSILON);
 }

--- a/tests/bevy_dbsp_loop.rs
+++ b/tests/bevy_dbsp_loop.rs
@@ -1,0 +1,33 @@
+use bevy::prelude::*;
+use lille::{
+    apply_dbsp_outputs_system, cache_state_for_dbsp_system, init_dbsp_system, DdlogId,
+    VelocityComp as Velocity, GRAVITY_PULL,
+};
+
+#[test]
+fn ecs_dbsp_round_trip_applies_gravity() {
+    let mut app = App::new();
+    app.add_plugins(MinimalPlugins)
+        .add_systems(Startup, init_dbsp_system)
+        .add_systems(
+            Update,
+            (cache_state_for_dbsp_system, apply_dbsp_outputs_system).chain(),
+        );
+
+    let entity = app
+        .world
+        .spawn((
+            DdlogId(1),
+            Transform::from_xyz(0.0, 0.0, 1.0),
+            Velocity::default(),
+        ))
+        .id();
+
+    app.update();
+
+    let transform = app.world.get::<Transform>(entity).unwrap();
+    assert!((transform.translation.z - (1.0 + GRAVITY_PULL as f32)).abs() < f32::EPSILON);
+
+    let vel = app.world.get::<Velocity>(entity).unwrap();
+    assert!((vel.vz - GRAVITY_PULL as f32).abs() < f32::EPSILON);
+}

--- a/tests/bevy_dbsp_loop.rs
+++ b/tests/bevy_dbsp_loop.rs
@@ -4,6 +4,9 @@ use lille::{
     VelocityComp as Velocity, GRAVITY_PULL,
 };
 
+/// Verifies that the ECS-DBSP round trip applies gravity to entity position and
+/// velocity.
+
 #[test]
 fn ecs_dbsp_round_trip_applies_gravity() {
     let mut app = App::new();


### PR DESCRIPTION
## Summary
- add a `Velocity` ECS component
- spawn entities with velocity
- implement `dbsp_sync` systems to marshal data between Bevy and the DBSP circuit
- expose new systems from the library
- add BDD test verifying ECS→DBSP→ECS gravity behaviour

## Testing
- `make fmt`
- `make markdownlint`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6871a26de338832294f6b6e5f08cbf23

## Summary by Sourcery

Integrate a DBSP physics circuit with the Bevy ECS by adding a Velocity component, implementing and exposing sync systems, updating entity spawn logic to include velocities, and adding an integration test for the gravity simulation

New Features:
- Introduce Velocity ECS component for entity motion
- Add dbsp_sync module with initialization, state caching, and output application systems for DBSP integration

Enhancements:
- Expose the new DBSP sync systems in the library API
- Include default Velocity components when spawning entities

Tests:
- Add integration test verifying ECS→DBSP→ECS gravity behavior