### PR TITLE
Extract rspec scenario macro

### DIFF
--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -117,7 +117,7 @@ fn world() -> TestWorld {
 /// Runs a physics scenario using `rspec` with the provided parameters.
 macro_rules! physics_spec {
     ($world:expr, $description:expr, $setup:expr, $expected_pos:expr, $expected_vel:expr) => {
-        rspec::run(&rspec::given($description, $world, |ctx| {
+        rspec::run(&rspec::given($description, ($world), |ctx| {
             ctx.before_each($setup);
             ctx.when("the simulation ticks once", |ctx| {
                 ctx.before_each(|world| world.tick());


### PR DESCRIPTION
## Summary
- factor repeated rspec setup into a `physics_spec!` macro
- call the macro from the parameterised `physics_scenarios` tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6894ecf90dd48322a5a58b4f40f4c17d

## Summary by Sourcery

Factor out repeated RSpec-based physics test setup into a reusable macro and fixture, and update existing parameterized tests to use them.

Enhancements:
- Extract repeated physics scenario logic into a `physics_spec!` macro
- Add a `world` rstest fixture to supply a fresh `TestWorld` for each scenario
- Refactor `physics_scenarios` tests to invoke the new macro with the fixture