### PR TITLE
Add serial tag for gravity scenario

### DIFF
--- a/tests/cucumber.rs
+++ b/tests/cucumber.rs
@@ -8,7 +8,9 @@ use steps::gravity_steps::PhysicsWorld;
 
 mod steps;
 
-#[tokio::main(flavor = "current_thread")]
+// The DBSP circuit spawns its own Tokio runtime. To allow `block_in_place`
+// within step definitions, use the default multi-threaded runtime here.
+#[tokio::main]
 async fn main() {
     let features = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/features");
     let features = features.to_str().expect("valid features path");

--- a/tests/features/gravity.feature
+++ b/tests/features/gravity.feature
@@ -1,4 +1,5 @@
 Feature: DBSP gravity integration
+  @serial
   Scenario: Unsupported entity falls
     Given a headless app with a single unsupported entity
     When the simulation ticks once


### PR DESCRIPTION
## Summary
- tag gravity.feature scenario to run serially

## Testing
- `make fmt`
- `make lint`
- `make test` *(fails: test cucumber)*

------
https://chatgpt.com/codex/tasks/task_e_687ce6da5c60832290a1d9d17d055cfd

## Summary by Sourcery

Tests:
- Add @serial tag to the gravity.feature Cucumber scenario for serial execution