### PR TITLE
Implement FloorHeightAt with slope support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 color-eyre = "0.6"
-anyhow = "1"
+anyhow = ">=1.0.0, <2.0.0"
 ordered-float = { workspace = true }
 size-of = { version = "0.1", package = "feldera-size-of", features = ["ordered-float"] }
 rkyv = { version = "0.7", default-features = false, features = ["std", "size_64", "validation", "uuid"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 color-eyre = "0.6"
+anyhow = "1"
 ordered-float = { workspace = true }
 size-of = { version = "0.1", package = "feldera-size-of", features = ["ordered-float"] }
 rkyv = { version = "0.7", default-features = false, features = ["std", "size_64", "validation", "uuid"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 color-eyre = "0.6"
-anyhow = ">=1.0.0, <2.0.0"
+anyhow = "^1"
 ordered-float = { workspace = true }
 size-of = { version = "0.1", package = "feldera-size-of", features = ["ordered-float"] }
 rkyv = { version = "0.7", default-features = false, features = ["std", "size_64", "validation", "uuid"] }

--- a/docs/lille-physics-and-world-engine-roadmap.md
+++ b/docs/lille-physics-and-world-engine-roadmap.md
@@ -95,7 +95,7 @@ DDlog-based version.
 
 1. **Full Geometry Model**:
 
-   - [ ] Implement the `FloorHeightAt` calculation, including the `left_join`
+   - [x] Implement the `FloorHeightAt` calculation, including the `left_join`
      with `BlockSlope` data to handle sloped surfaces correctly.
 
    - [ ] Implement the logic to join an entity's continuous `Position` with the

--- a/docs/lille-physics-engine-design.md
+++ b/docs/lille-physics-engine-design.md
@@ -29,8 +29,8 @@ source of truth for the state of the world.
 
 ## 2. Architectural Overview
 
-The architecture creates a clean separation between the *state* of the world (in
-Bevy) and the *logic* that governs it (in DBSP).
+The architecture creates a clean separation between the *state* of the world
+(in Bevy) and the *logic* that governs it (in DBSP).
 
 The data flows in a continuous loop each simulation tick:
 
@@ -43,8 +43,9 @@ The data flows in a continuous loop each simulation tick:
    `circuit`.
 
 3. **Incremental Computation**: The `circuit.step()` method is called. DBSP
-   propagates the input changes through the entire dataflow graph, incrementally
-   re-calculating all derived facts and producing new output streams.
+   propagates the input changes through the entire dataflow graph,
+   incrementally re-calculating all derived facts and producing new output
+   streams.
 
 4. **ECS State Write**: Bevy systems read the records from the circuit's output
    streams (e.g., `NewPosition`, `NewVelocity`) and apply these changes back to
@@ -77,8 +78,10 @@ The dataflow is as follows:
 
 2. **Floor Height Calculation**: The resulting `HighestBlockAt` stream is joined
    with `BlockSlope` data. A `map` operator then calculates the precise
-   `z_floor` coordinate. If a slope is present, it uses the plane equation;
-   otherwise, it assumes a flat surface one unit above the block.
+   `z_floor` coordinate. Slopes are joined using the block `id` and, for now,
+   the height is evaluated at the centre of the block (`0.5, 0.5`) because the
+   entity-specific offset is not yet available. If no slope exists the floor is
+   flat one unit above the block.
 
 ### 3.2. Entity State: Standing vs. Unsupported
 
@@ -120,8 +123,8 @@ declarative dataflow model.
   entity.
 
 - **State-driven Decisions**: More complex logic can be built by composing
-  operators. For example, to make an agent flee when its health is low, we would
-  `join` entities with their `Health` component, `filter` for those where
+  operators. For example, to make an agent flee when its health is low, we
+  would `join` entities with their `Health` component, `filter` for those where
   `health < threshold`, and then `join` the result with the fleeing-behaviour
   sub-graph.
 

--- a/docs/lille-physics-engine-design.md
+++ b/docs/lille-physics-engine-design.md
@@ -79,9 +79,9 @@ The dataflow is as follows:
 2. **Floor Height Calculation**: The resulting `HighestBlockAt` stream is joined
    with `BlockSlope` data. A `map` operator then calculates the precise
    `z_floor` coordinate. Slopes are joined using the block `id` and, for now,
-   the height is evaluated at the centre of the block (`0.5, 0.5`) because the
-   entity-specific offset is not yet available. If no slope exists the floor is
-   flat one unit above the block.
+   the height is evaluated at the constant `BLOCK_CENTRE_OFFSET` (currently
+   `0.5`) because the entity-specific offset is not yet available. If no slope
+   exists the floor is flat one unit above the block.
 
 ### 3.2. Entity State: Standing vs. Unsupported
 

--- a/src/components.rs
+++ b/src/components.rs
@@ -65,8 +65,8 @@ pub struct Block {
 #[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
 pub struct BlockSlope {
     pub block_id: i64,
-    pub grad_x: OrderedFloat<f64>,
-    pub grad_y: OrderedFloat<f64>,
+    pub grad_x: OrderedFloat<f32>,
+    pub grad_y: OrderedFloat<f32>,
 }
 #[derive(Component, Debug, Clone, Default, Serialize)]
 pub struct VelocityComp {

--- a/src/components.rs
+++ b/src/components.rs
@@ -65,8 +65,8 @@ pub struct Block {
 #[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
 pub struct BlockSlope {
     pub block_id: i64,
-    pub grad_x: OrderedFloat<f32>,
-    pub grad_y: OrderedFloat<f32>,
+    pub grad_x: OrderedFloat<f64>,
+    pub grad_y: OrderedFloat<f64>,
 }
 #[derive(Component, Debug, Clone, Default, Serialize)]
 pub struct VelocityComp {

--- a/src/components.rs
+++ b/src/components.rs
@@ -1,6 +1,7 @@
 //! ECS component types used by the game.
 //! Includes identifiers, health, target positions, and unit descriptors shared between systems.
 use bevy::prelude::*;
+use ordered_float::OrderedFloat;
 use serde::Serialize;
 
 #[derive(Component, Debug, Serialize)]
@@ -45,11 +46,27 @@ pub struct Block {
     pub z: i32,
 }
 
-#[derive(Component, Debug, Clone, Serialize)]
+#[derive(
+    Archive,
+    RkyvSerialize,
+    Deserialize,
+    Component,
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Default,
+    SizeOf,
+)]
+#[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
 pub struct BlockSlope {
     pub block_id: i64,
-    pub grad_x: f32,
-    pub grad_y: f32,
+    pub grad_x: OrderedFloat<f64>,
+    pub grad_y: OrderedFloat<f64>,
 }
 #[derive(Component, Debug, Clone, Default, Serialize)]
 pub struct VelocityComp {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,3 +11,9 @@ pub const DELTA_TIME: f64 = 1.0;
 pub const DEFAULT_MASS: f64 = 70.0;
 pub const FEAR_RADIUS_MULTIPLIER: f64 = 2.0;
 pub const FEAR_THRESHOLD: f64 = 0.2;
+/// The normalised offset used to sample slopes within a block.
+///
+/// The `FloorHeightAt` calculation currently evaluates the slope at the
+/// centre of each block because entity-specific offsets are not yet
+/// available.
+pub const BLOCK_CENTRE_OFFSET: f64 = 0.5;

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -313,7 +313,19 @@ impl DbspCircuit {
         &self.block_in
     }
 
-    /// Returns a reference to the input handle for block slope records.
+    /// Returns a reference to the input handle for feeding block slope records into the circuit.
+    ///
+    /// Use this handle to supply slope gradient data for blocks, enabling
+    /// slope-aware floor height calculations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use lille::prelude::*;
+    /// let circuit = DbspCircuit::new().expect("circuit construction failed");
+    /// let slope_handle = circuit.block_slope_in();
+    /// // Feed block slope data into the circuit using `slope_handle`
+    /// ```
     pub fn block_slope_in(&self) -> &ZSetHandle<BlockSlope> {
         &self.block_slope_in
     }
@@ -369,6 +381,19 @@ impl DbspCircuit {
     }
 
     /// Returns a reference to the output handle for calculated floor heights.
+    ///
+    /// The output contains `FloorHeightAt` records representing the computed
+    /// floor height at each `(x, y)` position, incorporating block heights and
+    /// optional slope gradients.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use lille::prelude::*;
+    /// let circuit = DbspCircuit::new().expect("circuit construction failed");
+    /// let floor_heights = circuit.floor_height_out();
+    /// // Read computed floor heights from the output handle
+    /// ```
     pub fn floor_height_out(&self) -> &OutputHandle<OrdZSet<FloorHeightAt>> {
         &self.floor_height_out
     }

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -265,8 +265,7 @@ impl DbspCircuit {
                 },
                 |_, _| None,
             )
-            .filter(|fh| fh.is_some())
-            .map(|fh| fh.clone().unwrap())
+            .flat_map(|fh| fh.clone().into_iter())
     }
 
     fn new_velocity_stream(

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -192,8 +192,8 @@ impl DbspCircuit {
                             z: OrderedFloat(
                                 z as f64
                                     + 1.0
-                                    + BLOCK_CENTRE_OFFSET * grad_x.into_inner() as f64
-                                    + BLOCK_CENTRE_OFFSET * grad_y.into_inner() as f64,
+                                    + BLOCK_CENTRE_OFFSET * grad_x.into_inner()
+                                    + BLOCK_CENTRE_OFFSET * grad_y.into_inner(),
                             ),
                         })
                     },

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use bevy::prelude::*;
 use log::error;
 
-use crate::components::{Block, DdlogId, VelocityComp};
+use crate::components::{Block, BlockSlope, DdlogId, VelocityComp};
 use crate::dbsp_circuit::{DbspCircuit, Position, Velocity};
 
 /// Bevy plugin that wires the DBSP circuit into the app.
@@ -78,10 +78,13 @@ pub fn init_dbsp_system(world: &mut World) -> Result<(), dbsp::Error> {
 pub fn cache_state_for_dbsp_system(
     mut state: NonSendMut<DbspState>,
     entity_query: Query<(Entity, &DdlogId, &Transform, Option<&VelocityComp>)>,
-    block_query: Query<&Block>,
+    block_query: Query<(&Block, Option<&BlockSlope>)>,
 ) {
-    for block in &block_query {
+    for (block, slope) in &block_query {
         state.circuit.block_in().push(block.clone(), 1);
+        if let Some(s) = slope {
+            state.circuit.block_slope_in().push(s.clone(), 1);
+        }
     }
 
     state.id_map.clear();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub use constants::*;
 // Re-export commonly used items
 pub use actor::Actor;
 pub use components::{DdlogId, Health, Target, UnitType, VelocityComp};
-pub use dbsp_circuit::{DbspCircuit, HighestBlockAt, NewPosition, Position};
+pub use dbsp_circuit::{DbspCircuit, FloorHeightAt, HighestBlockAt, NewPosition, Position};
 pub use dbsp_circuit::{NewVelocity, Velocity};
 pub use dbsp_sync::{
     apply_dbsp_outputs_system, cache_state_for_dbsp_system, init_dbsp_system, DbspPlugin,
@@ -38,6 +38,7 @@ pub mod prelude {
     pub use crate::components::Block;
     pub use crate::DbspCircuit;
     pub use crate::DbspPlugin;
+    pub use crate::FloorHeightAt;
     pub use crate::Velocity;
     pub use ordered_float::OrderedFloat;
 }

--- a/src/world_handle.rs
+++ b/src/world_handle.rs
@@ -61,8 +61,8 @@ impl WorldHandle {
     pub fn floor_height_at(block: &Block, slope: Option<&BlockSlope>, x: f32, y: f32) -> f32 {
         let base = block.z as f32 + 1.0;
         if let Some(s) = slope {
-            base + (x - block.x as f32) * s.grad_x.into_inner()
-                + (y - block.y as f32) * s.grad_y.into_inner()
+            base + (x - block.x as f32) * s.grad_x.into_inner() as f32
+                + (y - block.y as f32) * s.grad_y.into_inner() as f32
         } else {
             base
         }

--- a/src/world_handle.rs
+++ b/src/world_handle.rs
@@ -61,7 +61,8 @@ impl WorldHandle {
     pub fn floor_height_at(block: &Block, slope: Option<&BlockSlope>, x: f32, y: f32) -> f32 {
         let base = block.z as f32 + 1.0;
         if let Some(s) = slope {
-            base + (x - block.x as f32) * s.grad_x + (y - block.y as f32) * s.grad_y
+            base + (x - block.x as f32) * s.grad_x.into_inner() as f32
+                + (y - block.y as f32) * s.grad_y.into_inner() as f32
         } else {
             base
         }

--- a/src/world_handle.rs
+++ b/src/world_handle.rs
@@ -61,8 +61,8 @@ impl WorldHandle {
     pub fn floor_height_at(block: &Block, slope: Option<&BlockSlope>, x: f32, y: f32) -> f32 {
         let base = block.z as f32 + 1.0;
         if let Some(s) = slope {
-            base + (x - block.x as f32) * s.grad_x.into_inner() as f32
-                + (y - block.y as f32) * s.grad_y.into_inner() as f32
+            base + (x - block.x as f32) * s.grad_x.into_inner()
+                + (y - block.y as f32) * s.grad_y.into_inner()
         } else {
             base
         }

--- a/src/world_handle.rs
+++ b/src/world_handle.rs
@@ -59,12 +59,14 @@ impl WorldHandle {
     }
 
     pub fn floor_height_at(block: &Block, slope: Option<&BlockSlope>, x: f32, y: f32) -> f32 {
-        let base = block.z as f32 + 1.0;
+        let base = block.z as f64 + 1.0;
         if let Some(s) = slope {
-            base + (x - block.x as f32) * s.grad_x.into_inner() as f32
-                + (y - block.y as f32) * s.grad_y.into_inner() as f32
+            let height = base
+                + (x as f64 - block.x as f64) * s.grad_x.into_inner()
+                + (y as f64 - block.y as f64) * s.grad_y.into_inner();
+            height as f32
         } else {
-            base
+            base as f32
         }
     }
 

--- a/tests/dbsp_floor_height.rs
+++ b/tests/dbsp_floor_height.rs
@@ -12,8 +12,8 @@ fn blk(id: i64, x: i32, y: i32, z: i32) -> Block {
 fn slope(block_id: i64, gx: f32, gy: f32) -> BlockSlope {
     BlockSlope {
         block_id,
-        grad_x: (gx as f64).into(),
-        grad_y: (gy as f64).into(),
+        grad_x: gx.into(),
+        grad_y: gy.into(),
     }
 }
 

--- a/tests/dbsp_floor_height.rs
+++ b/tests/dbsp_floor_height.rs
@@ -27,6 +27,9 @@ fn fh(x: i32, y: i32, z: f64) -> FloorHeightAt {
 #[case(vec![blk(1,0,0,0), blk(2,0,0,1)], vec![], vec![fh(0,0,2.0)])] // highest block wins
 #[case(vec![blk(1,0,0,0)], vec![slope(1,-1.0,0.0)], vec![fh(0,0,0.5)])] // negative slope
 #[case(vec![blk(1,0,0,0)], vec![slope(1,0.0,0.0)], vec![fh(0,0,1.0)])] // zero slope
+#[case(vec![blk(1,-1,-1,0)], vec![slope(1,1.0,1.0)], vec![fh(-1,-1,2.0)])] // negative coordinates
+#[case(vec![blk(1,0,0,0)], vec![slope(1,100.0,100.0)], vec![fh(0,0,101.0)])] // large gradients
+#[case(vec![blk(1,0,0,0), blk(2,0,0,1)], vec![slope(1,1.0,0.0), slope(2,0.0,1.0)], vec![fh(0,0,2.5)])] // multiple slopes, highest wins
 fn floor_height_cases(
     #[case] blocks: Vec<Block>,
     #[case] slopes: Vec<BlockSlope>,

--- a/tests/dbsp_floor_height.rs
+++ b/tests/dbsp_floor_height.rs
@@ -9,7 +9,7 @@ fn blk(id: i64, x: i32, y: i32, z: i32) -> Block {
     Block { id, x, y, z }
 }
 
-fn slope(block_id: i64, gx: f32, gy: f32) -> BlockSlope {
+fn slope(block_id: i64, gx: f64, gy: f64) -> BlockSlope {
     BlockSlope {
         block_id,
         grad_x: gx.into(),
@@ -24,6 +24,9 @@ fn fh(x: i32, y: i32, z: f64) -> FloorHeightAt {
 #[rstest]
 #[case(vec![blk(1,0,0,0)], vec![], vec![fh(0,0,1.0)])]
 #[case(vec![blk(1,0,0,0)], vec![slope(1,1.0,0.0)], vec![fh(0,0,1.5)])]
+#[case(vec![blk(1,0,0,0), blk(2,0,0,1)], vec![], vec![fh(0,0,2.0)])] // highest block wins
+#[case(vec![blk(1,0,0,0)], vec![slope(1,-1.0,0.0)], vec![fh(0,0,0.5)])] // negative slope
+#[case(vec![blk(1,0,0,0)], vec![slope(1,0.0,0.0)], vec![fh(0,0,1.0)])] // zero slope
 fn floor_height_cases(
     #[case] blocks: Vec<Block>,
     #[case] slopes: Vec<BlockSlope>,

--- a/tests/dbsp_floor_height.rs
+++ b/tests/dbsp_floor_height.rs
@@ -1,0 +1,50 @@
+use lille::{
+    components::{Block, BlockSlope},
+    dbsp_circuit::FloorHeightAt,
+};
+mod common;
+use rstest::rstest;
+
+fn blk(id: i64, x: i32, y: i32, z: i32) -> Block {
+    Block { id, x, y, z }
+}
+
+fn slope(block_id: i64, gx: f32, gy: f32) -> BlockSlope {
+    BlockSlope {
+        block_id,
+        grad_x: (gx as f64).into(),
+        grad_y: (gy as f64).into(),
+    }
+}
+
+fn fh(x: i32, y: i32, z: f64) -> FloorHeightAt {
+    FloorHeightAt { x, y, z: z.into() }
+}
+
+#[rstest]
+#[case(vec![blk(1,0,0,0)], vec![], vec![fh(0,0,1.0)])]
+#[case(vec![blk(1,0,0,0)], vec![slope(1,1.0,0.0)], vec![fh(0,0,1.5)])]
+fn floor_height_cases(
+    #[case] blocks: Vec<Block>,
+    #[case] slopes: Vec<BlockSlope>,
+    #[case] expected: Vec<FloorHeightAt>,
+) {
+    let mut circuit = common::new_circuit();
+    for b in &blocks {
+        circuit.block_in().push(b.clone(), 1);
+    }
+    for s in &slopes {
+        circuit.block_slope_in().push(s.clone(), 1);
+    }
+    circuit.step().expect("step");
+    let mut vals: Vec<FloorHeightAt> = circuit
+        .floor_height_out()
+        .consolidate()
+        .iter()
+        .map(|(fh, _, _)| fh.clone())
+        .collect();
+    vals.sort_by_key(|h| (h.x, h.y));
+    let mut exp = expected;
+    exp.sort_by_key(|h| (h.x, h.y));
+    assert_eq!(vals, exp);
+}

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -1,3 +1,7 @@
+//! Behavioural tests validating slope-aware floor height calculations.
+//!
+//! These rspec-style tests build a single-threaded DBSP circuit and verify
+//! that block slopes modify the computed ground height as expected.
 use lille::{
     components::{Block, BlockSlope},
     dbsp_circuit::FloorHeightAt,

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -31,7 +31,7 @@ impl Default for Env {
 
 impl Env {
     fn push(&self, block: Block, slope: Option<BlockSlope>) {
-        let c = &mut *self.circuit.lock().unwrap();
+        let c = &mut *self.circuit.lock().expect("mutex poisoned");
         c.block_in().push(block, 1);
         if let Some(s) = slope {
             c.block_slope_in().push(s, 1);
@@ -39,11 +39,15 @@ impl Env {
     }
 
     fn step(&self) {
-        self.circuit.lock().unwrap().step().unwrap();
+        self.circuit
+            .lock()
+            .expect("mutex poisoned")
+            .step()
+            .expect("step failed");
     }
 
     fn output(&self) -> Vec<FloorHeightAt> {
-        let mut c = self.circuit.lock().unwrap();
+        let mut c = self.circuit.lock().expect("mutex poisoned");
         let vals: Vec<_> = c
             .floor_height_out()
             .consolidate()
@@ -71,8 +75,8 @@ fn slope_block_outputs_height() {
                     },
                     Some(BlockSlope {
                         block_id: 1,
-                        grad_x: 1.0f32.into(),
-                        grad_y: 0.0f32.into(),
+                        grad_x: 1.0.into(),
+                        grad_y: 0.0.into(),
                     }),
                 );
                 env.step();

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -1,0 +1,93 @@
+use lille::{
+    components::{Block, BlockSlope},
+    dbsp_circuit::FloorHeightAt,
+    DbspCircuit,
+};
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+#[allow(clippy::arc_with_non_send_sync)]
+struct Env {
+    circuit: Arc<Mutex<DbspCircuit>>,
+}
+
+unsafe impl Send for Env {}
+unsafe impl Sync for Env {}
+
+impl fmt::Debug for Env {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Env").finish()
+    }
+}
+
+impl Default for Env {
+    fn default() -> Self {
+        #[allow(clippy::arc_with_non_send_sync)]
+        let circuit = Arc::new(Mutex::new(DbspCircuit::new().expect("c")));
+        Self { circuit }
+    }
+}
+
+impl Env {
+    fn push(&self, block: Block, slope: Option<BlockSlope>) {
+        let c = &mut *self.circuit.lock().unwrap();
+        c.block_in().push(block, 1);
+        if let Some(s) = slope {
+            c.block_slope_in().push(s, 1);
+        }
+    }
+
+    fn step(&self) {
+        self.circuit.lock().unwrap().step().unwrap();
+    }
+
+    fn output(&self) -> Vec<FloorHeightAt> {
+        let mut c = self.circuit.lock().unwrap();
+        let vals: Vec<_> = c
+            .floor_height_out()
+            .consolidate()
+            .iter()
+            .map(|(fh, _, _)| fh.clone())
+            .collect();
+        c.clear_inputs();
+        vals
+    }
+}
+
+#[test]
+fn slope_block_outputs_height() {
+    rspec::run(&rspec::given(
+        "a block with a slope",
+        Env::default(),
+        |ctx| {
+            ctx.before_each(|env| {
+                env.push(
+                    Block {
+                        id: 1,
+                        x: 0,
+                        y: 0,
+                        z: 0,
+                    },
+                    Some(BlockSlope {
+                        block_id: 1,
+                        grad_x: 1.0f64.into(),
+                        grad_y: 0.0f64.into(),
+                    }),
+                );
+                env.step();
+            });
+            ctx.then("floor height reflects the slope", |env| {
+                let out = env.output();
+                assert_eq!(
+                    out,
+                    vec![FloorHeightAt {
+                        x: 0,
+                        y: 0,
+                        z: 1.5.into()
+                    }]
+                );
+            });
+        },
+    ));
+}

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -12,10 +12,10 @@ struct Env {
     circuit: Arc<Mutex<DbspCircuit>>,
 }
 
-// SAFETY: The tests execute in a single-threaded context but rspec requires
-// `Send + Sync` bounds for the environment. `DbspCircuit` itself is not
-// thread-safe, so we guard access with a `Mutex` and only use it on one thread.
-// This guarantees safety despite the manual `Send`/`Sync` implementations.
+// SAFETY: `DbspCircuit` is not `Send` or `Sync` due to its use of `Rc`.
+// The tests execute entirely on a single thread, and access to the circuit is
+// serialised through a `Mutex`. This guarantees that no two threads can access
+// the circuit concurrently, so manually implementing these traits is sound.
 unsafe impl Send for Env {}
 unsafe impl Sync for Env {}
 

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -71,8 +71,8 @@ fn slope_block_outputs_height() {
                     },
                     Some(BlockSlope {
                         block_id: 1,
-                        grad_x: 1.0f64.into(),
-                        grad_y: 0.0f64.into(),
+                        grad_x: 1.0f32.into(),
+                        grad_y: 0.0f32.into(),
                     }),
                 );
                 env.step();

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -28,7 +28,9 @@ impl fmt::Debug for Env {
 impl Default for Env {
     fn default() -> Self {
         #[allow(clippy::arc_with_non_send_sync)]
-        let circuit = Arc::new(Mutex::new(DbspCircuit::new().expect("c")));
+        let circuit = Arc::new(Mutex::new(
+            DbspCircuit::new().expect("Failed to create DbspCircuit"),
+        ));
         Self { circuit }
     }
 }


### PR DESCRIPTION
## Summary
- calculate `FloorHeightAt` from highest block and optional slope
- expose slope input/output in DBSP circuit
- sync `BlockSlope` components into the circuit
- document block-centre slope calculation
- test floor height logic with `rstest` and `rspec`
- mark roadmap task as done

## Testing
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6881812ec5b4832281b71773665f9a54

## Summary by Sourcery

Implement floor height calculation in the DBSP circuit with support for optional block slopes, introduce FloorHeightAt type and corresponding I/O handles, update components and world helper, refresh documentation, and add tests for flat and sloped surfaces.

New Features:
- Add FloorHeightAt type to represent computed floor heights with slope support
- Calculate floor height by joining highest block data with optional BlockSlope gradients

Enhancements:
- Expose BlockSlope input and FloorHeightAt output handles in DbspCircuit
- Update BlockSlope component to use OrderedFloat<f64> and derive additional traits
- Add world_handle helper for computing floor height with slopes

Documentation:
- Document centre-of-block slope-based height calculation in design guide
- Mark FloorHeightAt task as completed in the roadmap

Tests:
- Add rstest and rspec tests covering flat and sloped floor height computations