### PR TITLE
Add inline hint for block_top

### DIFF
--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -236,6 +236,7 @@ impl DbspCircuit {
             })
     }
 
+    #[inline]
     fn block_top(z: i32) -> f64 {
         z as f64 + BLOCK_TOP_OFFSET
     }

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -236,6 +236,7 @@ impl DbspCircuit {
             })
     }
 
+    /// Returns the world height at the top face of a block.
     #[inline]
     fn block_top(z: i32) -> f64 {
         z as f64 + BLOCK_TOP_OFFSET


### PR DESCRIPTION
## Summary
- mark the `block_top` helper with `#[inline]` to allow the compiler to inline it

## Testing
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688524470a74832286819baf0998a0a1

## Summary by Sourcery

Enhancements:
- Add #[inline] attribute to block_top helper to allow inlining by the compiler