### PR TITLE
Implement Position-Floor join in DBSP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@
 - **Clarity over cleverness.** Be concise, but favour explicit over terse or
   obscure idioms. Prefer code that's easy to follow.
 - **Use functions and composition.** Avoid repetition by extracting reusable
-  logic. Prefer generators or comprehensions, and declarative code to imperative
-  repetition when readable.
+  logic. Prefer generators or comprehensions, and declarative code to
+  imperative repetition when readable.
 - **Small, meaningful functions.** Functions must be small, clear in purpose,
   single responsibility, and obey command/query segregation.
 - **Clear commit messages.** Commit messages should be descriptive, explaining
@@ -25,12 +25,14 @@
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs.
 - **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating the usage and outcome of the function. Test documentation
-  should omit examples where the example serves only to reiterate the test logic.
-- **Keep file size managable.** No single code file may be longer than 400 lines.
+  examples demonstrating the usage and outcome of the function. Test
+  documentation should omit examples where the example serves only to reiterate
+  the test logic.
+- **Keep file size managable.** No single code file may be longer than 400
+  lines.
   Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be moved
-  to external data files.
+  constituents colocated with targets. Large blocks of test data should be
+  moved to external data files.
 
 ## Documentation Maintenance
 
@@ -42,8 +44,8 @@
   relevant file(s) in the `docs/` directory to reflect the latest state.
   **Ensure the documentation remains accurate and current.**
 - Documentation must use en-GB-oxendict ("-ize" / "-yse" / "-our") spelling
-  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which
-  is to be left unchanged for community consistency.)
+  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which is to be
+  left unchanged for community consistency.)
 
 ## Change Quality & Committing
 
@@ -153,12 +155,12 @@ project:
   specified in `Cargo.toml` must use SemVer-compatible caret requirements
   (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
   non-breaking updates to minor and patch versions while preventing breaking
-  changes from new major versions. This approach is critical for ensuring
-  build stability and reproducibility.
+  changes from new major versions. This approach is critical for ensuring build
+  stability and reproducibility.
 
 - **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden
-  as they introduce unacceptable risk and unpredictability. Tilde requirements
+  open-ended inequality (`>=`) version requirements is strictly forbidden as
+  they introduce unacceptable risk and unpredictability. Tilde requirements
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,11 +28,10 @@
   examples demonstrating the usage and outcome of the function. Test
   documentation should omit examples where the example serves only to reiterate
   the test logic.
-- **Keep file size managable.** No single code file may be longer than 400
-  lines.
-  Long switch statements or dispatch tables should be broken up by feature and
-  constituents colocated with targets. Large blocks of test data should be
-  moved to external data files.
+- **Keep file size manageable.** No single code file may be longer than 400
+  lines. Long switch statements or dispatch tables should be broken up by
+  feature and constituents colocated with targets. Large blocks of test data
+  should be moved to external data files.
 
 ## Documentation Maintenance
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
 # Lille
 
 A simple real-time strategy prototype demonstrating a dataflow-driven game loop
-with Bevy rendering. The project currently implements "Phase 1" of the migration
-roadmap, synchronizing the legacy `GameWorld` state into Bevy and rendering
-static entities.
+with Bevy rendering. The project currently implements "Phase 1" of the
+migration roadmap, synchronizing the legacy `GameWorld` state into Bevy and
+rendering static entities.
 
 ## Game Setting
 
 *A fractured city of steel, brick, and neon — and your next battlefield.*
 
-A city with too many masters and too little future. Once the jewel of a vanished
-federation, its streets are now ruled by whoever can seize them — corporate
-militias, rogue syndicates, data cults, and the last vestiges of an irrelevant
-state.
+A city with too many masters and too little future. Once the jewel of a
+vanished federation, its streets are now ruled by whoever can seize them —
+corporate militias, rogue syndicates, data cults, and the last vestiges of an
+irrelevant state.
 
 The skyline tells the story: rusted iron arcades tower over flooded canals and
 cracked boulevards. Century-old stone buildings are patched with ferroglass and
@@ -21,8 +21,8 @@ of expansion, their data relays and skyways flickering with black market
 signals.
 
 Beneath this decaying grandeur, commerce thrives in the margins. Street-level
-markets sprawl through abandoned plazas; encrypted auction houses operate out of
-gutted tram stations. Every corner offers a new opportunity — or an ambush.
+markets sprawl through abandoned plazas; encrypted auction houses operate out
+of gutted tram stations. Every corner offers a new opportunity — or an ambush.
 
 Here, real power belongs to those who can move fastest, strike hardest, and
 control the flow of information. Squads operate in the open, armed, and

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,8 +23,8 @@ model.
 
 ## 2. Core Components and Data Flow
 
-The engine operates in a continuous, unidirectional data-flow loop that executes
-on every simulation tick.
+The engine operates in a continuous, unidirectional data-flow loop that
+executes on every simulation tick.
 
 ```text
 +--------------------------------+      +----------------------------------+
@@ -46,16 +46,16 @@ on every simulation tick.
 ### The Tick Cycle
 
 1. **Data Extraction (ECS → DBSP)**: A set of dedicated Bevy "input systems" run
-   at the beginning of the frame. They query the ECS for all components relevant
-   to the simulation logic (e.g., `Transform`, `Velocity`, `Block`, `Target`).
-   This data is collected and fed as a batch of updates into the corresponding
-   `InputHandle`s of the DBSP circuit.
+   at the beginning of the frame. They query the ECS for all components
+   relevant to the simulation logic (e.g., `Transform`, `Velocity`, `Block`,
+   `Target`). This data is collected and fed as a batch of updates into the
+   corresponding `InputHandle`s of the DBSP circuit.
 
 2. **Declarative Computation (DBSP)**: A central system calls `circuit.step()`
    exactly once. This single function call triggers DBSP to process the entire
    batch of input changes. The engine incrementally propagates these changes
-   through the dataflow graph, re-computing only what is necessary. This step is
-   where all physics calculations, geometry checks, and AI decisions occur,
+   through the dataflow graph, re-computing only what is necessary. This step
+   is where all physics calculations, geometry checks, and AI decisions occur,
    resulting in a new set of output streams.
 
 3. **State Synchronisation (DBSP → ECS)**: A final set of Bevy "output systems"
@@ -81,8 +81,8 @@ The DBSP circuit is the ideal place for any logic that is **relational** and
   gravity, friction, and force application.
 
 - **Simple, Reactive AI**: Agent behaviours that can be expressed as direct
-  reactions to the current state, such as fleeing from a source of fear, seeking
-  a target, or responding to damage.
+  reactions to the current state, such as fleeing from a source of fear,
+  seeking a target, or responding to damage.
 
 - **Game Rules**: Any rule that can be modelled as a data transformation, such
   as "if an entity is standing on a 'lava' block, create a `Damage` event".
@@ -102,8 +102,8 @@ event-driven.
   dataflow model. The canonical example is **A\* pathfinding**, which requires
   maintaining stateful data structures (open/closed sets, priority queues) and
   performing iterative, heuristic searches. Such algorithms are implemented in
-  standard Rust, and their *results* (e.g., the next waypoint on a path) are fed
-  into the DBSP circuit as just another input stream.
+  standard Rust, and their *results* (e.g., the next waypoint on a path) are
+  fed into the DBSP circuit as just another input stream.
 
 ## 4. Advantages of this Architecture
 

--- a/docs/bevy-headless-testing.md
+++ b/docs/bevy-headless-testing.md
@@ -6,23 +6,24 @@ The Bevy Engine, a refreshingly simple data-driven game engine built in Rust,
 leverages an Entity Component System (ECS) architecture to facilitate modular
 and performant game development.1 In modern software development, particularly
 within the context of game development where complexity can escalate rapidly,
-automated testing is an indispensable practice. Integrating automated tests into
-Continuous Integration/Continuous Deployment (CI/CD) pipelines ensures that new
-changes do not introduce regressions and that the codebase remains robust and
-maintainable over time.3
+automated testing is an indispensable practice. Integrating automated tests
+into Continuous Integration/Continuous Deployment (CI/CD) pipelines ensures
+that new changes do not introduce regressions and that the codebase remains
+robust and maintainable over time.3
 
 Testing game logic, however, often presents unique challenges, especially when
 graphical output or windowing systems are involved. Running tests in a headless
 environment—that is, without a visible window or direct GPU rendering
-output—offers a way to circumvent these challenges, allowing for focused testing
-of game systems and logic in automated CI environments. This report provides a
-comprehensive guide to implementing various testing strategies for Bevy
-applications in Rust, with a specific focus on leveraging headless mode within a
-CI framework. It will cover the foundational setup for headless testing, core
-techniques for testing systems and components, methods for crafting effective
-test scenarios by manipulating states, inputs, and time, advanced strategies
-such as snapshot testing and Test-Driven Development (TDD), and best practices
-for integrating these tests into CI pipelines like GitHub Actions.
+output—offers a way to circumvent these challenges, allowing for focused
+testing of game systems and logic in automated CI environments. This report
+provides a comprehensive guide to implementing various testing strategies for
+Bevy applications in Rust, with a specific focus on leveraging headless mode
+within a CI framework. It will cover the foundational setup for headless
+testing, core techniques for testing systems and components, methods for
+crafting effective test scenarios by manipulating states, inputs, and time,
+advanced strategies such as snapshot testing and Test-Driven Development (TDD),
+and best practices for integrating these tests into CI pipelines like GitHub
+Actions.
 
 ## 2. Setting Up Bevy for Headless Testing in CI
 
@@ -31,16 +32,16 @@ testing in CI environments where graphical output is typically unavailable or
 undesirable. Headless mode allows the Bevy application to run its core logic,
 update systems, and manage its ECS world without attempting to create a window
 or render to a screen.4 This is particularly useful for integration tests that
-simulate application behavior without the overhead and flakiness associated with
-UI rendering.
+simulate application behavior without the overhead and flakiness associated
+with UI rendering.
 
 To configure a Bevy application for headless operation, modifications to the
 `RenderPlugin` are necessary. The key is to instruct Bevy's rendering backend,
-which relies on WGPU, to not initialize any specific presentation backends. This
-is achieved by setting the `backends` field within `WgpuSettings` to `None`.
-Additionally, ensuring synchronous pipeline compilation can make test execution
-more deterministic. The following code illustrates the setup within a Bevy
-`App`:
+which relies on WGPU, to not initialize any specific presentation backends.
+This is achieved by setting the `backends` field within `WgpuSettings` to
+`None`. Additionally, ensuring synchronous pipeline compilation can make test
+execution more deterministic. The following code illustrates the setup within a
+Bevy `App`:
 
 ```rust
 use bevy::prelude::*;
@@ -75,9 +76,9 @@ distinction is important: headless tests configured this way are excellent for
 verifying game logic and system interactions that may depend on render-related
 data structures being present, but they may not capture issues related to
 specific GPU vendor quirks or driver bugs that only manifest during actual
-rendering and presentation to a display. For projects where high visual fidelity
-and rendering correctness are paramount, these headless tests should be
-complemented by some form of on-target visual testing, even if executed less
+rendering and presentation to a display. For projects where high visual
+fidelity and rendering correctness are paramount, these headless tests should
+be complemented by some form of on-target visual testing, even if executed less
 frequently. The community project `bevy_geppetto`, for instance, has noted a
 long-term interest in capturing and comparing visual output, which aligns with
 this need for broader testing coverage.5
@@ -86,9 +87,9 @@ The setting `synchronous_pipeline_compilation: true` is also beneficial for CI
 environments.4 In a typical game loop, asynchronous shader compilation can
 improve performance by not blocking the main thread. However, for tests,
 determinism is paramount. Synchronous compilation ensures that all shader
-processing is completed before the application proceeds, eliminating a potential
-source of variability in test execution times or states, especially if tests
-depend on render state being fully established.
+processing is completed before the application proceeds, eliminating a
+potential source of variability in test execution times or states, especially
+if tests depend on render state being fully established.
 
 When choosing which plugins to include, `DefaultPlugins` (modified as shown)
 provides an environment closer to the actual game, including essential
@@ -103,8 +104,8 @@ initialization. However, for most integration-style tests, the modified
 
 The core of testing Bevy applications lies in verifying the behavior of its
 systems and the state of its components within the ECS framework. Bevy's
-architecture lends itself well to a structured testing approach where individual
-pieces of logic can be instantiated and examined with relative ease.
+architecture lends itself well to a structured testing approach where
+individual pieces of logic can be instantiated and examined with relative ease.
 
 The fundamental workflow for testing systems or component interactions begins
 with creating an instance of `App`: `let mut app = App::new();`.6 This `App`
@@ -131,9 +132,9 @@ App's World.
 
 Entity and Component Setup:
 
-Tests often require specific entities with particular components to exist in the
-world. These are spawned using app.world_mut(): let entity_id =
-app.world_mut().spawn(MyComponent { /\*... \*/ }).id();.6 For more complex or
+Tests often require specific entities with particular components to exist in
+the world. These are spawned using app.world_mut(): let entity_id =
+app.world_mut().spawn(MyComponent { /\*… \*/ }).id();.6 For more complex or
 common entity configurations, Bevy's Bundle trait can be used to group
 components, simplifying setup.2
 
@@ -208,31 +209,31 @@ fn test_movement() {
 }
 ```
 
-This common pattern of `App::new() -> setup -> app.update() -> assert` 2 creates
-a highly controlled "micro-loop" for testing game logic. This capability is a
-direct consequence of Bevy's architectural design, where the `App` and `World`
-are central, programmatically manipulable constructs. The explicit
-`app.update()` call drives registered systems through their schedules, allowing
-tests to precisely control the execution flow and make assertions on a
+This common pattern of `App::new() -> setup -> app.update() -> assert` 2
+creates a highly controlled "micro-loop" for testing game logic. This
+capability is a direct consequence of Bevy's architectural design, where the
+`App` and `World` are central, programmatically manipulable constructs. The
+explicit `app.update()` call drives registered systems through their schedules,
+allowing tests to precisely control the execution flow and make assertions on a
 well-defined world state after a specific number of "game ticks." This
-fine-grained control contrasts with testing in some other game engines where the
-main loop might be more opaque, or systems could be tightly coupled to engine
-singletons, necessitating more complex mocking.
+fine-grained control contrasts with testing in some other game engines where
+the main loop might be more opaque, or systems could be tightly coupled to
+engine singletons, necessitating more complex mocking.
 
 Consequently, developers can write very focused tests for individual systems or
 small groups of interacting systems with minimal boilerplate code. This
 encourages a testing approach akin to unit testing for game logic, which can
-significantly improve code quality and reduce the likelihood of regressions. The
-inherent modularity of Bevy's ECS, which allows for the easy addition and
+significantly improve code quality and reduce the likelihood of regressions.
+The inherent modularity of Bevy's ECS, which allows for the easy addition and
 removal of systems, resources, and entities on a per-test basis 2, is
 fundamental to achieving this level of test isolation and control.
 
 ## 4. Crafting Effective Test Scenarios
 
-Beyond testing individual systems in isolation, effective testing often requires
-simulating more complex scenarios involving state changes, user inputs, and the
-passage of time. Bevy provides mechanisms to control these aspects
-programmatically, enabling robust scenario-based testing.
+Beyond testing individual systems in isolation, effective testing often
+requires simulating more complex scenarios involving state changes, user
+inputs, and the passage of time. Bevy provides mechanisms to control these
+aspects programmatically, enabling robust scenario-based testing.
 
 ### 4.1. Leveraging Bevy States for Test Isolation
 
@@ -259,7 +260,8 @@ is active.
   components.10 Entities spawned with such a component are automatically
   despawned when the application exits the specified state. This greatly
   simplifies cleanup logic in tests. For example:
-  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`.
+  `commands.spawn((Name::new("TestPlayer"), StateScoped(GameState::InGame), PlayerComponent));`
+  .
 
 - **Programmatic State Transitions:** Tests can trigger state changes by
   modifying the `NextState<MyTestState>` resource:
@@ -331,10 +333,10 @@ for several frames, release), one would modify the input resource and call
 `app.update()` iteratively.
 
 The resource-based nature of Bevy's input system is a significant advantage for
-testability. Systems consuming input data do not need to be aware of whether the
-`ButtonInput` resource was populated by actual hardware events or by test code;
-they only interact with its current state. This design avoids the need for
-complex mocking of hardware event loops or platform-specific input APIs.
+testability. Systems consuming input data do not need to be aware of whether
+the `ButtonInput` resource was populated by actual hardware events or by test
+code; they only interact with its current state. This design avoids the need
+for complex mocking of hardware event loops or platform-specific input APIs.
 Consequently, testing game controls, UI interactions, and any logic contingent
 on discrete or continuous input states is greatly simplified, facilitating the
 achievement of high test coverage for player-facing mechanics.
@@ -374,13 +376,13 @@ The abstraction provided by `Time<Virtual>` is fundamental for creating
 deterministic and efficient tests for time-sensitive game logic, such as
 animations, cooldowns, or physics updates. It allows the test environment to
 dictate the passage of "game time," irrespective of the actual execution speed
-of the test machine or CI runner. This means gameplay mechanics that unfold over
-several seconds or minutes in real gameplay, like a 10-second ability cooldown,
-can be tested in milliseconds by controlling how `Time<Virtual>` is advanced or
-by iterating `app.update()` an appropriate number of times. Understanding the
-relationship between `Time<Virtual>`, `Time<Fixed>`, and the `app.update()`
-mechanism is key to accurately simulating time for systems operating in
-different Bevy schedules.
+of the test machine or CI runner. This means gameplay mechanics that unfold
+over several seconds or minutes in real gameplay, like a 10-second ability
+cooldown, can be tested in milliseconds by controlling how `Time<Virtual>` is
+advanced or by iterating `app.update()` an appropriate number of times.
+Understanding the relationship between `Time<Virtual>`, `Time<Fixed>`, and the
+`app.update()` mechanism is key to accurately simulating time for systems
+operating in different Bevy schedules.
 
 ## 5. Advanced Testing Strategies for Bevy
 
@@ -398,20 +400,20 @@ against this baseline. Deviations from the snapshot signal potential
 regressions.
 
 - **Data Snapshotting:** For Bevy, this typically means serializing relevant
-  components, resources, or even entire entity hierarchies into a human-readable
-  format like RON (Rusty Object Notation) or JSON. Crates like `insta` 13 are
-  excellent for managing these snapshot files, automatically storing them and
-  providing easy workflows for updating them when changes are intentional. A
-  test might query for entities with specific components, collect their data,
-  serialize it, and then assert its consistency using
+  components, resources, or even entire entity hierarchies into a
+  human-readable format like RON (Rusty Object Notation) or JSON. Crates like
+  `insta` 13 are excellent for managing these snapshot files, automatically
+  storing them and providing easy workflows for updating them when changes are
+  intentional. A test might query for entities with specific components,
+  collect their data, serialize it, and then assert its consistency using
   `insta::assert_ron_snapshot!`.
 - `bevy_geppetto`**:** This proof-of-concept crate offers a specialized form of
   snapshot testing for Bevy, drawing inspiration from ideas discussed by Chad
-  Nauseam.2 Its current focus is on capturing sequences of input events during a
-  test run and serializing them (as RON files in a `snapshots/inputs`
-  directory). These recorded inputs can then be replayed in subsequent test runs
-  (`cargo test --test $TEST_NAME -- -r`) to ensure consistent behavior. It also
-  supports capturing inputs at a specified frame rate
+  Nauseam.2 Its current focus is on capturing sequences of input events during
+  a test run and serializing them (as RON files in a `snapshots/inputs`
+  directory). These recorded inputs can then be replayed in subsequent test
+  runs (`cargo test --test $TEST_NAME -- -r`) to ensure consistent behavior. It
+  also supports capturing inputs at a specified frame rate
   (`cargo test --test $TEST_NAME -- -c $FRAMES_PER_SEC`). A notable
   characteristic of `bevy_geppetto` is its requirement to run tests on the main
   thread, often due to dependencies like `winit` that have main-thread
@@ -429,17 +431,18 @@ regressions.
   different hardware or driver versions, and the complexity of managing updates.
 
 The emergence of tools like `bevy_geppetto` 5 and the expressed interest in
-visual snapshotting reflect a maturing testing ecosystem around Bevy. Developers
-are seeking more comprehensive methods for regression testing that go beyond
-simple value assertions, aiming for techniques common in other domains like web
-development (e.g., Jest's snapshot testing, visual diffing tools). Input
-recording and replaying, as facilitated by `bevy_geppetto`, is a step towards
-testing emergent behaviors that arise from complex interactions over simulated
-time. While powerful, snapshot tests, particularly visual ones, demand careful
-management regarding the updating of snapshots and handling minor, acceptable
-differences. Data snapshots are generally more robust and easier to integrate
-into CI workflows. The main-thread requirement noted for `bevy_geppetto` 5 is a
-practical constraint that CI configurations must accommodate.
+visual snapshotting reflect a maturing testing ecosystem around Bevy.
+Developers are seeking more comprehensive methods for regression testing that
+go beyond simple value assertions, aiming for techniques common in other
+domains like web development (e.g., Jest's snapshot testing, visual diffing
+tools). Input recording and replaying, as facilitated by `bevy_geppetto`, is a
+step towards testing emergent behaviors that arise from complex interactions
+over simulated time. While powerful, snapshot tests, particularly visual ones,
+demand careful management regarding the updating of snapshots and handling
+minor, acceptable differences. Data snapshots are generally more robust and
+easier to integrate into CI workflows. The main-thread requirement noted for
+`bevy_geppetto` 5 is a practical constraint that CI configurations must
+accommodate.
 
 ### 5.2. Integration Testing Complex Interactions
 
@@ -463,8 +466,8 @@ Designing effective integration tests involves:
 For example, testing a complete combat interaction might involve a
 `PlayerAttackSystem` generating a `DamageEvent`, which is then processed by a
 `HealthSystem` on an enemy entity. This could lead to the enemy's health
-dropping, potentially triggering a `DeathEvent` if health reaches zero, which in
-turn might be handled by a `LootDropSystem` and an `EnemyCleanupSystem`. The
+dropping, potentially triggering a `DeathEvent` if health reaches zero, which
+in turn might be handled by a `LootDropSystem` and an `EnemyCleanupSystem`. The
 integration test would set up the player and enemy entities, simulate the
 attack, and then verify the enemy's health reduction, the correct emission of
 death and loot events, and the eventual despawning of the enemy entity. Bevy's
@@ -493,8 +496,8 @@ are written *before* the actual application code is implemented.16 The typical
 TDD cycle is "Red-Green-Refactor":
 
 1. **Red:** Write a test that defines a desired improvement or new function.
-   This test will initially fail because the code doesn't exist or isn't correct
-   yet.
+   This test will initially fail because the code doesn't exist or isn't
+   correct yet.
 2. **Green:** Write the minimal amount of code necessary to make the test pass.
 3. **Refactor:** Clean up the newly written code (and the test code itself) for
    clarity, efficiency, and good design, ensuring all tests still pass.
@@ -520,16 +523,16 @@ that a newly spawned character entity defaults to an "idle" animation state
 after the animation system runs for the first time.16
 
 Adopting TDD in a Bevy context encourages developers to think critically about
-system interactions and data transformations from the perspective of testability
-and desired behavior *before* writing any implementation code. This process
-naturally leads to clearer, more decoupled designs because, to write a test for
-a system, its inputs (queries, resources, events) and expected outputs
+system interactions and data transformations from the perspective of
+testability and desired behavior *before* writing any implementation code. This
+process naturally leads to clearer, more decoupled designs because, to write a
+test for a system, its inputs (queries, resources, events) and expected outputs
 (component changes, new events) must be precisely defined. This forced clarity
 on a system's responsibilities and its API often results in more focused and
 less coupled code. While TDD can sometimes feel slower during rapid prototyping
-phases, which are common in game development, its benefits in terms of long-term
-maintainability and stability, especially for core game systems, can be
-substantial. The idea of "playing your tests," as mentioned in relation to
+phases, which are common in game development, its benefits in terms of
+long-term maintainability and stability, especially for core game systems, can
+be substantial. The idea of "playing your tests," as mentioned in relation to
 creating interactive test scenes 2, can be seen as a game development-friendly
 adaptation of the TDD feedback loop, allowing for both automated verification
 and interactive debugging of the feature under development.
@@ -559,20 +562,20 @@ When incorporating headless Bevy tests into this workflow, a few additional
 considerations arise:
 
 - **System Dependencies:** The CI runner environment must have any necessary
-  libraries for headless operation. While the `backends: None` WGPU setting aims
-  to minimize external graphics dependencies, if WGPU (or underlying graphics
-  drivers) still attempts to initialize certain low-level graphics components, a
-  minimal set of graphics libraries (e.g., Vulkan SDK components or X server
-  libraries like Xvfb on Linux for a virtual display) might be needed. Bevy's
-  own CI often uses `ubuntu-latest` runners, which generally have good support
-  for these.18
+  libraries for headless operation. While the `backends: None` WGPU setting
+  aims to minimize external graphics dependencies, if WGPU (or underlying
+  graphics drivers) still attempts to initialize certain low-level graphics
+  components, a minimal set of graphics libraries (e.g., Vulkan SDK components
+  or X server libraries like Xvfb on Linux for a virtual display) might be
+  needed. Bevy's own CI often uses `ubuntu-latest` runners, which generally
+  have good support for these.18
 
 - **Main Thread Requirement:** If tests utilize crates like `bevy_geppetto` 5 or
   otherwise have components (often related to `winit` or event loops) that
   require execution on the main thread, the standard `cargo test` invocation
   might not suffice. Such tests often need to be structured as separate
-  integration test binaries defined in `Cargo.toml` using the `[[test]]` syntax,
-  for example:
+  integration test binaries defined in `Cargo.toml` using the `[[test]]`
+  syntax, for example:
 
   ```toml
   [[test]]
@@ -596,17 +599,17 @@ configurations observed in such workflows include:
     reproducible builds, though it can increase build times compared to local
     incremental builds.
   - `CARGO_PROFILE_TEST_DEBUG: 0`, `CARGO_PROFILE_DEV_DEBUG: 0`: To control the
-    inclusion of debug information in test and development profiles, potentially
-    reducing binary sizes and compile times for CI artifacts.
+    inclusion of debug information in test and development profiles,
+    potentially reducing binary sizes and compile times for CI artifacts.
   - Specialized flags like `RUSTFLAGS` and `MIRIFLAGS` for enabling tools like
     Miri.
 - **Jobs:** A comprehensive CI setup often includes multiple jobs:
   - Basic compilation checks (`check-compiles`).
   - Extensive test runs across a matrix of configurations
     (`test-various-configs`), covering different feature flag combinations,
-    operating systems (e.g., `windows-latest`, `macos-latest`, `ubuntu-latest`),
-    and Rust toolchain versions (stable, beta, nightly). This matrix testing is
-    a best practice for ensuring broad compatibility.
+    operating systems (e.g., `windows-latest`, `macos-latest`,
+    `ubuntu-latest`), and Rust toolchain versions (stable, beta, nightly). This
+    matrix testing is a best practice for ensuring broad compatibility.
   - Execution with Miri (`miri`) to detect undefined behavior.
   - Static analysis and linting (`clippy`).
   - Code formatting checks (`rustfmt`).
@@ -615,15 +618,15 @@ configurations observed in such workflows include:
   fine-tuned, specifying paths such as `~/.cargo/bin/`,
   `~/.cargo/registry/index/`, `~/.cargo/registry/cache/`, `~/.cargo/git/db/`,
   and the project-local `target/` directory. The cache key is usually composed
-  of the operating system, Rust toolchain version, the hash of `Cargo.lock`, and
-  potentially other custom strings to ensure cache validity.18
+  of the operating system, Rust toolchain version, the hash of `Cargo.lock`,
+  and potentially other custom strings to ensure cache validity.18
 
 Bevy's own CI configuration 18 provides a battle-tested template that
 demonstrates mature practices for testing a complex Rust project. Its use of
 matrix builds to cover diverse environments, integration of Miri for memory
 safety checks, and sophisticated caching strategies are indicative of a serious
-approach to maintaining code quality and build efficiency. Developers setting up
-CI for their own Bevy projects can save significant time and avoid common
+approach to maintaining code quality and build efficiency. Developers setting
+up CI for their own Bevy projects can save significant time and avoid common
 pitfalls by referencing this existing configuration. The choice of
 `CARGO_INCREMENTAL: 0` is a common CI trade-off: it ensures more consistent
 builds at the cost of speed; projects experiencing very long CI times might
@@ -635,9 +638,9 @@ realities that the CI testing strategy must accommodate.
 ## 7. Best Practices for Writing Testable Bevy Code
 
 The ease and effectiveness of testing a Bevy application are significantly
-influenced by how the application code itself is structured. Adhering to certain
-design principles not only leads to better overall code quality but also makes
-writing unit, integration, and headless tests considerably simpler.
+influenced by how the application code itself is structured. Adhering to
+certain design principles not only leads to better overall code quality but
+also makes writing unit, integration, and headless tests considerably simpler.
 
 - **Designing Clear and Focused Components:** Components are the fundamental
   data containers in Bevy's ECS. They should ideally be plain Rust structs or
@@ -645,14 +648,14 @@ writing unit, integration, and headless tests considerably simpler.
 
   - **Granularity:** Keep components small and focused on a single, cohesive
     piece of data or concern. As a guideline, "all of the data on a component
-    should generally be accessed at once".19 This avoids overly large components
-    where only a fraction of the data is relevant to most systems, improving
-    clarity and potentially performance.
+    should generally be accessed at once".19 This avoids overly large
+    components where only a fraction of the data is relevant to most systems,
+    improving clarity and potentially performance.
   - **Behavior vs. Data:** Components should primarily hold data. Logic
-    operating on this data resides in systems. Avoid writing "anemic tests" that
-    merely check simple getters or setters on components if those components
-    encapsulate no inherent logic 20; instead, test the behavior of systems that
-    interact with these components.
+    operating on this data resides in systems. Avoid writing "anemic tests"
+    that merely check simple getters or setters on components if those
+    components encapsulate no inherent logic 20; instead, test the behavior of
+    systems that interact with these components.
   - **Specialized Components:** Utilize marker components (empty structs
     deriving `Component`) for tagging entities or filtering queries
     effectively.8 Newtype wrappers around simple types (e.g.,
@@ -660,8 +663,8 @@ writing unit, integration, and headless tests considerably simpler.
     ambiguity and enhancing type safety.8
 
 - **Effective Use of Events for Decoupled Communication:** Bevy's event system
-  is a powerful tool for enabling communication between systems without creating
-  tight coupling.10
+  is a powerful tool for enabling communication between systems without
+  creating tight coupling.10
 
   - **Decoupling:** Prefer events for signaling occurrences or passing data that
     may affect multiple, disparate parts of the game. Systems can subscribe to
@@ -685,29 +688,29 @@ writing unit, integration, and headless tests considerably simpler.
     Resources, consumed Events) and its outputs (changes to Components or
     Resources, sent Events via Commands or EventWriters) should be well-defined.
   - **Isolation:** When testing, aim to test systems in isolation or in small,
-    controlled groups. As suggested, one can "create a standalone stage with the
-    systems you want to run, and manually run it on the World".7 This aligns
-    with the idea that "ideally every test just adds the bare-minimum components
-    it needs... This is the anti-spaghetti property that makes me really love
-    ECS".2
+    controlled groups. As suggested, one can "create a standalone stage with
+    the systems you want to run, and manually run it on the World".7 This
+    aligns with the idea that "ideally every test just adds the bare-minimum
+    components it needs… This is the anti-spaghetti property that makes me
+    really love ECS".2
 
 - **Managing Entity Lifecycles and IDs:** Proper management of entity lifecycles
   is crucial for both game correctness and test hygiene.10
 
   - **Naming Entities:** Spawning top-level or significant entities with a
-    `Name` component (e.g., `Name::new("Player")`) greatly aids in debugging, as
-    it allows for easier identification of entities in logs or inspectors.
+    `Name` component (e.g., `Name::new("Player")`) greatly aids in debugging,
+    as it allows for easier identification of entities in logs or inspectors.
   - **Automated Cleanup with** `StateScoped`**:** The preferred method for
     ensuring entities are cleaned up when they are no longer relevant (e.g.,
     when exiting a game state or a test scenario) is to spawn them with a
     `StateScoped(MyState::Variant)` component. This automatically despawns the
-    entity when the application transitions out of `MyState::Variant`. This is a
-    significant improvement for test hygiene, preventing state leakage between
-    tests.
+    entity when the application transitions out of `MyState::Variant`. This is
+    a significant improvement for test hygiene, preventing state leakage
+    between tests.
   - **Strong IDs:** For entities that need to persist across game sessions
-    (e.g., through saving and loading) or be reliably referenced over a network,
-    do not rely solely on Bevy's `Entity` ID, which is ephemeral and can be
-    reused. Instead, implement custom "strong ID" types (e.g., a
+    (e.g., through saving and loading) or be reliably referenced over a
+    network, do not rely solely on Bevy's `Entity` ID, which is ephemeral and
+    can be reused. Instead, implement custom "strong ID" types (e.g., a
     `struct QuestId(u32);`) that provide stable, unique identification.
 
 - **Co-locating** `OnEnter`**/**`OnExit` **Systems for State Transitions:** When
@@ -733,8 +736,8 @@ cleanup. Similarly, the use of strong IDs enables more reliable testing of
 persistence and networking logic. Therefore, designing for testability from the
 outset by adopting these practices makes the process of writing comprehensive
 tests significantly easier and the tests themselves more robust and
-maintainable. Ignoring these principles can lead to tightly coupled code that is
-difficult to test effectively, especially in automated CI environments.2 The
+maintainable. Ignoring these principles can lead to tightly coupled code that
+is difficult to test effectively, especially in automated CI environments.2 The
 evolution of Bevy, including features like `StateScoped` entities 10,
 demonstrates a trend towards providing engine-level support for patterns that
 enhance both application structure and testability.
@@ -765,43 +768,43 @@ testing ecosystem 13 and their potential applications in Bevy testing:
 The applicability of these general-purpose Rust testing crates to Bevy projects
 underscores the strength of Rust's ecosystem and Bevy's successful integration
 within it. Developers are not confined to the testing utilities provided
-directly by Bevy but can draw upon a rich set of mature, widely-used tools. This
-allows for the construction of more sophisticated, robust, and maintainable test
-suites, tailored to the specific needs of the Bevy application being developed.
-For example, `proptest` can be invaluable for uncovering subtle bugs in complex
-game logic by exploring a wide input space, while `insta` can simplify the
-verification of intricate game states that would otherwise require numerous
-individual assertions.
+directly by Bevy but can draw upon a rich set of mature, widely-used tools.
+This allows for the construction of more sophisticated, robust, and
+maintainable test suites, tailored to the specific needs of the Bevy
+application being developed. For example, `proptest` can be invaluable for
+uncovering subtle bugs in complex game logic by exploring a wide input space,
+while `insta` can simplify the verification of intricate game states that would
+otherwise require numerous individual assertions.
 
 ## 9. Conclusion: Building Quality Bevy Applications with Confidence
 
 This guide has detailed a comprehensive array of strategies for testing Bevy
-applications in Rust, with a particular emphasis on leveraging headless mode for
-effective automation within Continuous Integration environments. Key approaches
-include the foundational setup for headless execution, techniques for testing
-individual systems and components by manipulating the `App` and `World`, methods
-for crafting effective test scenarios through the control of Bevy `States`,
-simulated inputs, and virtual time, and advanced strategies such as data-driven
-snapshot testing and the application of Test-Driven Development principles.
-Furthermore, the integration of these tests into CI pipelines, drawing from
-Bevy's own robust CI practices, and adherence to best practices for writing
-testable Bevy code have been explored.
+applications in Rust, with a particular emphasis on leveraging headless mode
+for effective automation within Continuous Integration environments. Key
+approaches include the foundational setup for headless execution, techniques
+for testing individual systems and components by manipulating the `App` and
+`World`, methods for crafting effective test scenarios through the control of
+Bevy `States`, simulated inputs, and virtual time, and advanced strategies such
+as data-driven snapshot testing and the application of Test-Driven Development
+principles. Furthermore, the integration of these tests into CI pipelines,
+drawing from Bevy's own robust CI practices, and adherence to best practices
+for writing testable Bevy code have been explored.
 
 The core message is that a disciplined and comprehensive approach to testing,
 one that fully utilizes the strengths of Bevy's Entity Component System and its
-capability for headless operation, is not merely an adjunct to development but a
-critical component for building high-quality, maintainable, and robust Bevy
+capability for headless operation, is not merely an adjunct to development but
+a critical component for building high-quality, maintainable, and robust Bevy
 applications. The modularity inherent in ECS, combined with Bevy's programmatic
-control over its execution loop, resources, and state, provides a fertile ground
-for a wide spectrum of testing methodologies.
+control over its execution loop, resources, and state, provides a fertile
+ground for a wide spectrum of testing methodologies.
 
 Automated testing, especially when integrated into CI, should be viewed as an
-enabler rather than a chore. It facilitates faster iteration cycles by providing
-rapid feedback on changes, allows for safer refactoring by guarding against
-regressions, and ultimately instills greater confidence in the development
-process. The patterns and tools discussed—from `StateScoped` entities
-simplifying test cleanup to the `Time<Virtual>` resource enabling deterministic
-testing of time-dependent logic—are available to Bevy developers.
+enabler rather than a chore. It facilitates faster iteration cycles by
+providing rapid feedback on changes, allows for safer refactoring by guarding
+against regressions, and ultimately instills greater confidence in the
+development process. The patterns and tools discussed—from `StateScoped`
+entities simplifying test cleanup to the `Time<Virtual>` resource enabling
+deterministic testing of time-dependent logic—are available to Bevy developers.
 
 The comprehensive nature of the testing strategies applicable to Bevy, ranging
 from low-level unit tests of systems to sophisticated CI automation workflows,
@@ -810,6 +813,6 @@ projects where reliability and maintainability are paramount. As the Bevy
 community continues to expand and more complex applications are developed, the
 widespread knowledge and adoption of these testing strategies will be a key
 determinant in the overall quality and success of projects within the Bevy
-ecosystem. Encouraging a "testing culture," where testing is an integral part of
-the development lifecycle, will empower developers to build with Bevy more
+ecosystem. Encouraging a "testing culture," where testing is an integral part
+of the development lifecycle, will empower developers to build with Bevy more
 confidently and effectively.

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -28,21 +28,21 @@ robust, maintainable, and understandable for the long haul.
 
 To effectively manage complexity, it is essential to measure it. Two prominent
 metrics in software engineering are Cyclomatic Complexity and Cognitive
-Complexity, each offering a distinct perspective on the challenges inherent in a
-codebase.
+Complexity, each offering a distinct perspective on the challenges inherent in
+a codebase.
 
 ### A. Cyclomatic Complexity: Measuring Testability
 
 Cyclomatic Complexity (CC), developed by Thomas J. McCabe, Sr. in 1976, is a
 quantitative measure of the number of linearly independent paths through a
-program's source code.3 It essentially quantifies the structural complexity of a
-program by counting decision points that can affect the execution flow.4 This
+program's source code.3 It essentially quantifies the structural complexity of
+a program by counting decision points that can affect the execution flow.4 This
 metric is computed using the control-flow graph of the program, where nodes
-represent indivisible groups of commands and directed edges connect nodes if one
-command can immediately follow another.3
+represent indivisible groups of commands and directed edges connect nodes if
+one command can immediately follow another.3
 
-The formula for Cyclomatic Complexity is often given as M=E−N+2P, where E is the
-number of edges, N is the number of nodes, and P is the number of connected
+The formula for Cyclomatic Complexity is often given as M=E−N+2P, where E is
+the number of edges, N is the number of nodes, and P is the number of connected
 components (typically 1 for a single program or method).3 A simpler formulation
 for a single subroutine is
 
@@ -73,8 +73,8 @@ risk categorization based on CC scores 3:
 
 Cognitive Complexity, a metric notably championed by SonarSource, addresses a
 different facet of code complexity: how difficult a piece of code is to
-intuitively read and understand by a human.1 Unlike Cyclomatic Complexity, which
-is rooted in mathematical graph theory, Cognitive Complexity aims to more
+intuitively read and understand by a human.1 Unlike Cyclomatic Complexity,
+which is rooted in mathematical graph theory, Cognitive Complexity aims to more
 accurately reflect the mental effort required to comprehend the control flow of
 a unit of code.7 It acknowledges that developers spend more time reading and
 understanding code than writing it.8
@@ -95,9 +95,9 @@ Cognitive Complexity is incremented based on three main rules 8:
 3. **Shorthand Discount:** Structures that allow multiple statements to be read
    as a single unit (e.g., a well-named method call) do not incur the same
    penalties as the raw statements they encapsulate. Method calls are generally
-   "free" in terms of cognitive complexity, as a well-chosen name summarizes the
-   underlying logic, allowing readers to grasp the high-level view before diving
-   into details. Recursive calls, however, do increment the score.8
+   "free" in terms of cognitive complexity, as a well-chosen name summarizes
+   the underlying logic, allowing readers to grasp the high-level view before
+   diving into details. Recursive calls, however, do increment the score.8
 
 For instance, a `switch` statement with multiple cases might have a high
 Cyclomatic Complexity because each case represents a distinct path for testing.
@@ -110,10 +110,10 @@ Thresholds and Implications:
 
 Code with high Cognitive Complexity is harder to read, understand, test, and
 modify.8 SonarQube, for example, raises issues when a function's Cognitive
-Complexity exceeds a certain threshold, signaling that the code should likely be
-refactored into smaller, more manageable pieces.8 The primary impact of high
-Cognitive Complexity is a slowdown in development and an increase in maintenance
-costs.8
+Complexity exceeds a certain threshold, signaling that the code should likely
+be refactored into smaller, more manageable pieces.8 The primary impact of high
+Cognitive Complexity is a slowdown in development and an increase in
+maintenance costs.8
 
 ### Table 1: Cyclomatic vs. Cognitive Complexity
 
@@ -189,18 +189,18 @@ The severity of a Bumpy Road can be assessed by 6:
   model).
 
 Fundamentally, a Bumpy Road signifies a function that is trying to do too many
-things, violating the Single Responsibility Principle. It acts as an obstacle to
-comprehension, forcing developers to slow down and pay meticulous attention,
+things, violating the Single Responsibility Principle. It acts as an obstacle
+to comprehension, forcing developers to slow down and pay meticulous attention,
 much like a physical bumpy road slows down driving.6
 
 ### B. How It Forms and Its Impact
 
 The Bumpy Road antipattern, like many software antipatterns, often emerges from
-development practices that prioritize short-term speed over long-term structural
-integrity.2 Rushed development cycles, lack of clear design, or cutting corners
-on maintenance can lead to the gradual accumulation of conditional logic within
-a single function.2 As new requirements or edge cases are handled, developers
-might add more
+development practices that prioritize short-term speed over long-term
+structural integrity.2 Rushed development cycles, lack of clear design, or
+cutting corners on maintenance can lead to the gradual accumulation of
+conditional logic within a single function.2 As new requirements or edge cases
+are handled, developers might add more
 
 `if` statements or loops to an existing method rather than stepping back to
 refactor and create appropriate abstractions.
@@ -227,8 +227,9 @@ The impact of this antipattern is significant:
   such code can be frustrating and demotivating.2
 
 The Bumpy Road is a strong predictor of code that is expensive to maintain and
-risky to evolve.6 It's a clear signal that the code is not well-aligned with how
-human brains process information, making it a prime candidate for refactoring.
+risky to evolve.6 It's a clear signal that the code is not well-aligned with
+how human brains process information, making it a prime candidate for
+refactoring.
 
 ## IV. Navigating and Rectifying the Bumpy Road
 
@@ -238,13 +239,13 @@ code. Identifying early warning signs is also crucial.
 
 ### A. Avoiding the Antipattern: Proactive Strategies
 
-Preventing the Bumpy Road begins with a commitment to sound software engineering
-principles from the outset.
+Preventing the Bumpy Road begins with a commitment to sound software
+engineering principles from the outset.
 
 1. **Adherence to Single Responsibility Principle (SRP):** Ensure that each
-   function or method has one clear, well-defined responsibility.8 If a function
-   starts handling multiple distinct logical blocks, it's a sign that it needs
-   to be decomposed.
+   function or method has one clear, well-defined responsibility.8 If a
+   function starts handling multiple distinct logical blocks, it's a sign that
+   it needs to be decomposed.
 
 2. **Incremental Refactoring:** Don't wait for complexity to accumulate.
    Refactor code regularly as part of the development process, not as a
@@ -263,8 +264,8 @@ principles from the outset.
    using tools like SonarQube.1 Set thresholds and address violations promptly.
 
 6. **Return Early / Guard Clauses:** To avoid deep nesting for validation or
-   pre-condition checks, process exceptional cases first and return early.8 This
-   flattens the main logic path. For example, instead of:
+   pre-condition checks, process exceptional cases first and return early.8
+   This flattens the main logic path. For example, instead of:
 
    ```cpp
    void process(Data d) {
@@ -337,8 +338,8 @@ perform auto-refactoring for certain languages.6
 
 ### C. Red Flags Portending the Bumpy Road
 
-Being vigilant for early warning signs can help prevent a minor complexity issue
-from escalating into a full-blown Bumpy Road.
+Being vigilant for early warning signs can help prevent a minor complexity
+issue from escalating into a full-blown Bumpy Road.
 
 1. **Increasing Cognitive Complexity Scores:** A rising Cognitive Complexity
    score for a method in static analysis tools is a direct indicator.8
@@ -369,46 +370,46 @@ from escalating into a full-blown Bumpy Road.
 7. **Declining Code Health Metrics:** Tools like CodeScene provide "Code Health"
    metrics which can degrade if Bumpy Roads are introduced.6
 
-By proactively addressing these red flags through disciplined refactoring, teams
-can maintain a smoother, more navigable codebase.
+By proactively addressing these red flags through disciplined refactoring,
+teams can maintain a smoother, more navigable codebase.
 
 ## V. Broader Implications and Clean Refactoring Approaches
 
-The challenges posed by high complexity and antipatterns like the Bumpy Road are
-deeply intertwined with fundamental software design principles. Understanding
-these connections and employing sophisticated refactoring techniques are key to
-building truly maintainable systems.
+The challenges posed by high complexity and antipatterns like the Bumpy Road
+are deeply intertwined with fundamental software design principles.
+Understanding these connections and employing sophisticated refactoring
+techniques are key to building truly maintainable systems.
 
 ### A. Relation to Separation of Concerns and CQRS
 
 1\. Separation of Concerns (SoC)
 
 Separation of Concerns is a design principle that advocates for dividing a
-computer program into distinct sections, where each section addresses a separate
-concern.17 A "concern" is a set of information that affects the code of a
-computer program. Modularity is achieved by encapsulating information within a
-section of code that has a well-defined interface.17
+computer program into distinct sections, where each section addresses a
+separate concern.17 A "concern" is a set of information that affects the code
+of a computer program. Modularity is achieved by encapsulating information
+within a section of code that has a well-defined interface.17
 
-The Bumpy Road antipattern is a direct violation of SoC. Each "bump" in the code
-often represents a distinct concern or responsibility that has been improperly
-co-located within a single method.6 For example, a single method might handle
-input validation, business logic processing for different cases, data
-transformation, and error handling for each case, all intermingled. Refactoring
-a Bumpy Road by extracting methods inherently applies SoC, as each extracted
-method ideally handles a single, well-defined concern.10 This leads to increased
-freedom for simplification, maintenance, module upgrade, reuse, and independent
-development.17 While SoC might introduce more interfaces and potentially more
-code to execute, the benefits in clarity and maintainability often outweigh
-these costs, especially as systems grow.17
+The Bumpy Road antipattern is a direct violation of SoC. Each "bump" in the
+code often represents a distinct concern or responsibility that has been
+improperly co-located within a single method.6 For example, a single method
+might handle input validation, business logic processing for different cases,
+data transformation, and error handling for each case, all intermingled.
+Refactoring a Bumpy Road by extracting methods inherently applies SoC, as each
+extracted method ideally handles a single, well-defined concern.10 This leads
+to increased freedom for simplification, maintenance, module upgrade, reuse,
+and independent development.17 While SoC might introduce more interfaces and
+potentially more code to execute, the benefits in clarity and maintainability
+often outweigh these costs, especially as systems grow.17
 
 Consider a function that processes different types of user commands. A Bumpy
 Road approach might have a large `if-else if-else` structure, with each block
 handling a command type and its associated logic. This mixes the concern of
-"dispatching" or "routing" based on command type with the concern of "executing"
-each specific command. Applying SoC would involve separating these: perhaps one
-component decides which command to execute, and separate components (functions
-or classes) handle the execution of each command. This separation makes the
-system easier to understand, test, and extend with new commands.
+"dispatching" or "routing" based on command type with the concern of
+"executing" each specific command. Applying SoC would involve separating these:
+perhaps one component decides which command to execute, and separate components
+(functions or classes) handle the execution of each command. This separation
+makes the system easier to understand, test, and extend with new commands.
 
 2\. Command Query Responsibility Segregation (CQRS)
 
@@ -416,8 +417,8 @@ CQRS is an architectural pattern that segregates operations that modify state
 (Commands) from operations that read state (Queries).18 Commands are task-based
 and should represent specific business intentions (e.g.,
 
-`BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries, on
-the other hand, never alter data and return Data Transfer Objects (DTOs)
+`BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries,
+on the other hand, never alter data and return Data Transfer Objects (DTOs)
 optimized for display needs.18
 
 While CQRS operates at a higher architectural level than a single Bumpy Road
@@ -447,27 +448,27 @@ together.
   methods within that class becoming Bumpy Roads. CQRS can help decompose God
   Objects by separating their command-handling responsibilities from their
   query-handling responsibilities, potentially leading to smaller, more focused
-  classes (e.g., one class for command processing, another for query processing,
-  or even finer-grained handlers).21 This separation simplifies each part,
-  making them easier to manage and reducing the cognitive load associated with
-  the original monolithic structure.
+  classes (e.g., one class for command processing, another for query
+  processing, or even finer-grained handlers).21 This separation simplifies
+  each part, making them easier to manage and reducing the cognitive load
+  associated with the original monolithic structure.
 
-CQRS promotes a clear separation that can prevent the kind of tangled logic that
-forms Bumpy Roads. By isolating write operations (commands) from read operations
-(queries), and by encouraging task-based commands, the system naturally tends
-towards smaller, more cohesive units of behavior, thus reducing overall
-cognitive complexity within individual components.18 The separation allows for
-independent optimization and scaling of read and write sides, but more
-importantly for this discussion, it enforces a structural discipline that
+CQRS promotes a clear separation that can prevent the kind of tangled logic
+that forms Bumpy Roads. By isolating write operations (commands) from read
+operations (queries), and by encouraging task-based commands, the system
+naturally tends towards smaller, more cohesive units of behavior, thus reducing
+overall cognitive complexity within individual components.18 The separation
+allows for independent optimization and scaling of read and write sides, but
+more importantly for this discussion, it enforces a structural discipline that
 discourages methods from accumulating diverse responsibilities.18
 
 ### B. Avoiding Spaghetti Code Turning into Ravioli Code
 
 When refactoring complex, tangled code (often called "Spaghetti Code" 2), a
 common approach is to break it down into smaller pieces, such as functions or
-classes. However, if this is done without careful consideration for cohesion and
-appropriate levels of abstraction, it can lead to "Ravioli Code".24 Ravioli Code
-is characterized by a multitude of small, often overly granular classes or
+classes. However, if this is done without careful consideration for cohesion
+and appropriate levels of abstraction, it can lead to "Ravioli Code".24 Ravioli
+Code is characterized by a multitude of small, often overly granular classes or
 functions, where understanding the overall program flow requires navigating
 through numerous tiny, disconnected pieces, making it as hard to follow as the
 original spaghetti.24
@@ -523,8 +524,8 @@ original spaghetti.24
    be simple, the difficulty lies in tracing the overall execution flow. Ensure
    that the interactions and dependencies between components are clear and easy
    to follow. Sometimes, a slightly larger, more cohesive component is
-   preferable to many tiny ones if it improves the clarity of the overall system
-   behavior.
+   preferable to many tiny ones if it improves the clarity of the overall
+   system behavior.
 
 The goal is not to have the fewest classes or methods, but to have a structure
 where each component is easy to understand in isolation, and the interactions
@@ -559,18 +560,18 @@ and method structure.
 
 1\. Structural Pattern Matching
 
-Structural pattern matching, available in languages like Python (since 3.10 with
-match-case) and C#, offers a declarative and expressive way to handle complex
-conditional logic, often replacing verbose if-elif-else chains or switch
-statements.31
+Structural pattern matching, available in languages like Python (since 3.10
+with match-case) and C#, offers a declarative and expressive way to handle
+complex conditional logic, often replacing verbose if-elif-else chains or
+switch statements.31
 
 It works by allowing code to match against the *structure* of data—such as its
 type, shape, or specific values within sequences (lists, tuples) or mappings
 (dictionaries)—and simultaneously destructure this data, binding parts of it to
 variables.32 This approach can significantly reduce cognitive load. The clarity
-comes from the direct mapping of data shapes to code blocks, making it easier to
-understand the conditions under which a piece of code executes.31 For instance,
-instead of multiple
+comes from the direct mapping of data shapes to code blocks, making it easier
+to understand the conditions under which a piece of code executes.31 For
+instance, instead of multiple
 
 `isinstance` checks followed by key lookups and value comparisons in a nested
 `if` structure to parse a JSON object, a single `case` statement with a mapping
@@ -578,8 +579,8 @@ pattern can define the expected structure and extract the necessary values
 concisely.32 This shifts the focus from an imperative sequence of checks to a
 declarative description of data shapes, which is often more intuitive. The
 destructuring capability is particularly powerful, as it eliminates the manual
-code otherwise needed to extract values after a condition has been met, reducing
-boilerplate and the number of mental steps a developer must follow.32
+code otherwise needed to extract values after a condition has been met,
+reducing boilerplate and the number of mental steps a developer must follow.32
 
 Consider processing different event types from a UI framework, where events are
 represented as dictionaries.39
@@ -624,20 +625,20 @@ further enhancing its power.32
 
 Declarative programming focuses on describing what result is desired, rather
 than detailing how to achieve it step-by-step, as is typical in imperative
-programming.34 This paradigm shift can significantly reduce cognitive complexity
-by abstracting away low-level control flow and state management.
+programming.34 This paradigm shift can significantly reduce cognitive
+complexity by abstracting away low-level control flow and state management.
 
 When developers write declarative code, they operate at a higher level of
-abstraction, allowing them to reason about the program's intent more directly.34
-This often leads to more concise, readable, and maintainable code because the
-"noise" of explicit iteration, temporary variables, and manual state updates is
-minimized.34 Many declarative approaches also inherently favor immutability and
-reduce side effects, which are common culprits for bugs and increased cognitive
-load in imperative code.35
+abstraction, allowing them to reason about the program's intent more
+directly.34 This often leads to more concise, readable, and maintainable code
+because the "noise" of explicit iteration, temporary variables, and manual
+state updates is minimized.34 Many declarative approaches also inherently favor
+immutability and reduce side effects, which are common culprits for bugs and
+increased cognitive load in imperative code.35
 
-Examples include using SQL for database queries (specifying the desired dataset,
-not the retrieval algorithm) 34, or employing functional programming constructs
-like
+Examples include using SQL for database queries (specifying the desired
+dataset, not the retrieval algorithm) 34, or employing functional programming
+constructs like
 
 `map`, `filter`, and `reduce` on collections instead of writing explicit loops.
 Refactoring imperative code to a declarative style can start small, perhaps by
@@ -655,15 +656,15 @@ For managing complex conditional logic that selects different behaviors (often
 found in Bumpy Roads or large switch statements), the Command and Dispatcher
 patterns offer a structured and extensible alternative.
 
-The **Command pattern** encapsulates a request or an action as an object.36 Each
-command object implements a common interface (e.g., with an
+The **Command pattern** encapsulates a request or an action as an object.36
+Each command object implements a common interface (e.g., with an
 
-`execute()` method). This decouples the object that invokes the command from the
-object that knows how to perform it. Instead of a large conditional checking a
-type and then executing logic, different command objects can be instantiated
-based on the type, and then their `execute()` method is called. This promotes
-SRP, as each command class handles a single action, making the system easier to
-test and extend.37
+`execute()` method). This decouples the object that invokes the command from
+the object that knows how to perform it. Instead of a large conditional
+checking a type and then executing logic, different command objects can be
+instantiated based on the type, and then their `execute()` method is called.
+This promotes SRP, as each command class handles a single action, making the
+system easier to test and extend.37
 
 The **Dispatcher pattern** often works in conjunction with the Command pattern.
 A dispatcher is a central component that receives requests (which could be
@@ -734,9 +735,9 @@ This approach not only simplifies the original `handleMessage` method but also
 makes the system more extensible, as new message types can be supported by
 adding new handler classes and registering them with the dispatcher, often
 without modifying existing dispatcher code (aligning with the Open/Closed
-Principle). However, it's important to ensure that the dispatch mechanism itself
-remains clear and that the proliferation of small classes doesn't lead to
-Ravioli Code, where the overall system flow becomes obscured.24 Clear naming
+Principle). However, it's important to ensure that the dispatch mechanism
+itself remains clear and that the proliferation of small classes doesn't lead
+to Ravioli Code, where the overall system flow becomes obscured.24 Clear naming
 conventions and logical organization are vital.42
 
 The **State pattern** is a related behavioral pattern useful when an object's
@@ -749,19 +750,20 @@ effective for refactoring state machines implemented with complex
 `if/else` or `switch` statements.45
 
 By thoughtfully applying these refactoring strategies, developers can
-significantly reduce cognitive complexity, making codebases more understandable,
-maintainable, and adaptable to future changes.
+significantly reduce cognitive complexity, making codebases more
+understandable, maintainable, and adaptable to future changes.
 
 ## VI. Conclusion: Towards a More Maintainable and Understandable Codebase
 
 Managing software complexity, particularly the cognitive load it imposes on
 developers, is not a one-time task but a continuous discipline crucial for the
-long-term health and success of any software project.12 This report has explored
-Cyclomatic and Cognitive Complexity as vital metrics for quantifying different
-aspects of this challenge, with Cognitive Complexity offering a more nuanced
-view of human understandability. The Bumpy Road antipattern serves as a clear
-indicator of localized, excessive complexity, often stemming from violations of
-the Single Responsibility Principle and a lack of timely refactoring.
+long-term health and success of any software project.12 This report has
+explored Cyclomatic and Cognitive Complexity as vital metrics for quantifying
+different aspects of this challenge, with Cognitive Complexity offering a more
+nuanced view of human understandability. The Bumpy Road antipattern serves as a
+clear indicator of localized, excessive complexity, often stemming from
+violations of the Single Responsibility Principle and a lack of timely
+refactoring.
 
 The journey towards a more maintainable codebase involves recognizing such
 antipatterns and understanding their connection to fundamental principles like
@@ -782,9 +784,10 @@ maintainability over adherence to a pattern for its own sake, to avoid pitfalls
 like Ravioli Code.
 
 A proactive and disciplined approach, where these principles and techniques are
-integrated into daily development practices, is essential. This includes regular
-code reviews, monitoring complexity metrics, and fostering a team culture that
-values code quality and continuous improvement. The oft-quoted wisdom, "Good
-programmers write code that humans can understand" 1, remains the guiding
-principle. By striving for this ideal, development teams can build systems that
-are not only powerful and efficient but also a pleasure to evolve and maintain.
+integrated into daily development practices, is essential. This includes
+regular code reviews, monitoring complexity metrics, and fostering a team
+culture that values code quality and continuous improvement. The oft-quoted
+wisdom, "Good programmers write code that humans can understand" 1, remains the
+guiding principle. By striving for this ideal, development teams can build
+systems that are not only powerful and efficient but also a pleasure to evolve
+and maintain.

--- a/docs/declarative-world-inference-with-dbsp-and-rust.md
+++ b/docs/declarative-world-inference-with-dbsp-and-rust.md
@@ -8,9 +8,9 @@ performance of incremental computation with the clarity of a declarative
 programming model.
 
 This architecture replaces a previous implementation that used DDlog. By
-migrating to DBSP, we have eliminated the need for a separate language toolchain
-and a foreign function interface (FFI) boundary, resulting in a more robust,
-type-safe, and maintainable pure-Rust codebase.
+migrating to DBSP, we have eliminated the need for a separate language
+toolchain and a foreign function interface (FFI) boundary, resulting in a more
+robust, type-safe, and maintainable pure-Rust codebase.
 
 ## The DBSP Circuit & Dataflow Model
 
@@ -84,16 +84,16 @@ DBSP operators.
 
 #### Geometry Dataflow: Calculating Floor Height
 
-The first stage of the circuit calculates the height of the "floor" at any given
-`(x, y)` coordinate.
+The first stage of the circuit calculates the height of the "floor" at any
+given `(x, y)` coordinate.
 
 1. **Find Highest Block**: The `Block` input stream is grouped by its `(x, y)`
    coordinates, and we find the maximum `z` for each group.
 
 2. **Calculate Floor Height**: This `HighestBlockAt` stream is then joined with
    the `BlockSlope` stream. A `map` operator calculates the final
-   `FloorHeightAt(x, y, z_floor)`, using a plane equation for sloped blocks or a
-   flat offset for others.
+   `FloorHeightAt(x, y, z_floor)`, using a plane equation for sloped blocks or
+   a flat offset for others.
 
 Here is how that dataflow is constructed in Rust:
 
@@ -143,8 +143,8 @@ unsupported entities and applying gravity.
    calculated `FloorHeightAt` stream.
 
 2. **Filter for Unsupported**: A `filter` operator selects only those entities
-   whose `z` position is greater than their calculated floor height plus a small
-   grace distance.
+   whose `z` position is greater than their calculated floor height plus a
+   small grace distance.
 
 3. **Apply Gravity**: A final `map` operator takes the unsupported entities and
    calculates their new position by subtracting `GRAVITY_PULL` from their `z`
@@ -182,9 +182,9 @@ let gravity_applied = unsupported_entities.map(|(pos, _z_floor)| {
 
 ## Data Synchronisation with Bevy ECS
 
-The DBSP circuit operates as a self-contained computational engine driven by the
-Bevy ECS. The interaction is orchestrated by a set of Bevy systems that manage
-the data flow each tick.
+The DBSP circuit operates as a self-contained computational engine driven by
+the Bevy ECS. The interaction is orchestrated by a set of Bevy systems that
+manage the data flow each tick.
 
 1. **Data Extraction (Rust → DBSP)**: A Bevy system queries the ECS for all
    relevant components (e.g., `Transform`, `Velocity`). This data is collected
@@ -200,9 +200,9 @@ the data flow each tick.
    incrementally propagate the changes through the entire dataflow graph.
 
 4. **Applying Results (DBSP → Rust)**: A final system reads the computed results
-   from the circuit's output streams. For instance, it consumes all records from
-   the `NewPosition` output stream and updates the `Transform` component of the
-   corresponding entities in the ECS.
+   from the circuit's output streams. For instance, it consumes all records
+   from the `NewPosition` output stream and updates the `Transform` component
+   of the corresponding entities in the ECS.
 
 The following sequence diagram summarizes how the application constructs and
 drives the circuit each tick.

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -58,8 +58,8 @@ fn add(a: i32, b: i32) -> i32 {
 
 ## API doc comments (Rust)
 
-Use doc comments to document public APIs. Keep them consistent with the contents
-of the manual.
+Use doc comments to document public APIs. Keep them consistent with the
+contents of the manual.
 
 - Begin each block with `///`.
 - Keep the summary line short, followed by further detail.
@@ -71,7 +71,7 @@ of the manual.
   they do not execute during documentation tests.
 - Put function attributes after the doc comment.
 
-````rust
+```rust
 /// Returns the sum of `a` and `b`.
 ///
 /// # Parameters
@@ -90,14 +90,14 @@ of the manual.
 pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
-````
+```
 
 ## Diagrams and images
 
-Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams. When
-embedding figures, use `![alt text](path/to/image)` and provide concise alt text
-describing the content. Add a short description before each Mermaid diagram so
-screen readers can understand it.
+Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
+When embedding figures, use `![alt text](path/to/image)` and provide concise
+alt text describing the content. Add a short description before each Mermaid
+diagram so screen readers can understand it.
 
 ```mermaid
 flowchart TD

--- a/docs/lille-physics-and-world-engine-roadmap.md
+++ b/docs/lille-physics-and-world-engine-roadmap.md
@@ -98,7 +98,7 @@ DDlog-based version.
    - [x] Implement the `FloorHeightAt` calculation, including the `left_join`
      with `BlockSlope` data to handle sloped surfaces correctly.
 
-   - [ ] Implement the logic to join an entity's continuous `Position` with the
+   - [x] Implement the logic to join an entity's continuous `Position` with the
      discrete `FloorHeightAt` grid.
 
 2. **Complete Motion Logic**:

--- a/docs/lille-physics-engine-design.md
+++ b/docs/lille-physics-engine-design.md
@@ -89,7 +89,9 @@ An entity's physical state is derived by comparing its position to the
 calculated floor height.
 
 1. The `Position` stream is joined with the `FloorHeightAt` stream based on the
-   entity's `(x, y)` coordinates.
+   entity's `(x, y)` coordinates. The continuous `x` and `y` values are floored
+   to determine the grid cell. The join emits a `PositionFloor` record pairing
+   the original position with the matched `z_floor` height.
 
 2. A `filter` operator then partitions entities into two streams:
 

--- a/docs/map-data-format.md
+++ b/docs/map-data-format.md
@@ -1,8 +1,8 @@
 # Map Data Format
 
-This document describes the JSON/MessagePack structure used to represent maps in
-the Lille engine. The layout is identical whether serialized as human‑readable
-JSON or as a binary MessagePack payload.
+This document describes the JSON/MessagePack structure used to represent maps
+in the Lille engine. The layout is identical whether serialized as
+human‑readable JSON or as a binary MessagePack payload.
 
 ## 1. Top-level object
 
@@ -66,8 +66,8 @@ erDiagram
 
 ## 2. `block_types` entries
 
-Each entry in `"block_types"` describes the physical and navigational properties
-of one kind of block.
+Each entry in `"block_types"` describes the physical and navigational
+properties of one kind of block.
 
 ```json
 "block_types": {
@@ -87,10 +87,10 @@ of one kind of block.
 
 ## 3. `entity_defs` entries
 
-Each entry in `"entity_defs"` defines a reusable template for spawning entities.
-Templates may inherit from another template using an optional `"extends"` field
-and can override or add arbitrary properties. If a property is absent, the
-engine falls back to the defaults for that entity archetype.
+Each entry in `"entity_defs"` defines a reusable template for spawning
+entities. Templates may inherit from another template using an optional
+`"extends"` field and can override or add arbitrary properties. If a property
+is absent, the engine falls back to the defaults for that entity archetype.
 
 ```jsonc
 "entity_defs": {
@@ -138,9 +138,9 @@ through to the engine.
 ]
 ```
 
-Each entry spawns one entity. `type` refers to a template ID from `entity_defs`.
-Properties listed here override both the template and the archetype defaults.
-Position is a mandatory `[x,y,z]` triple.
+Each entry spawns one entity. `type` refers to a template ID from
+`entity_defs`. Properties listed here override both the template and the
+archetype defaults. Position is a mandatory `[x,y,z]` triple.
 
 ## 6. Serialization
 
@@ -251,6 +251,6 @@ streaming. The recommended layout is:
 2. **Sparse tensor** for `map`, storing only cells that contain a block token
    and leaving empty cells implicit.
 
-When serialized via the Arrow IPC or Feather format, this representation remains
-interoperable with the JSON/MessagePack structure while leveraging Arrow's
-columnar compression and sparse data handling.
+When serialized via the Arrow IPC or Feather format, this representation
+remains interoperable with the JSON/MessagePack structure while leveraging
+Arrow's columnar compression and sparse data handling.

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -357,7 +357,7 @@ states.1
 Consider testing a state machine's transition logic based on current state and
 an incoming event:
 
-````rust
+```rust
 use rstest::rstest;
 
 #
@@ -1332,4 +1332,4 @@ markdownlint-disable MD013 -->
 By mastering `rstest`, Rust developers can significantly elevate the quality
 and efficiency of their testing practices, leading to more reliable and
 maintainable software.
-````
+```

--- a/docs/testing-declarative-game-logic-in-dbsp.md
+++ b/docs/testing-declarative-game-logic-in-dbsp.md
@@ -4,8 +4,8 @@ The migration of our core physics and geometry logic from DDlog to a pure-Rust
 DBSP circuit has profound, positive implications for our testing strategy.
 Because the dataflow logic is now standard Rust code, we can leverage the full
 power of Rust's native testing ecosystem, from fine-grained unit tests to
-high-level behavioural scenarios. This eliminates the indirection and complexity
-of testing a foreign language module via an FFI boundary.
+high-level behavioural scenarios. This eliminates the indirection and
+complexity of testing a foreign language module via an FFI boundary.
 
 This document outlines our two-tiered approach to ensuring the correctness and
 robustness of the DBSP-based world inference engine.
@@ -13,10 +13,11 @@ robustness of the DBSP-based world inference engine.
 ## 1. Unit Testing: Verifying Individual Dataflow Operators
 
 At the lowest level, we must verify that each logical step in our dataflow
-circuit behaves as expected. A "unit" in this context is a small, self-contained
-part of the circuit—typically a single operator (`map`, `join`, `filter`,
-`aggregate`) or a small chain of them. The goal is to test the operator's logic
-in isolation, providing it with controlled inputs and asserting on its outputs.
+circuit behaves as expected. A "unit" in this context is a small,
+self-contained part of the circuit—typically a single operator (`map`, `join`,
+`filter`, `aggregate`) or a small chain of them. The goal is to test the
+operator's logic in isolation, providing it with controlled inputs and
+asserting on its outputs.
 
 The move to DBSP makes this remarkably straightforward. A test for a dataflow
 operator is simply a standard Rust test function marked with `#[test]`.
@@ -124,10 +125,10 @@ results, all without the overhead of rendering or user input.
    back to the ECS components.
 
 3. **Then (State Assertion)**: After the update, we query the `World` again to
-   verify the outcome. We check if components have been updated as expected. For
-   example, we might assert that a falling entity's `Transform.translation.z`
-   has decreased, or that a standing entity's position now matches the
-   calculated floor height.
+   verify the outcome. We check if components have been updated as expected.
+   For example, we might assert that a falling entity's
+   `Transform.translation.z` has decreased, or that a standing entity's
+   position now matches the calculated floor height.
 
 ### Example: BDD test for gravity
 

--- a/src/dbsp_circuit/streams.rs
+++ b/src/dbsp_circuit/streams.rs
@@ -1,0 +1,206 @@
+//! DBSP dataflow stream construction for spatial simulation.
+//!
+//! This module defines helper functions for building the dataflow streams used
+//! by `DbspCircuit` to process the game world. These streams implement:
+//!
+//! - Block aggregation to track the highest block at each grid cell
+//! - Floor height calculation with optional slopes
+//! - Velocity updates applying gravity
+//! - Position integration based on velocities
+//! - Joining positions with floor height for collision queries
+//!
+//! Each function returns a new [`Stream`] that can be composed into the overall
+//! circuit.
+
+use dbsp::{operator::Max, typed_batch::OrdZSet, RootCircuit, Stream};
+use ordered_float::OrderedFloat;
+
+use crate::components::{Block, BlockSlope};
+use crate::{BLOCK_CENTRE_OFFSET, BLOCK_TOP_OFFSET, GRAVITY_PULL};
+
+use super::{FloorHeightAt, HighestBlockAt, Position, Velocity};
+
+/// Returns a stream pairing each grid cell with its highest block and id.
+///
+/// The function aggregates incoming [`Block`] records by `(x, y)` to find the
+/// maximum `z` value at each coordinate. The output preserves the originating
+/// block id so that subsequent joins can access slope information.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # fn main() -> Result<(), dbsp::Error> {
+/// # use lille::prelude::*;
+/// # use dbsp::{RootCircuit, typed_batch::OrdZSet};
+/// # use lille::dbsp_circuit::highest_block_pair;
+/// RootCircuit::build(|circuit| {
+///     let (stream, _handle) = circuit.add_input_zset::<Block>();
+///     let _highest = lille::dbsp_circuit::highest_block_pair(&stream);
+///     Ok(())
+/// })?;
+/// # Ok::<(), dbsp::Error>(())
+/// # }
+/// ```
+pub fn highest_block_pair(
+    blocks: &Stream<RootCircuit, OrdZSet<Block>>,
+) -> Stream<RootCircuit, OrdZSet<(HighestBlockAt, i64)>> {
+    blocks
+        .map_index(|b| ((b.x, b.y), (b.z, b.id)))
+        .aggregate(Max)
+        .map(|((x, y), (z, id))| {
+            (
+                HighestBlockAt {
+                    x: *x,
+                    y: *y,
+                    z: *z,
+                },
+                *id,
+            )
+        })
+}
+
+/// Calculates the world-space `z` coordinate of a block's upper surface.
+fn block_top(z: i32) -> f64 {
+    z as f64 + BLOCK_TOP_OFFSET
+}
+
+/// Calculates the world-space `z` coordinate for a block's floor height.
+///
+/// If a slope gradient is provided, it adjusts the block's top height by the
+/// gradient scaled by [`BLOCK_CENTRE_OFFSET`]. This helper keeps the
+/// slope-adjustment logic out of the stream closures so that they remain
+/// concise.
+fn compute_floor_height_at(x: i32, y: i32, z: i32, grad: Option<(f64, f64)>) -> FloorHeightAt {
+    let base = block_top(z);
+    let extra = grad
+        .map(|(gx, gy)| BLOCK_CENTRE_OFFSET * (gx + gy))
+        .unwrap_or(0.0);
+    FloorHeightAt {
+        x,
+        y,
+        z: OrderedFloat(base + extra),
+    }
+}
+
+/// Derives the floor height for each block, optionally applying slopes.
+///
+/// The stream joins the highest block id at a grid cell with any matching
+/// [`BlockSlope`] record. When slope data is present the returned
+/// [`FloorHeightAt`] accounts for the block's gradient, producing a smooth
+/// surface. Missing slope data falls back to a flat top.
+pub(super) fn floor_height_stream(
+    highest_pair: &Stream<RootCircuit, OrdZSet<(HighestBlockAt, i64)>>,
+    slopes: &Stream<RootCircuit, OrdZSet<BlockSlope>>,
+) -> Stream<RootCircuit, OrdZSet<FloorHeightAt>> {
+    let slope_idx = slopes.map_index(|bs| (bs.block_id, (bs.grad_x, bs.grad_y)));
+    highest_pair
+        .map_index(|(hb, id)| (*id, (hb.x, hb.y, hb.z)))
+        .outer_join(
+            &slope_idx,
+            |_, &(x, y, z), &(gx, gy)| {
+                Some(compute_floor_height_at(
+                    x,
+                    y,
+                    z,
+                    Some((gx.into_inner(), gy.into_inner())),
+                ))
+            },
+            |_, &(x, y, z)| Some(compute_floor_height_at(x, y, z, None)),
+            |_, _| None,
+        )
+        .flat_map(|fh| fh.clone())
+}
+
+/// Applies gravity to each velocity record.
+///
+/// This helper keeps the velocity update logic separate from entity position
+/// updates. It adds [`GRAVITY_PULL`] to the incoming `vz` component and passes
+/// through the remaining fields unchanged.
+pub(super) fn new_velocity_stream(
+    velocities: &Stream<RootCircuit, OrdZSet<Velocity>>,
+) -> Stream<RootCircuit, OrdZSet<Velocity>> {
+    velocities.map(|v| Velocity {
+        entity: v.entity,
+        vx: v.vx,
+        vy: v.vy,
+        vz: OrderedFloat(v.vz.into_inner() + GRAVITY_PULL),
+    })
+}
+
+/// Integrates positions with updated velocities.
+///
+/// The input streams are joined by `entity`, producing a new [`Position`]
+/// translated by the entity's velocity components. The function performs a
+/// simple Euler integration suitable for the small time step used in the game
+/// loop.
+pub(super) fn new_position_stream(
+    positions: &Stream<RootCircuit, OrdZSet<Position>>,
+    new_vel: &Stream<RootCircuit, OrdZSet<Velocity>>,
+) -> Stream<RootCircuit, OrdZSet<Position>> {
+    positions.map_index(|p| (p.entity, p.clone())).join(
+        &new_vel.map_index(|v| (v.entity, v.clone())),
+        |_, p, v| Position {
+            entity: p.entity,
+            x: OrderedFloat(p.x.into_inner() + v.vx.into_inner()),
+            y: OrderedFloat(p.y.into_inner() + v.vy.into_inner()),
+            z: OrderedFloat(p.z.into_inner() + v.vz.into_inner()),
+        },
+    )
+}
+
+#[derive(
+    rkyv::Archive,
+    rkyv::Serialize,
+    rkyv::Deserialize,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Default,
+    size_of::SizeOf,
+)]
+#[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
+/// Pairs an entity's position with the floor height at its grid location.
+///
+/// This struct is the result of joining the continuous [`Position`] stream with
+/// the discrete [`FloorHeightAt`] grid. It is primarily consumed by higher-level
+/// physics logic for tasks such as collision detection or standing vs. falling
+/// checks.
+///
+/// * `position` - The entity's current position in world coordinates
+/// * `z_floor` - The computed floor height at the position's grid cell
+pub struct PositionFloor {
+    pub position: Position,
+    pub z_floor: OrderedFloat<f64>,
+}
+
+/// Joins each `Position` with the corresponding floor height.
+///
+/// Positions are discretised to grid coordinates by flooring their `x` and `y`
+/// values. Those indices look up a [`FloorHeightAt`] record to produce a
+/// [`PositionFloor`] stream suitable for higher-level physics logic.
+pub(super) fn position_floor_stream(
+    positions: &Stream<RootCircuit, OrdZSet<Position>>,
+    floor_height: &Stream<RootCircuit, OrdZSet<FloorHeightAt>>,
+) -> Stream<RootCircuit, OrdZSet<PositionFloor>> {
+    positions
+        .map_index(|p| {
+            (
+                (
+                    p.x.into_inner().floor() as i32,
+                    p.y.into_inner().floor() as i32,
+                ),
+                p.clone(),
+            )
+        })
+        .join(
+            &floor_height.map_index(|fh| ((fh.x, fh.y), fh.z)),
+            |_idx, pos, &z_floor| PositionFloor {
+                position: pos.clone(),
+                z_floor,
+            },
+        )
+}

--- a/src/dbsp_circuit/streams.rs
+++ b/src/dbsp_circuit/streams.rs
@@ -91,6 +91,8 @@ pub(super) fn floor_height_stream(
             },
             |_, _| None,
         )
+        // Flatten `Option<FloorHeightAt>` from the outer join, discarding
+        // unmatched slope records.
         .flat_map(|fh| fh.clone())
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@ pub use constants::*;
 // Re-export commonly used items
 pub use actor::Actor;
 pub use components::{DdlogId, Health, Target, UnitType, VelocityComp};
-pub use dbsp_circuit::{DbspCircuit, FloorHeightAt, HighestBlockAt, NewPosition, Position};
+pub use dbsp_circuit::{
+    DbspCircuit, FloorHeightAt, HighestBlockAt, NewPosition, Position, PositionFloor,
+};
 pub use dbsp_circuit::{NewVelocity, Velocity};
 pub use dbsp_sync::{
     apply_dbsp_outputs_system, cache_state_for_dbsp_system, init_dbsp_system, DbspPlugin,
@@ -39,6 +41,7 @@ pub mod prelude {
     pub use crate::DbspCircuit;
     pub use crate::DbspPlugin;
     pub use crate::FloorHeightAt;
+    pub use crate::PositionFloor;
     pub use crate::Velocity;
     pub use ordered_float::OrderedFloat;
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -3,6 +3,18 @@ use lille::dbsp_circuit::DbspCircuit;
 /// Create a new `DbspCircuit` for tests.
 ///
 /// Panics if the circuit cannot be constructed.
+#[allow(dead_code)]
 pub fn new_circuit() -> DbspCircuit {
     DbspCircuit::new().expect("failed to build DBSP circuit")
+}
+
+/// Convenience constructor for [`Position`] records used in tests.
+#[allow(dead_code)]
+pub fn pos(entity: i64, x: f64, y: f64, z: f64) -> lille::dbsp_circuit::Position {
+    lille::dbsp_circuit::Position {
+        entity,
+        x: x.into(),
+        y: y.into(),
+        z: z.into(),
+    }
 }

--- a/tests/dbsp_position_floor.rs
+++ b/tests/dbsp_position_floor.rs
@@ -1,0 +1,83 @@
+//! Unit tests for joining continuous positions with the floor grid.
+//!
+//! The helper functions build small DBSP circuits to ensure that
+//! `position_floor_stream` associates entities with the correct
+//! floor height across a range of scenarios.
+use lille::{
+    components::{Block, BlockSlope},
+    dbsp_circuit::{Position, PositionFloor},
+};
+mod common;
+use common::pos;
+use rstest::rstest;
+
+/// Creates a [`Block`] positioned at integer grid coordinates.
+fn blk(id: i64, x: i32, y: i32, z: i32) -> Block {
+    Block { id, x, y, z }
+}
+
+/// Constructs a [`BlockSlope`] for use in test cases.
+fn slope(block_id: i64, gx: f64, gy: f64) -> BlockSlope {
+    BlockSlope {
+        block_id,
+        grad_x: gx.into(),
+        grad_y: gy.into(),
+    }
+}
+
+/// Helper to create expected [`PositionFloor`] outputs.
+fn pf(position: Position, z_floor: f64) -> PositionFloor {
+    PositionFloor {
+        position,
+        z_floor: z_floor.into(),
+    }
+}
+
+#[rstest]
+#[case(
+    vec![blk(1,0,0,0)],
+    vec![],
+    vec![pos(1,0.2,0.3,2.0)],
+    vec![pf(pos(1,0.2,0.3,2.0),1.0)],
+)]
+#[case(
+    vec![],
+    vec![],
+    vec![pos(1,0.0,0.0,0.5)],
+    vec![],
+)]
+#[case(
+    vec![blk(1,-1,-1,0)],
+    vec![slope(1,1.0,0.0)],
+    vec![pos(2,-0.8,-0.2,3.0)],
+    vec![pf(pos(2,-0.8,-0.2,3.0),1.5)],
+)]
+/// Asserts that the position-floor join yields the expected records.
+fn position_floor_cases(
+    #[case] blocks: Vec<Block>,
+    #[case] slopes: Vec<BlockSlope>,
+    #[case] positions: Vec<Position>,
+    #[case] expected: Vec<PositionFloor>,
+) {
+    let mut circuit = common::new_circuit();
+    for b in &blocks {
+        circuit.block_in().push(b.clone(), 1);
+    }
+    for s in &slopes {
+        circuit.block_slope_in().push(s.clone(), 1);
+    }
+    for p in &positions {
+        circuit.position_in().push(p.clone(), 1);
+    }
+    circuit.step().expect("step");
+    let mut vals: Vec<PositionFloor> = circuit
+        .position_floor_out()
+        .consolidate()
+        .iter()
+        .map(|(pf, _, _)| pf.clone())
+        .collect();
+    vals.sort_by_key(|pf| pf.position.entity);
+    let mut exp = expected;
+    exp.sort_by_key(|pf| pf.position.entity);
+    assert_eq!(vals, exp);
+}

--- a/tests/dbsp_position_floor.rs
+++ b/tests/dbsp_position_floor.rs
@@ -81,3 +81,30 @@ fn position_floor_cases(
     exp.sort_by_key(|pf| pf.position.entity);
     assert_eq!(vals, exp);
 }
+
+/// Ensures multiple entities in the same grid cell each receive a
+/// corresponding [`PositionFloor`] record.
+#[test]
+fn multiple_positions_same_grid_cell() {
+    let mut circuit = common::new_circuit();
+    circuit.block_in().push(blk(1, 0, 0, 0), 1);
+    circuit.position_in().push(pos(1, 0.1, 0.1, 2.0), 1);
+    circuit.position_in().push(pos(2, 0.8, 0.4, 3.0), 1);
+    circuit.step().expect("step");
+
+    let mut vals: Vec<PositionFloor> = circuit
+        .position_floor_out()
+        .consolidate()
+        .iter()
+        .map(|(pf, _, _)| pf.clone())
+        .collect();
+    vals.sort_by_key(|pf| pf.position.entity);
+
+    let mut exp = vec![
+        pf(pos(1, 0.1, 0.1, 2.0), 1.0),
+        pf(pos(2, 0.8, 0.4, 3.0), 1.0),
+    ];
+    exp.sort_by_key(|pf| pf.position.entity);
+
+    assert_eq!(vals, exp);
+}

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -7,6 +7,7 @@ use approx::assert_relative_eq;
 use lille::dbsp_circuit::{NewPosition, NewVelocity, Position, Velocity};
 use rstest::rstest;
 mod common;
+use common::pos;
 
 /// Tests that an entity's position and velocity are updated correctly under gravity in the physics circuit.
 ///
@@ -53,15 +54,6 @@ fn entity_falls_due_to_gravity() {
     assert_eq!(vresults.len(), 1);
     assert_eq!(vresults[0].entity, 1);
     assert_relative_eq!(vresults[0].vz.into_inner(), lille::GRAVITY_PULL);
-}
-
-fn pos(entity: i64, x: f64, y: f64, z: f64) -> Position {
-    Position {
-        entity,
-        x: x.into(),
-        y: y.into(),
-        z: z.into(),
-    }
 }
 
 fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {

--- a/tests/position_floor_rspec.rs
+++ b/tests/position_floor_rspec.rs
@@ -1,0 +1,116 @@
+//! Behaviour-driven tests for position and floor height joins in DBSP circuits.
+//!
+//! This module exercises the DBSP pipeline using the `rust-rspec` framework. It
+//! verifies that entity positions are correctly paired with floor height
+//! information when processed through `DbspCircuit`. The tests use a shared
+//! circuit environment to mimic real application usage and cover both
+//! successful joins and edge cases.
+use lille::{
+    components::{Block, BlockSlope},
+    dbsp_circuit::{Position, PositionFloor},
+    DbspCircuit,
+};
+mod common;
+use common::pos;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone)]
+/// Shared test environment wrapping a `DbspCircuit` in a thread-safe container.
+struct Env {
+    circuit: Arc<Mutex<DbspCircuit>>,
+}
+
+// SAFETY: DbspCircuit is Send and Sync when guarded by Arc<Mutex<_>> which
+// provides synchronisation for interior mutability.
+unsafe impl Send for Env {}
+unsafe impl Sync for Env {}
+
+impl fmt::Debug for Env {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Env").finish()
+    }
+}
+
+impl Default for Env {
+    /// Creates a new environment with a fresh [`DbspCircuit`] instance.
+    #[expect(
+        clippy::arc_with_non_send_sync,
+        reason = "DbspCircuit wrapped in Arc<Mutex<_>> for shared test access"
+    )]
+    fn default() -> Self {
+        let circuit = Arc::new(Mutex::new(
+            DbspCircuit::new().expect("failed to create DBSP circuit for test environment"),
+        ));
+        Self { circuit }
+    }
+}
+
+impl Env {
+    /// Inserts a block (and optional slope) into the circuit.
+    fn push_block(&self, block: Block, slope: Option<BlockSlope>) {
+        let c = self.circuit.lock().expect("lock");
+        c.block_in().push(block, 1);
+        if let Some(s) = slope {
+            c.block_slope_in().push(s, 1);
+        }
+    }
+
+    /// Pushes a [`Position`] record into the circuit.
+    fn push_position(&self, pos: Position) {
+        let c = self.circuit.lock().expect("lock");
+        c.position_in().push(pos, 1);
+    }
+
+    /// Advances the circuit by one tick.
+    fn step(&self) {
+        self.circuit.lock().expect("lock").step().expect("step");
+    }
+
+    /// Retrieves and clears the `PositionFloor` output collection.
+    fn output(&self) -> Vec<PositionFloor> {
+        let mut c = self.circuit.lock().expect("lock");
+        let vals: Vec<_> = c
+            .position_floor_out()
+            .consolidate()
+            .iter()
+            .map(|(pf, _, _)| pf.clone())
+            .collect();
+        c.clear_inputs();
+        vals
+    }
+}
+
+/// Runs a behavioural test that verifies positions are joined with floor height.
+#[test]
+fn join_position_with_floor() {
+    rspec::run(&rspec::given(
+        "a block with an entity above",
+        Env::default(),
+        |ctx| {
+            ctx.before_each(|env| {
+                env.push_block(
+                    Block {
+                        id: 1,
+                        x: 0,
+                        y: 0,
+                        z: 0,
+                    },
+                    None,
+                );
+                env.push_position(pos(1, 0.2, 0.2, 2.0));
+                env.step();
+            });
+            ctx.then("position is paired with floor height", |env| {
+                let out = env.output();
+                assert_eq!(
+                    out,
+                    vec![PositionFloor {
+                        position: pos(1, 0.2, 0.2, 2.0),
+                        z_floor: 1.0.into(),
+                    }]
+                );
+            });
+        },
+    ));
+}


### PR DESCRIPTION
## Summary
- expose `highest_block_pair` to allow doctest compilation
- update example to compile with `rust,no_run`
- deduplicate helper in `physics_bdd` tests

Closes #97

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: too many arguments. Expected 0 arguments but got 1)*

------
https://chatgpt.com/codex/tasks/task_e_68852c5151688322ae131c922b9814b5

## Summary by Sourcery

Implement a position-to-floor join in the DBSP circuit by refactoring stream constructors into a dedicated module and exposing a new PositionFloor output in DbspCircuit.

Enhancements:
- Extract dataflow helpers (highest_block_pair, floor_height_stream, new_velocity_stream, new_position_stream, position_floor_stream) into src/dbsp_circuit/streams.rs
- Add PositionFloor struct and integrate position_floor_out handle into DbspCircuit
- Update lib exports and prelude to include PositionFloor

Documentation:
- Refresh documentation examples to use rust,no_run and clarify position-floor join usage
- Reformat various markdown docs for consistent wrapping and updated code snippets

Tests:
- Add unit tests and rstest cases for position-floor join in dbsp_position_floor.rs
- Introduce BDD-style tests for position-floor behavior in position_floor_rspec.rs
- Deduplicate pos helper by moving it into tests/common.rs and remove duplicate definitions