### PR TITLE
Refactor floor height stream

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -17,3 +17,5 @@ pub const FEAR_THRESHOLD: f64 = 0.2;
 /// centre of each block because entity-specific offsets are not yet
 /// available.
 pub const BLOCK_CENTRE_OFFSET: f64 = 0.5;
+/// Offset from a block's base to its top face.
+pub const BLOCK_TOP_OFFSET: f64 = 1.0;

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -245,22 +245,22 @@ impl DbspCircuit {
             .outer_join(
                 &slopes.map_index(|bs| (bs.block_id, (bs.grad_x, bs.grad_y))),
                 |_, &(x, y, z), &(grad_x, grad_y)| {
+                    let base = z as f64 + 1.0;
                     Some(FloorHeightAt {
                         x,
                         y,
                         z: OrderedFloat(
-                            z as f64
-                                + 1.0
-                                + BLOCK_CENTRE_OFFSET * grad_x.into_inner()
+                            base + BLOCK_CENTRE_OFFSET * grad_x.into_inner()
                                 + BLOCK_CENTRE_OFFSET * grad_y.into_inner(),
                         ),
                     })
                 },
                 |_, &(x, y, z)| {
+                    let base = z as f64 + 1.0;
                     Some(FloorHeightAt {
                         x,
                         y,
-                        z: OrderedFloat(z as f64 + 1.0),
+                        z: OrderedFloat(base),
                     })
                 },
                 |_, _| None,


### PR DESCRIPTION
## Summary
- simplify floor height calculations by reusing a `base` value

## Testing
- `make fmt`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6884eb3d197c832299c4c1eab7bd1f52

## Summary by Sourcery

Enhancements:
- Refactor floor height stream to compute the base height once and reuse it for all calculations