### PR TITLE
Add force-driven acceleration to DBSP circuit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,5 @@ serial_test = "3.2"
 mockall = "0.13.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rspec = "1.0"
+test_utils = { path = "test_utils" }
 

--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -6,14 +6,7 @@ pub mod font;
 use color_eyre::eyre::Result;
 use std::path::PathBuf;
 
-#[expect(
-    unexpected_cfgs,
-    non_snake_case,
-    reason = "OrthoConfig macro generates names that trigger these lints"
-)]
-#[allow(unfulfilled_lint_expectations)] // macro output may not hit expected lints
 /// Execute all build steps required by `build.rs`.
-///
 /// This function downloads the Fira Sans font.
 /// Environment variables such as `CARGO_MANIFEST_DIR` must be set
 /// by Cargo before this function is called.

--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
     non_snake_case,
     reason = "OrthoConfig macro generates names that trigger these lints"
 )]
-#[allow(unfulfilled_lint_expectations)]
+#[allow(unfulfilled_lint_expectations)] // macro output may not hit expected lints
 /// Execute all build steps required by `build.rs`.
 ///
 /// This function downloads the Fira Sans font.

--- a/docs/lille-physics-and-world-engine-roadmap.md
+++ b/docs/lille-physics-and-world-engine-roadmap.md
@@ -146,11 +146,11 @@ physical properties and agent behaviours.
 
 1. **Velocity and Acceleration**:
 
-   - [ ] Add `Velocity` and `Force` as input streams to the DBSP circuit.
+   - [x] Add `Velocity` and `Force` as input streams to the DBSP circuit.
 
-   - [ ] Implement operators to calculate acceleration based on forces (`F=ma`).
+   - [x] Implement operators to calculate acceleration based on forces (`F=ma`).
 
-   - [ ] Integrate velocity into the `NewPosition` calculation
+   - [x] Integrate velocity into the `NewPosition` calculation
      (`p_new = p_old + v*dt`).
 
    - [ ] Implement a `friction` operator that reduces velocity for `Standing`

--- a/docs/lille-physics-engine-design.md
+++ b/docs/lille-physics-engine-design.md
@@ -108,6 +108,14 @@ their new position.
   through a simple `map` operator that subtracts the `GRAVITY_PULL` constant
   from the entity's `z` coordinate.
 
+- **Forces and Acceleration**: A dedicated `Force` input stream supplies
+  external forces. Each force is converted to acceleration using `F=ma` with an
+  optional per-entity mass (defaulting to `DEFAULT_MASS`). Invalid or
+  non-positive masses are ignored. The resulting acceleration is combined with
+  gravity and integrated into the velocity stream. This velocity is then used
+  to update positions (`p_new = p_old + v*dt`), ensuring the DBSP circuit
+  remains the authoritative source for derived motion.
+
   - **Movement for Standing Entities**: The `Standing` stream is joined with AI
   data (see below) to determine a desired movement vector `(dx, dy)`. The
   proposed new location `(x+dx, y+dy)` is then fed back into the

--- a/src/components.rs
+++ b/src/components.rs
@@ -97,6 +97,7 @@ pub struct VelocityComp {
 /// assert_eq!(f.mass, Some(2.0));
 /// ```
 #[derive(Component, Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
 pub struct ForceComp {
     #[serde(alias = "fx")]
     pub force_x: f64,

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,7 +2,7 @@
 //! Includes identifiers, health, target positions, and unit descriptors shared between systems.
 use bevy::prelude::*;
 use ordered_float::OrderedFloat;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Component, Debug, Serialize)]
 pub struct DdlogId(pub i64);
@@ -19,13 +19,13 @@ pub enum UnitType {
 #[derive(Component, Debug, Deref, DerefMut, Serialize)]
 pub struct Target(pub Vec2);
 
-use rkyv::{Archive, Deserialize, Serialize as RkyvSerialize};
+use rkyv::{Archive, Deserialize as RkyvDeserialize, Serialize as RkyvSerialize};
 use size_of::SizeOf;
 
 #[derive(
     Archive,
     RkyvSerialize,
-    Deserialize,
+    RkyvDeserialize,
     Component,
     Debug,
     Clone,
@@ -49,7 +49,7 @@ pub struct Block {
 #[derive(
     Archive,
     RkyvSerialize,
-    Deserialize,
+    RkyvDeserialize,
     Component,
     Debug,
     Clone,
@@ -79,7 +79,8 @@ pub struct VelocityComp {
 /// `F = m·a`.
 ///
 /// Units:
-/// - `fx`, `fy`, `fz` are forces in newtons applied for the current tick.
+/// - `force_x`, `force_y`, `force_z` are forces in newtons applied for the
+///   current tick.
 /// - `mass` is the entity's mass in kilograms. Use `Some(m)` for a known
 ///   mass; use `None` to defer to the default mass.
 ///
@@ -92,13 +93,16 @@ pub struct VelocityComp {
 /// Apply a 10 N upward force with an explicit 2 kg mass:
 /// ```
 /// use lille::components::ForceComp;
-/// let f = ForceComp { fx: 0.0, fy: 0.0, fz: 10.0, mass: Some(2.0) };
+/// let f = ForceComp { force_x: 0.0, force_y: 0.0, force_z: 10.0, mass: Some(2.0) };
 /// assert_eq!(f.mass, Some(2.0));
 /// ```
-#[derive(Component, Debug, Clone, Default, Serialize)]
+#[derive(Component, Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ForceComp {
-    pub fx: f32,
-    pub fy: f32,
-    pub fz: f32,
-    pub mass: Option<f32>,
+    #[serde(alias = "fx")]
+    pub force_x: f64,
+    #[serde(alias = "fy")]
+    pub force_y: f64,
+    #[serde(alias = "fz")]
+    pub force_z: f64,
+    pub mass: Option<f64>,
 }

--- a/src/components.rs
+++ b/src/components.rs
@@ -74,3 +74,11 @@ pub struct VelocityComp {
     pub vy: f32,
     pub vz: f32,
 }
+
+#[derive(Component, Debug, Clone, Default, Serialize)]
+pub struct ForceComp {
+    pub fx: f32,
+    pub fy: f32,
+    pub fz: f32,
+    pub mass: Option<f32>,
+}

--- a/src/components.rs
+++ b/src/components.rs
@@ -79,10 +79,10 @@ pub struct VelocityComp {
 /// `F = m·a`.
 ///
 /// Units:
-/// - `force_x`, `force_y`, `force_z` are forces in newtons applied for the
-///   current tick.
+/// - `force_x`, `force_y`, `force_z` are forces in newtons applied over the
+///   current simulation tick (one second).
 /// - `mass` is the entity's mass in kilograms. Use `Some(m)` for a known
-///   mass; use `None` to defer to the default mass.
+///   mass; use `None` to fall back to [`crate::DEFAULT_MASS`].
 ///
 /// Invariants:
 /// - `mass`, when provided, must be strictly positive.

--- a/src/components.rs
+++ b/src/components.rs
@@ -75,6 +75,26 @@ pub struct VelocityComp {
     pub vz: f32,
 }
 
+/// ECS component conveying an external force vector and optional mass for
+/// `F = m·a`.
+///
+/// Units:
+/// - `fx`, `fy`, `fz` are forces in newtons applied for the current tick.
+/// - `mass` is the entity's mass in kilograms. Use `Some(m)` for a known
+///   mass; use `None` to defer to the default mass.
+///
+/// Invariants:
+/// - `mass`, when provided, must be strictly positive.
+/// - Force components should be zero when no external force applies.
+///
+/// # Examples
+///
+/// Apply a 10 N upward force with an explicit 2 kg mass:
+/// ```
+/// use lille::components::ForceComp;
+/// let f = ForceComp { fx: 0.0, fy: 0.0, fz: 10.0, mass: Some(2.0) };
+/// assert_eq!(f.mass, Some(2.0));
+/// ```
 #[derive(Component, Debug, Clone, Default, Serialize)]
 pub struct ForceComp {
     pub fx: f32,

--- a/src/components.rs
+++ b/src/components.rs
@@ -76,16 +76,18 @@ pub struct VelocityComp {
 }
 
 /// ECS component conveying an external force vector and optional mass for
-/// `F = m·a`.
+/// `F = m·a`. Forces apply for a single tick and are cleared after the DBSP
+/// circuit runs.
 ///
 /// Units:
-/// - `force_x`, `force_y`, `force_z` are forces in newtons applied over the
-///   current simulation tick (one second).
-/// - `mass` is the entity's mass in kilograms. Use `Some(m)` for a known
-///   mass; use `None` to fall back to [`crate::DEFAULT_MASS`].
+/// - `force_x`, `force_y`, `force_z` are forces in newtons (N) applied for the
+///   current tick and cleared after each circuit step.
+/// - `mass` is the entity's mass in kilograms (kg). Use `Some(m)` for a known
+///   mass; use `None` to defer to the engine-defined default mass.
 ///
 /// Invariants:
-/// - `mass`, when provided, must be strictly positive.
+/// - `mass`, when provided, must be strictly positive; non-positive values are
+///   ignored by the physics pipeline.
 /// - Force components should be zero when no external force applies.
 ///
 /// # Examples

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -87,6 +87,30 @@ pub type NewVelocity = Velocity;
     Serialize,
     Deserialize,
     Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Default,
+    SizeOf,
+)]
+#[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
+pub struct Force {
+    pub entity: i64,
+    pub fx: OrderedFloat<f64>,
+    pub fy: OrderedFloat<f64>,
+    pub fz: OrderedFloat<f64>,
+    pub mass: Option<OrderedFloat<f64>>,
+}
+
+#[derive(
+    Archive,
+    Serialize,
+    Deserialize,
+    Clone,
     Debug,
     PartialEq,
     Eq,
@@ -128,6 +152,7 @@ pub struct DbspCircuit {
     circuit: CircuitHandle,
     position_in: ZSetHandle<Position>,
     velocity_in: ZSetHandle<Velocity>,
+    force_in: ZSetHandle<Force>,
     block_in: ZSetHandle<Block>,
     block_slope_in: ZSetHandle<BlockSlope>,
     new_position_out: OutputHandle<OrdZSet<NewPosition>>,
@@ -140,6 +165,7 @@ pub struct DbspCircuit {
 struct BuildHandles {
     position_in: ZSetHandle<Position>,
     velocity_in: ZSetHandle<Velocity>,
+    force_in: ZSetHandle<Force>,
     block_in: ZSetHandle<Block>,
     block_slope_in: ZSetHandle<BlockSlope>,
     new_position_out: OutputHandle<OrdZSet<NewPosition>>,
@@ -174,6 +200,7 @@ impl DbspCircuit {
             circuit,
             position_in: handles.position_in,
             velocity_in: handles.velocity_in,
+            force_in: handles.force_in,
             block_in: handles.block_in,
             block_slope_in: handles.block_slope_in,
             new_position_out: handles.new_position_out,
@@ -191,6 +218,7 @@ impl DbspCircuit {
     fn build_streams(circuit: &mut RootCircuit) -> Result<BuildHandles, AnyError> {
         let (positions, position_in) = circuit.add_input_zset::<Position>();
         let (velocities, velocity_in) = circuit.add_input_zset::<Velocity>();
+        let (forces, force_in) = circuit.add_input_zset::<Force>();
         let (blocks, block_in) = circuit.add_input_zset::<Block>();
         let (slopes, block_slope_in) = circuit.add_input_zset::<BlockSlope>();
 
@@ -206,24 +234,26 @@ impl DbspCircuit {
             .filter(|pf| pf.position.z.into_inner() <= pf.z_floor.into_inner() + GRACE_DISTANCE);
 
         let unsupported_positions = unsupported.map(|pf| pf.position);
-        let unsupported_velocities = velocities.map_index(|v| (v.entity, *v)).join(
+        let all_new_vel = new_velocity_stream(&velocities, &forces);
+        let unsupported_velocities = all_new_vel.map_index(|v| (v.entity, *v)).join(
             &unsupported.map_index(|pf| (pf.position.entity, ())),
             |_, vel, _| *vel,
         );
-        let new_vel_unsupported = new_velocity_stream(&unsupported_velocities);
-        let new_pos_unsupported = new_position_stream(&unsupported_positions, &new_vel_unsupported);
+        let new_pos_unsupported =
+            new_position_stream(&unsupported_positions, &unsupported_velocities);
 
         let (new_pos_standing, new_vel_standing) =
-            standing_motion_stream(&standing, &floor_height, &velocities);
+            standing_motion_stream(&standing, &floor_height, &all_new_vel);
 
         let new_pos = new_pos_unsupported.plus(&new_pos_standing);
-        let new_vel = new_vel_unsupported.plus(&new_vel_standing);
+        let new_vel = unsupported_velocities.plus(&new_vel_standing);
 
         Ok(BuildHandles {
             position_in,
             velocity_in,
             block_in,
             block_slope_in,
+            force_in,
             new_position_out: new_pos.output(),
             new_velocity_out: new_vel.output(),
             highest_block_out: highest.output(),
@@ -270,6 +300,14 @@ impl DbspCircuit {
     /// ```
     pub fn velocity_in(&self) -> &ZSetHandle<Velocity> {
         &self.velocity_in
+    }
+
+    /// Returns a reference to the input handle for feeding force records into the circuit.
+    ///
+    /// Use this handle to supply external forces acting on entities. If a
+    /// force is omitted for an entity, only gravity is applied.
+    pub fn force_in(&self) -> &ZSetHandle<Force> {
+        &self.force_in
     }
 
     /// Returns a reference to the input handle for feeding block records into the circuit.
@@ -409,6 +447,7 @@ impl DbspCircuit {
     pub fn clear_inputs(&mut self) {
         self.position_in.clear_input();
         self.velocity_in.clear_input();
+        self.force_in.clear_input();
         self.block_in.clear_input();
         self.block_slope_in.clear_input();
     }

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -98,6 +98,26 @@ pub type NewVelocity = Velocity;
     SizeOf,
 )]
 #[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
+/// Force applied to an entity.
+///
+/// Units:
+/// - `fx`, `fy`, `fz` are Newtons (N).
+/// - `mass` is kilograms (kg). When `mass` is `None`, a default mass is used downstream.
+/// - When `mass` is present but non-positive, the force is ignored.
+///
+/// # Examples
+/// ```rust,no_run
+/// # use lille::prelude::*;
+/// use ordered_float::OrderedFloat;
+/// let f = Force {
+///     entity: 42,
+///     fx: OrderedFloat(5.0),
+///     fy: OrderedFloat(0.0),
+///     fz: OrderedFloat(0.0),
+///     mass: Some(OrderedFloat(5.0)),
+/// };
+/// assert_eq!(f.entity, 42);
+/// ```
 pub struct Force {
     pub entity: i64,
     pub fx: OrderedFloat<f64>,
@@ -306,6 +326,25 @@ impl DbspCircuit {
     ///
     /// Use this handle to supply external forces acting on entities. If a
     /// force is omitted for an entity, only gravity is applied.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use lille::prelude::*;
+    /// # use ordered_float::OrderedFloat;
+    /// let circuit = DbspCircuit::new().expect("circuit construction failed");
+    /// let force_in = circuit.force_in();
+    /// force_in.push(
+    ///     Force {
+    ///         entity: 1,
+    ///         fx: OrderedFloat(5.0),
+    ///         fy: OrderedFloat(0.0),
+    ///         fz: OrderedFloat(0.0),
+    ///         mass: Some(OrderedFloat(5.0)),
+    ///     },
+    ///     1,
+    /// );
+    /// ```
     pub fn force_in(&self) -> &ZSetHandle<Force> {
         &self.force_in
     }

--- a/src/dbsp_circuit/streams.rs
+++ b/src/dbsp_circuit/streams.rs
@@ -99,7 +99,8 @@ pub(super) fn floor_height_stream(
         .flat_map(|fh| fh.clone())
 }
 
-/// Applies gravity and a single external force to each velocity record.
+/// Applies gravity and a single external force to each velocity record
+/// (dt = 1).
 ///
 /// Each entity may supply at most one [`Force`] record per tick. Forces with
 /// invalid masses are ignored with a log warning.

--- a/src/dbsp_circuit/streams.rs
+++ b/src/dbsp_circuit/streams.rs
@@ -18,7 +18,8 @@ use ordered_float::OrderedFloat;
 use crate::components::{Block, BlockSlope};
 use crate::{BLOCK_CENTRE_OFFSET, BLOCK_TOP_OFFSET, GRAVITY_PULL};
 
-use super::{FloorHeightAt, HighestBlockAt, Position, Velocity};
+use super::{FloorHeightAt, Force, HighestBlockAt, Position, Velocity};
+use crate::physics::applied_acceleration;
 
 /// Returns a stream pairing each grid cell with its highest block and id.
 ///
@@ -105,13 +106,40 @@ pub(super) fn floor_height_stream(
 /// through the remaining fields unchanged.
 pub(super) fn new_velocity_stream(
     velocities: &Stream<RootCircuit, OrdZSet<Velocity>>,
+    forces: &Stream<RootCircuit, OrdZSet<Force>>,
 ) -> Stream<RootCircuit, OrdZSet<Velocity>> {
-    velocities.map(|v| Velocity {
-        entity: v.entity,
-        vx: v.vx,
-        vy: v.vy,
-        vz: OrderedFloat(v.vz.into_inner() + GRAVITY_PULL),
-    })
+    velocities
+        .map_index(|v| (v.entity, *v))
+        .outer_join(
+            &forces.map_index(|f| (f.entity, *f)),
+            |_, vel, force| {
+                let accel = applied_acceleration(
+                    (
+                        force.fx.into_inner(),
+                        force.fy.into_inner(),
+                        force.fz.into_inner(),
+                    ),
+                    force.mass.map(|m| m.into_inner()),
+                );
+                let (ax, ay, az) = accel.unwrap_or((0.0, 0.0, 0.0));
+                Some(Velocity {
+                    entity: vel.entity,
+                    vx: OrderedFloat(vel.vx.into_inner() + ax),
+                    vy: OrderedFloat(vel.vy.into_inner() + ay),
+                    vz: OrderedFloat(vel.vz.into_inner() + az + GRAVITY_PULL),
+                })
+            },
+            |_, vel| {
+                Some(Velocity {
+                    entity: vel.entity,
+                    vx: vel.vx,
+                    vy: vel.vy,
+                    vz: OrderedFloat(vel.vz.into_inner() + GRAVITY_PULL),
+                })
+            },
+            |_, _| None,
+        )
+        .flat_map(|v| *v)
 }
 
 /// Integrates positions with updated velocities.

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -73,7 +73,7 @@ pub fn init_dbsp_system(world: &mut World) -> Result<(), dbsp::Error> {
 
 /// Caches current ECS state into the DBSP circuit inputs.
 ///
-/// This system gathers `Transform`, optional `Velocity`, and `Block`
+/// This system gathers `Transform`, optional `Velocity`, `Block`, and `Force`
 /// components and pushes them into the circuit's input handles.
 pub fn cache_state_for_dbsp_system(
     mut state: NonSendMut<DbspState>,

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -120,10 +120,10 @@ pub fn cache_state_for_dbsp_system(
             state.circuit.force_in().push(
                 Force {
                     entity: id.0,
-                    fx: (f.fx as f64).into(),
-                    fy: (f.fy as f64).into(),
-                    fz: (f.fz as f64).into(),
-                    mass: f.mass.map(|m| (m as f64).into()),
+                    fx: f.force_x.into(),
+                    fy: f.force_y.into(),
+                    fz: f.force_z.into(),
+                    mass: f.mass.map(|m| m.into()),
                 },
                 1,
             );

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -74,7 +74,8 @@ pub fn init_dbsp_system(world: &mut World) -> Result<(), dbsp::Error> {
 /// Caches current ECS state into the DBSP circuit inputs.
 ///
 /// This system gathers `Transform`, optional `Velocity`, `Block`, and optional
-/// `Force` components and pushes them into the circuit's input handles.
+/// `Force` components and pushes them into the circuit's input handles. Forces
+/// for entities not present in the current position pass are ignored.
 pub fn cache_state_for_dbsp_system(
     mut state: NonSendMut<DbspState>,
     entity_query: Query<(Entity, &DdlogId, &Transform, Option<&VelocityComp>)>,

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -73,8 +73,8 @@ pub fn init_dbsp_system(world: &mut World) -> Result<(), dbsp::Error> {
 
 /// Caches current ECS state into the DBSP circuit inputs.
 ///
-/// This system gathers `Transform`, optional `Velocity`, `Block`, and `Force`
-/// components and pushes them into the circuit's input handles.
+/// This system gathers `Transform`, optional `Velocity`, `Block`, and optional
+/// `Force` components and pushes them into the circuit's input handles.
 pub fn cache_state_for_dbsp_system(
     mut state: NonSendMut<DbspState>,
     entity_query: Query<(Entity, &DdlogId, &Transform, Option<&VelocityComp>)>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,9 @@ pub mod prelude {
     //! use lille::prelude::*;
     //! ```
 
+    pub use crate::applied_acceleration;
     pub use crate::components::Block;
+    pub use crate::dbsp_circuit::Force;
     pub use crate::DbspCircuit;
     pub use crate::DbspPlugin;
     pub use crate::FloorHeightAt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod dbsp_sync;
 pub mod ddlog_sync;
 pub mod entity;
 pub mod logging;
+pub mod physics;
 pub mod spawn_world;
 pub mod vector_math;
 pub mod world_handle;
@@ -15,9 +16,9 @@ pub use constants::*;
 
 // Re-export commonly used items
 pub use actor::Actor;
-pub use components::{DdlogId, Health, Target, UnitType, VelocityComp};
+pub use components::{DdlogId, ForceComp, Health, Target, UnitType, VelocityComp};
 pub use dbsp_circuit::{
-    DbspCircuit, FloorHeightAt, HighestBlockAt, NewPosition, Position, PositionFloor,
+    DbspCircuit, FloorHeightAt, Force, HighestBlockAt, NewPosition, Position, PositionFloor,
 };
 pub use dbsp_circuit::{NewVelocity, Velocity};
 pub use dbsp_sync::{
@@ -26,6 +27,7 @@ pub use dbsp_sync::{
 pub use ddlog_sync::{apply_ddlog_deltas_system, cache_state_for_ddlog_system};
 pub use entity::{BadGuy, Entity};
 pub use logging::init as init_logging;
+pub use physics::applied_acceleration;
 pub use spawn_world::spawn_world_system;
 pub use vector_math::{vec_mag, vec_normalize};
 pub use world_handle::{init_world_handle_system, WorldHandle};

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -7,11 +7,14 @@
 
 use crate::DEFAULT_MASS;
 
+/// Smallest acceptable mass to avoid numerically unstable accelerations.
+const MIN_MASS: f64 = 1e-12;
+
 /// Computes acceleration from a force vector and optional mass.
 ///
-/// Returns `None` if `mass` is non-positive. When `mass` is `None` the
-/// [`DEFAULT_MASS`] constant is used. The calculation applies `F=ma` for
-/// each component independently.
+/// Returns `None` if `mass` is non-positive or effectively zero (see
+/// [`MIN_MASS`]). When `mass` is `None` the [`DEFAULT_MASS`] constant is
+/// used. The calculation applies `F=ma` for each component independently.
 ///
 /// # Examples
 ///
@@ -24,12 +27,14 @@ use crate::DEFAULT_MASS;
 /// ```
 pub fn applied_acceleration(force: (f64, f64, f64), mass: Option<f64>) -> Option<(f64, f64, f64)> {
     match mass {
-        Some(m) if m > 0.0 => Some((force.0 / m, force.1 / m, force.2 / m)),
+        Some(m) if m > MIN_MASS => {
+            let (fx, fy, fz) = force;
+            Some((fx / m, fy / m, fz / m))
+        }
         Some(_) => None,
-        None => Some((
-            force.0 / DEFAULT_MASS,
-            force.1 / DEFAULT_MASS,
-            force.2 / DEFAULT_MASS,
-        )),
+        None => {
+            let (fx, fy, fz) = force;
+            Some((fx / DEFAULT_MASS, fy / DEFAULT_MASS, fz / DEFAULT_MASS))
+        }
     }
 }

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -1,0 +1,35 @@
+//! Physics helper functions.
+//!
+//! Provides utilities for basic physics calculations used by the
+//! simulation. These functions operate on simple numeric tuples so they
+//! can be reused both inside the DBSP circuit and in standalone unit
+//! tests.
+
+use crate::DEFAULT_MASS;
+
+/// Computes acceleration from a force vector and optional mass.
+///
+/// Returns `None` if `mass` is non-positive. When `mass` is `None` the
+/// [`DEFAULT_MASS`] constant is used. The calculation applies `F=ma` for
+/// each component independently.
+///
+/// # Examples
+///
+/// ```
+/// use lille::applied_acceleration;
+/// let (ax, ay, az) = applied_acceleration((7.0, -14.0, 21.0), Some(7.0)).unwrap();
+/// assert!((ax - 1.0).abs() < 1e-6);
+/// assert!((ay + 2.0).abs() < 1e-6);
+/// assert!((az - 3.0).abs() < 1e-6);
+/// ```
+pub fn applied_acceleration(force: (f64, f64, f64), mass: Option<f64>) -> Option<(f64, f64, f64)> {
+    match mass {
+        Some(m) if m > 0.0 => Some((force.0 / m, force.1 / m, force.2 / m)),
+        Some(_) => None,
+        None => Some((
+            force.0 / DEFAULT_MASS,
+            force.1 / DEFAULT_MASS,
+            force.2 / DEFAULT_MASS,
+        )),
+    }
+}

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -10,11 +10,6 @@ use crate::DEFAULT_MASS;
 /// Smallest acceptable mass to avoid numerically unstable accelerations.
 const MIN_MASS: f64 = 1e-12;
 
-const _: () = assert!(
-    DEFAULT_MASS > MIN_MASS,
-    "DEFAULT_MASS must exceed MIN_MASS to avoid unstable defaults"
-);
-
 /// Computes acceleration from a force vector and optional mass.
 ///
 /// Returns `None` if `mass` is non-positive or effectively zero (see
@@ -25,12 +20,21 @@ const _: () = assert!(
 ///
 /// ```
 /// use lille::applied_acceleration;
-/// let (ax, ay, az) = applied_acceleration((7.0, -14.0, 21.0), Some(7.0)).unwrap();
+/// let (ax, ay, az) = applied_acceleration((7.0, -14.0, 21.0), Some(7.0))
+///     .expect("valid positive mass yields acceleration");
 /// assert!((ax - 1.0).abs() < 1e-6);
 /// assert!((ay + 2.0).abs() < 1e-6);
 /// assert!((az - 3.0).abs() < 1e-6);
 /// ```
+#[expect(
+    clippy::assertions_on_constants,
+    reason = "guard against misconfigured default masses"
+)]
 pub fn applied_acceleration(force: (f64, f64, f64), mass: Option<f64>) -> Option<(f64, f64, f64)> {
+    debug_assert!(
+        DEFAULT_MASS > MIN_MASS,
+        "DEFAULT_MASS must exceed MIN_MASS to avoid unstable defaults",
+    );
     match mass {
         Some(m) if m > MIN_MASS => {
             let (fx, fy, fz) = force;

--- a/src/physics.rs
+++ b/src/physics.rs
@@ -10,6 +10,11 @@ use crate::DEFAULT_MASS;
 /// Smallest acceptable mass to avoid numerically unstable accelerations.
 const MIN_MASS: f64 = 1e-12;
 
+const _: () = assert!(
+    DEFAULT_MASS > MIN_MASS,
+    "DEFAULT_MASS must exceed MIN_MASS to avoid unstable defaults"
+);
+
 /// Computes acceleration from a force vector and optional mass.
 ///
 /// Returns `None` if `mass` is non-positive or effectively zero (see

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -6,3 +6,4 @@ publish = false
 
 [dependencies]
 syn = { version = "2.0.103", features = ["full"] }
+lille = { path = ".." }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,5 +1,9 @@
 //! Utility helpers for tests.
-//! Provides assertions for verifying generated code.
+//! Provides assertions for verifying generated code and constructors for
+//! common physics records.
+
+pub mod physics;
+pub use physics::{block, force, force_with_mass, new_circuit, pos, vel};
 
 /// Assert that all strings in `keys` are present in `code`.
 ///

--- a/test_utils/src/physics.rs
+++ b/test_utils/src/physics.rs
@@ -36,35 +36,36 @@ pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
 /// # Examples
 /// ```
 /// use test_utils::physics::force;
-/// let f = force(1, 10.0, 0.0, 0.0);
+/// let f = force(1, (10.0, 0.0, 0.0));
 /// assert_eq!(f.entity, 1);
 /// assert!(f.mass.is_none());
 /// ```
-pub fn force(entity: i64, fx: f64, fy: f64, fz: f64) -> Force {
+pub fn force(entity: i64, force: (f64, f64, f64)) -> Force {
     Force {
         entity,
-        fx: fx.into(),
-        fy: fy.into(),
-        fz: fz.into(),
+        fx: force.0.into(),
+        fy: force.1.into(),
+        fz: force.2.into(),
         mass: None,
     }
 }
 
-/// Convenience constructor for [`Force`] records with an explicit mass used in tests.
+/// Convenience constructor for [`Force`] records with an explicit mass used in
+/// tests.
 ///
 /// # Examples
 /// ```
 /// use test_utils::physics::force_with_mass;
-/// let f = force_with_mass(1, 10.0, 0.0, 0.0, 5.0);
+/// let f = force_with_mass(1, (10.0, 0.0, 0.0), 5.0);
 /// assert_eq!(f.entity, 1);
 /// assert_eq!(f.mass.unwrap().into_inner(), 5.0);
 /// ```
-pub fn force_with_mass(entity: i64, fx: f64, fy: f64, fz: f64, mass: f64) -> Force {
+pub fn force_with_mass(entity: i64, force: (f64, f64, f64), mass: f64) -> Force {
     Force {
         entity,
-        fx: fx.into(),
-        fy: fy.into(),
-        fz: fz.into(),
+        fx: force.0.into(),
+        fy: force.1.into(),
+        fz: force.2.into(),
         mass: Some(mass.into()),
     }
 }

--- a/test_utils/src/physics.rs
+++ b/test_utils/src/physics.rs
@@ -1,19 +1,17 @@
-//! Shared utilities for constructing common physics records in tests.
-#![allow(unfulfilled_lint_expectations)]
+//! Convenience constructors for physics-related records used in tests.
 
 use lille::components::Block;
 use lille::dbsp_circuit::{DbspCircuit, Force, Position, Velocity};
 
-/// Create a new `DbspCircuit` for tests.
+/// Create a new [`DbspCircuit`] for tests.
 ///
+/// # Panics
 /// Panics if the circuit cannot be constructed.
-#[allow(dead_code)]
 pub fn new_circuit() -> DbspCircuit {
     DbspCircuit::new().expect("failed to build DBSP circuit")
 }
 
 /// Convenience constructor for [`Position`] records used in tests.
-#[allow(dead_code)]
 pub fn pos(entity: i64, x: f64, y: f64, z: f64) -> Position {
     Position {
         entity,
@@ -24,7 +22,6 @@ pub fn pos(entity: i64, x: f64, y: f64, z: f64) -> Position {
 }
 
 /// Convenience constructor for [`Velocity`] records used in tests.
-#[allow(dead_code)]
 pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
     Velocity {
         entity,
@@ -35,10 +32,6 @@ pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
 }
 
 /// Convenience constructor for [`Force`] records without mass used in tests.
-#[expect(
-    dead_code,
-    reason = "Test utility function used across multiple test files"
-)]
 pub fn force(entity: i64, fx: f64, fy: f64, fz: f64) -> Force {
     Force {
         entity,
@@ -50,10 +43,6 @@ pub fn force(entity: i64, fx: f64, fy: f64, fz: f64) -> Force {
 }
 
 /// Convenience constructor for [`Force`] records with an explicit mass used in tests.
-#[expect(
-    dead_code,
-    reason = "Test utility function used across multiple test files"
-)]
 pub fn force_with_mass(entity: i64, fx: f64, fy: f64, fz: f64, mass: f64) -> Force {
     Force {
         entity,
@@ -65,7 +54,6 @@ pub fn force_with_mass(entity: i64, fx: f64, fy: f64, fz: f64, mass: f64) -> For
 }
 
 /// Convenience constructor for [`Block`] records used in tests.
-#[allow(dead_code)]
 pub fn block(id: i64, x: i32, y: i32, z: i32) -> Block {
     Block { id, x, y, z }
 }

--- a/test_utils/src/physics.rs
+++ b/test_utils/src/physics.rs
@@ -32,6 +32,14 @@ pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
 }
 
 /// Convenience constructor for [`Force`] records without mass used in tests.
+///
+/// # Examples
+/// ```
+/// use test_utils::physics::force;
+/// let f = force(1, 10.0, 0.0, 0.0);
+/// assert_eq!(f.entity, 1);
+/// assert!(f.mass.is_none());
+/// ```
 pub fn force(entity: i64, fx: f64, fy: f64, fz: f64) -> Force {
     Force {
         entity,
@@ -43,6 +51,14 @@ pub fn force(entity: i64, fx: f64, fy: f64, fz: f64) -> Force {
 }
 
 /// Convenience constructor for [`Force`] records with an explicit mass used in tests.
+///
+/// # Examples
+/// ```
+/// use test_utils::physics::force_with_mass;
+/// let f = force_with_mass(1, 10.0, 0.0, 0.0, 5.0);
+/// assert_eq!(f.entity, 1);
+/// assert_eq!(f.mass.unwrap().into_inner(), 5.0);
+/// ```
 pub fn force_with_mass(entity: i64, fx: f64, fy: f64, fz: f64, mass: f64) -> Force {
     Force {
         entity,

--- a/test_utils/src/physics.rs
+++ b/test_utils/src/physics.rs
@@ -67,14 +67,18 @@ pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
 /// assert_eq!(f.entity, 1);
 /// assert!(f.mass.is_none());
 /// ```
-pub fn force(entity: i64, (fx, fy, fz): (f64, f64, f64)) -> Force {
+fn force_inner(entity: i64, (fx, fy, fz): (f64, f64, f64), mass: Option<f64>) -> Force {
     Force {
         entity,
         fx: fx.into(),
         fy: fy.into(),
         fz: fz.into(),
-        mass: None,
+        mass: mass.map(Into::into),
     }
+}
+
+pub fn force(entity: i64, force: (f64, f64, f64)) -> Force {
+    force_inner(entity, force, None)
 }
 
 /// Convenience constructor for [`Force`] records with an explicit mass used in
@@ -87,14 +91,8 @@ pub fn force(entity: i64, (fx, fy, fz): (f64, f64, f64)) -> Force {
 /// assert_eq!(f.entity, 1);
 /// assert_eq!(f.mass.unwrap().into_inner(), 5.0);
 /// ```
-pub fn force_with_mass(entity: i64, (fx, fy, fz): (f64, f64, f64), mass: f64) -> Force {
-    Force {
-        entity,
-        fx: fx.into(),
-        fy: fy.into(),
-        fz: fz.into(),
-        mass: Some(mass.into()),
-    }
+pub fn force_with_mass(entity: i64, force: (f64, f64, f64), mass: f64) -> Force {
+    force_inner(entity, force, Some(mass))
 }
 
 /// Convenience constructor for [`Block`] records used in tests.

--- a/test_utils/src/physics.rs
+++ b/test_utils/src/physics.rs
@@ -7,11 +7,28 @@ use lille::dbsp_circuit::{DbspCircuit, Force, Position, Velocity};
 ///
 /// # Panics
 /// Panics if the circuit cannot be constructed.
+///
+/// # Examples
+/// ```no_run
+/// use test_utils::physics::new_circuit;
+/// let circuit = new_circuit();
+/// drop(circuit);
+/// ```
 pub fn new_circuit() -> DbspCircuit {
     DbspCircuit::new().expect("failed to build DBSP circuit")
 }
 
 /// Convenience constructor for [`Position`] records used in tests.
+///
+/// # Examples
+/// ```
+/// use test_utils::physics::pos;
+/// let p = pos(1, 0.0, 1.0, 2.0);
+/// assert_eq!(p.entity, 1);
+/// assert_eq!(p.x.into_inner(), 0.0);
+/// assert_eq!(p.y.into_inner(), 1.0);
+/// assert_eq!(p.z.into_inner(), 2.0);
+/// ```
 pub fn pos(entity: i64, x: f64, y: f64, z: f64) -> Position {
     Position {
         entity,
@@ -22,6 +39,16 @@ pub fn pos(entity: i64, x: f64, y: f64, z: f64) -> Position {
 }
 
 /// Convenience constructor for [`Velocity`] records used in tests.
+///
+/// # Examples
+/// ```
+/// use test_utils::physics::vel;
+/// let v = vel(1, 0.5, -0.5, 1.0);
+/// assert_eq!(v.entity, 1);
+/// assert_eq!(v.vx.into_inner(), 0.5);
+/// assert_eq!(v.vy.into_inner(), -0.5);
+/// assert_eq!(v.vz.into_inner(), 1.0);
+/// ```
 pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
     Velocity {
         entity,
@@ -40,12 +67,12 @@ pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
 /// assert_eq!(f.entity, 1);
 /// assert!(f.mass.is_none());
 /// ```
-pub fn force(entity: i64, force: (f64, f64, f64)) -> Force {
+pub fn force(entity: i64, (fx, fy, fz): (f64, f64, f64)) -> Force {
     Force {
         entity,
-        fx: force.0.into(),
-        fy: force.1.into(),
-        fz: force.2.into(),
+        fx: fx.into(),
+        fy: fy.into(),
+        fz: fz.into(),
         mass: None,
     }
 }
@@ -60,17 +87,27 @@ pub fn force(entity: i64, force: (f64, f64, f64)) -> Force {
 /// assert_eq!(f.entity, 1);
 /// assert_eq!(f.mass.unwrap().into_inner(), 5.0);
 /// ```
-pub fn force_with_mass(entity: i64, force: (f64, f64, f64), mass: f64) -> Force {
+pub fn force_with_mass(entity: i64, (fx, fy, fz): (f64, f64, f64), mass: f64) -> Force {
     Force {
         entity,
-        fx: force.0.into(),
-        fy: force.1.into(),
-        fz: force.2.into(),
+        fx: fx.into(),
+        fy: fy.into(),
+        fz: fz.into(),
         mass: Some(mass.into()),
     }
 }
 
 /// Convenience constructor for [`Block`] records used in tests.
+///
+/// # Examples
+/// ```
+/// use test_utils::physics::block;
+/// let b = block(1, 0, 0, 0);
+/// assert_eq!(b.id, 1);
+/// assert_eq!(b.x, 0);
+/// assert_eq!(b.y, 0);
+/// assert_eq!(b.z, 0);
+/// ```
 pub fn block(id: i64, x: i32, y: i32, z: i32) -> Block {
     Block { id, x, y, z }
 }

--- a/tests/applied_acceleration.rs
+++ b/tests/applied_acceleration.rs
@@ -9,6 +9,8 @@ use rstest::rstest;
 #[case::default_mass((70.0, 0.0, 0.0), None, Some((1.0, 0.0, 0.0)))]
 #[case::invalid_mass((1.0, 1.0, 1.0), Some(0.0), None)]
 #[case::negative_mass((1.0, 1.0, 1.0), Some(-5.0), None)]
+#[case::near_zero_mass((1.0, 0.0, 0.0), Some(1e-20), None)]
+#[case::extremely_large_mass((1.0, 2.0, 3.0), Some(1e12), Some((1e-12, 2e-12, 3e-12)))]
 fn acceleration_cases(
     #[case] force: (f64, f64, f64),
     #[case] mass: Option<f64>,

--- a/tests/applied_acceleration.rs
+++ b/tests/applied_acceleration.rs
@@ -1,12 +1,12 @@
 //! Unit tests for physics calculations.
 //! Covers acceleration helper functions for edge cases and typical inputs.
 use approx::assert_relative_eq;
-use lille::applied_acceleration;
+use lille::{applied_acceleration, DEFAULT_MASS};
 use rstest::rstest;
 
 #[rstest]
 #[case::explicit_mass((7.0, -14.0, 21.0), Some(7.0), Some((1.0, -2.0, 3.0)))]
-#[case::default_mass((70.0, 0.0, 0.0), None, Some((1.0, 0.0, 0.0)))]
+#[case::default_mass((70.0, 0.0, 0.0), None, Some((70.0 / DEFAULT_MASS, 0.0, 0.0)))]
 #[case::invalid_mass((1.0, 1.0, 1.0), Some(0.0), None)]
 #[case::negative_mass((1.0, 1.0, 1.0), Some(-5.0), None)]
 #[case::near_zero_mass((1.0, 0.0, 0.0), Some(1e-20), None)]
@@ -19,9 +19,9 @@ fn acceleration_cases(
     let acc = applied_acceleration(force, mass);
     match (acc, expected) {
         (Some(a), Some(e)) => {
-            assert_relative_eq!(a.0, e.0);
-            assert_relative_eq!(a.1, e.1);
-            assert_relative_eq!(a.2, e.2);
+            assert_relative_eq!(a.0, e.0, epsilon = 1e-12);
+            assert_relative_eq!(a.1, e.1, epsilon = 1e-12);
+            assert_relative_eq!(a.2, e.2, epsilon = 1e-12);
         }
         (None, None) => {}
         (a, e) => panic!("mismatch: {a:?} vs {e:?}"),

--- a/tests/applied_acceleration.rs
+++ b/tests/applied_acceleration.rs
@@ -1,38 +1,27 @@
 //! Unit tests for physics calculations.
 //! Covers acceleration helper functions for edge cases and typical inputs.
 use approx::assert_relative_eq;
-use lille::DEFAULT_MASS;
+use lille::applied_acceleration;
+use rstest::rstest;
 
-fn applied_acceleration(force: (f32, f32, f32), mass: Option<f32>) -> Option<(f32, f32, f32)> {
-    match mass {
-        Some(m) if m > 0.0 => Some((force.0 / m, force.1 / m, force.2 / m)),
-        Some(_) => None,
-        None => Some((
-            force.0 / DEFAULT_MASS as f32,
-            force.1 / DEFAULT_MASS as f32,
-            force.2 / DEFAULT_MASS as f32,
-        )),
+#[rstest]
+#[case::explicit_mass((7.0, -14.0, 21.0), Some(7.0), Some((1.0, -2.0, 3.0)))]
+#[case::default_mass((70.0, 0.0, 0.0), None, Some((1.0, 0.0, 0.0)))]
+#[case::invalid_mass((1.0, 1.0, 1.0), Some(0.0), None)]
+#[case::negative_mass((1.0, 1.0, 1.0), Some(-5.0), None)]
+fn acceleration_cases(
+    #[case] force: (f64, f64, f64),
+    #[case] mass: Option<f64>,
+    #[case] expected: Option<(f64, f64, f64)>,
+) {
+    let acc = applied_acceleration(force, mass);
+    match (acc, expected) {
+        (Some(a), Some(e)) => {
+            assert_relative_eq!(a.0, e.0);
+            assert_relative_eq!(a.1, e.1);
+            assert_relative_eq!(a.2, e.2);
+        }
+        (None, None) => {}
+        (a, e) => panic!("mismatch: {a:?} vs {e:?}"),
     }
-}
-
-#[test]
-fn acceleration_divides_force_by_mass() {
-    let acc = applied_acceleration((7.0, -14.0, 21.0), Some(7.0)).unwrap();
-    assert_relative_eq!(acc.0, 1.0);
-    assert_relative_eq!(acc.1, -2.0);
-    assert_relative_eq!(acc.2, 3.0);
-}
-
-#[test]
-fn acceleration_uses_default_mass_when_missing() {
-    let acc = applied_acceleration((70.0, 0.0, 0.0), None).unwrap();
-    assert_relative_eq!(acc.0, 1.0);
-    assert_relative_eq!(acc.1, 0.0);
-    assert_relative_eq!(acc.2, 0.0);
-}
-
-#[test]
-fn acceleration_filters_non_positive_mass() {
-    assert!(applied_acceleration((1.0, 1.0, 1.0), Some(0.0)).is_none());
-    assert!(applied_acceleration((1.0, 1.0, 1.0), Some(-5.0)).is_none());
 }

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,5 +1,5 @@
 use lille::components::Block;
-use lille::dbsp_circuit::{DbspCircuit, Position, Velocity};
+use lille::dbsp_circuit::{DbspCircuit, Force, Position, Velocity};
 
 /// Create a new `DbspCircuit` for tests.
 ///
@@ -28,6 +28,17 @@ pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
         vx: vx.into(),
         vy: vy.into(),
         vz: vz.into(),
+    }
+}
+
+#[allow(dead_code)]
+pub fn force(entity: i64, fx: f64, fy: f64, fz: f64, mass: Option<f64>) -> Force {
+    Force {
+        entity,
+        fx: fx.into(),
+        fy: fy.into(),
+        fz: fz.into(),
+        mass: mass.map(|m| m.into()),
     }
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,3 +1,6 @@
+//! Shared utilities for constructing common physics records in tests.
+#![allow(unfulfilled_lint_expectations)]
+
 use lille::components::Block;
 use lille::dbsp_circuit::{DbspCircuit, Force, Position, Velocity};
 
@@ -31,14 +34,33 @@ pub fn vel(entity: i64, vx: f64, vy: f64, vz: f64) -> Velocity {
     }
 }
 
-#[allow(dead_code)]
-pub fn force(entity: i64, fx: f64, fy: f64, fz: f64, mass: Option<f64>) -> Force {
+/// Convenience constructor for [`Force`] records without mass used in tests.
+#[expect(
+    dead_code,
+    reason = "Test utility function used across multiple test files"
+)]
+pub fn force(entity: i64, fx: f64, fy: f64, fz: f64) -> Force {
     Force {
         entity,
         fx: fx.into(),
         fy: fy.into(),
         fz: fz.into(),
-        mass: mass.map(|m| m.into()),
+        mass: None,
+    }
+}
+
+/// Convenience constructor for [`Force`] records with an explicit mass used in tests.
+#[expect(
+    dead_code,
+    reason = "Test utility function used across multiple test files"
+)]
+pub fn force_with_mass(entity: i64, fx: f64, fy: f64, fz: f64, mass: f64) -> Force {
+    Force {
+        entity,
+        fx: fx.into(),
+        fy: fy.into(),
+        fz: fz.into(),
+        mass: Some(mass.into()),
     }
 }
 

--- a/tests/dbsp_floor_height.rs
+++ b/tests/dbsp_floor_height.rs
@@ -2,8 +2,8 @@ use lille::{
     components::{Block, BlockSlope},
     dbsp_circuit::FloorHeightAt,
 };
-mod common;
 use rstest::rstest;
+use test_utils::new_circuit;
 
 fn blk(id: i64, x: i32, y: i32, z: i32) -> Block {
     Block { id, x, y, z }
@@ -35,7 +35,7 @@ fn floor_height_cases(
     #[case] slopes: Vec<BlockSlope>,
     #[case] expected: Vec<FloorHeightAt>,
 ) {
-    let mut circuit = common::new_circuit();
+    let mut circuit = new_circuit();
     for b in &blocks {
         circuit.block_in().push(b.clone(), 1);
     }
@@ -57,7 +57,7 @@ fn floor_height_cases(
 
 #[test]
 fn unmatched_slope_is_ignored() {
-    let mut circuit = common::new_circuit();
+    let mut circuit = new_circuit();
     circuit.block_in().push(blk(1, 0, 0, 0), 1);
     circuit.block_slope_in().push(slope(2, 1.0, 0.0), 1);
 
@@ -75,7 +75,7 @@ fn unmatched_slope_is_ignored() {
 
 #[test]
 fn slope_without_block_yields_no_height() {
-    let mut circuit = common::new_circuit();
+    let mut circuit = new_circuit();
     circuit.block_slope_in().push(slope(1, 1.0, 0.0), 1);
 
     circuit.step().expect("step");

--- a/tests/dbsp_highest_block.rs
+++ b/tests/dbsp_highest_block.rs
@@ -4,9 +4,8 @@
 //! at each `(x, y)` coordinate pair from multiple input blocks.
 
 use lille::{components::Block, dbsp_circuit::HighestBlockAt};
-mod common;
-use common::block;
 use rstest::rstest;
+use test_utils::{block, new_circuit};
 
 fn hb(x: i32, y: i32, z: i32) -> HighestBlockAt {
     HighestBlockAt { x, y, z }
@@ -14,7 +13,7 @@ fn hb(x: i32, y: i32, z: i32) -> HighestBlockAt {
 
 #[test]
 fn test_highest_block_aggregation() {
-    let mut circuit = common::new_circuit();
+    let mut circuit = new_circuit();
 
     circuit.block_in().push(
         Block {
@@ -60,7 +59,7 @@ fn test_highest_block_aggregation() {
 #[case::duplicate_same_height(vec![block(1,1,1,5), block(2,1,1,5)], vec![hb(1,1,5)])]
 #[case::mixed(vec![block(1,0,0,3), block(2,0,0,1), block(3,0,1,4)], vec![hb(0,0,3), hb(0,1,4)])]
 fn highest_block_cases(#[case] blocks: Vec<Block>, #[case] expected: Vec<HighestBlockAt>) {
-    let mut circuit = common::new_circuit();
+    let mut circuit = new_circuit();
     for blk in blocks {
         circuit.block_in().push(blk, 1);
     }

--- a/tests/dbsp_motion_logic.rs
+++ b/tests/dbsp_motion_logic.rs
@@ -39,7 +39,7 @@ use test_utils::{block, force_with_mass, new_circuit, vel};
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.0.into() },
     vel(1, 0.0, 0.0, 0.0),
     vec![block(1, 0, 0, 0), block(2, 1, 0, 1)],
-    Some(force_with_mass(1, 5.0, 0.0, 0.0, 5.0)),
+    Some(force_with_mass(1, (5.0, 0.0, 0.0), 5.0)),
     Position { entity: 1, x: 1.0.into(), y: 0.0.into(), z: 2.0.into() },
     vel(1, 1.0, 0.0, 0.0),
 )]
@@ -47,7 +47,7 @@ use test_utils::{block, force_with_mass, new_circuit, vel};
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 2.1.into() },
     vel(1, 0.0, 0.0, 0.0),
     vec![block(1, 0, 0, 0)],
-    Some(force_with_mass(1, 0.0, 0.0, 10.0, 0.0)),
+    Some(force_with_mass(1, (0.0, 0.0, 10.0), 0.0)),
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.1.into() },
     vel(1, 0.0, 0.0, GRAVITY_PULL),
 )]

--- a/tests/dbsp_motion_logic.rs
+++ b/tests/dbsp_motion_logic.rs
@@ -10,7 +10,7 @@ use lille::GRAVITY_PULL;
 use rstest::rstest;
 
 mod common;
-use common::{block, force, new_circuit, vel};
+use common::{block, force_with_mass, new_circuit, vel};
 
 #[rstest]
 #[case::standing_moves(
@@ -41,7 +41,7 @@ use common::{block, force, new_circuit, vel};
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.0.into() },
     vel(1, 0.0, 0.0, 0.0),
     vec![block(1, 0, 0, 0), block(2, 1, 0, 1)],
-    Some(force(1, 5.0, 0.0, 0.0, Some(5.0))),
+    Some(force_with_mass(1, 5.0, 0.0, 0.0, 5.0)),
     Position { entity: 1, x: 1.0.into(), y: 0.0.into(), z: 2.0.into() },
     vel(1, 1.0, 0.0, 0.0),
 )]
@@ -49,7 +49,7 @@ use common::{block, force, new_circuit, vel};
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 2.1.into() },
     vel(1, 0.0, 0.0, 0.0),
     vec![block(1, 0, 0, 0)],
-    Some(force(1, 0.0, 0.0, 10.0, Some(0.0))),
+    Some(force_with_mass(1, 0.0, 0.0, 10.0, 0.0)),
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.1.into() },
     vel(1, 0.0, 0.0, GRAVITY_PULL),
 )]

--- a/tests/dbsp_motion_logic.rs
+++ b/tests/dbsp_motion_logic.rs
@@ -5,18 +5,19 @@
 
 use approx::assert_relative_eq;
 use lille::components::Block;
-use lille::dbsp_circuit::{NewPosition, NewVelocity, Position, Velocity};
+use lille::dbsp_circuit::{Force, NewPosition, NewVelocity, Position, Velocity};
 use lille::GRAVITY_PULL;
 use rstest::rstest;
 
 mod common;
-use common::{block, new_circuit, vel};
+use common::{block, force, new_circuit, vel};
 
 #[rstest]
 #[case::standing_moves(
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.0.into() },
     vel(1, 1.0, 0.0, 0.0),
     vec![block(1, 0, 0, 0), block(2, 1, 0, 1)],
+    None,
     Position { entity: 1, x: 1.0.into(), y: 0.0.into(), z: 2.0.into() },
     vel(1, 1.0, 0.0, 0.0),
 )]
@@ -24,6 +25,7 @@ use common::{block, new_circuit, vel};
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 2.1.into() },
     vel(1, 0.0, 0.0, 0.0),
     vec![block(1, 0, 0, 0)],
+    None,
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.1.into() },
     vel(1, 0.0, 0.0, GRAVITY_PULL),
 )]
@@ -31,13 +33,31 @@ use common::{block, new_circuit, vel};
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.1.into() },
     vel(1, 0.0, 0.0, 0.0),
     vec![block(1, 0, 0, 0)],
+    None,
     Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.0.into() },
     vel(1, 0.0, 0.0, 0.0),
+)]
+#[case::force_accelerates(
+    Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.0.into() },
+    vel(1, 0.0, 0.0, 0.0),
+    vec![block(1, 0, 0, 0), block(2, 1, 0, 1)],
+    Some(force(1, 5.0, 0.0, 0.0, Some(5.0))),
+    Position { entity: 1, x: 1.0.into(), y: 0.0.into(), z: 2.0.into() },
+    vel(1, 1.0, 0.0, 0.0),
+)]
+#[case::invalid_mass_ignores_force(
+    Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 2.1.into() },
+    vel(1, 0.0, 0.0, 0.0),
+    vec![block(1, 0, 0, 0)],
+    Some(force(1, 0.0, 0.0, 10.0, Some(0.0))),
+    Position { entity: 1, x: 0.0.into(), y: 0.0.into(), z: 1.1.into() },
+    vel(1, 0.0, 0.0, GRAVITY_PULL),
 )]
 fn motion_cases(
     #[case] position: Position,
     #[case] velocity: Velocity,
     #[case] blocks: Vec<Block>,
+    #[case] force_rec: Option<Force>,
     #[case] expected_pos: NewPosition,
     #[case] expected_vel: NewVelocity,
 ) {
@@ -48,6 +68,9 @@ fn motion_cases(
     }
     circuit.position_in().push(position, 1);
     circuit.velocity_in().push(velocity, 1);
+    if let Some(f) = force_rec {
+        circuit.force_in().push(f, 1);
+    }
 
     circuit.step().expect("circuit step failed");
 

--- a/tests/dbsp_motion_logic.rs
+++ b/tests/dbsp_motion_logic.rs
@@ -8,9 +8,7 @@ use lille::components::Block;
 use lille::dbsp_circuit::{Force, NewPosition, NewVelocity, Position, Velocity};
 use lille::GRAVITY_PULL;
 use rstest::rstest;
-
-mod common;
-use common::{block, force_with_mass, new_circuit, vel};
+use test_utils::{block, force_with_mass, new_circuit, vel};
 
 #[rstest]
 #[case::standing_moves(

--- a/tests/dbsp_position_floor.rs
+++ b/tests/dbsp_position_floor.rs
@@ -7,9 +7,8 @@ use lille::{
     components::{Block, BlockSlope},
     dbsp_circuit::{Position, PositionFloor},
 };
-mod common;
-use common::pos;
 use rstest::rstest;
+use test_utils::{new_circuit, pos};
 
 /// Creates a [`Block`] positioned at integer grid coordinates.
 fn blk(id: i64, x: i32, y: i32, z: i32) -> Block {
@@ -59,7 +58,7 @@ fn position_floor_cases(
     #[case] positions: Vec<Position>,
     #[case] expected: Vec<PositionFloor>,
 ) {
-    let mut circuit = common::new_circuit();
+    let mut circuit = new_circuit();
     for b in &blocks {
         circuit.block_in().push(b.clone(), 1);
     }
@@ -86,7 +85,7 @@ fn position_floor_cases(
 /// corresponding [`PositionFloor`] record.
 #[test]
 fn multiple_positions_same_grid_cell() {
-    let mut circuit = common::new_circuit();
+    let mut circuit = new_circuit();
     circuit.block_in().push(blk(1, 0, 0, 0), 1);
     circuit.position_in().push(pos(1, 0.1, 0.1, 2.0), 1);
     circuit.position_in().push(pos(2, 0.8, 0.4, 3.0), 1);

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -32,7 +32,7 @@ impl Default for Env {
     fn default() -> Self {
         #[expect(
             clippy::arc_with_non_send_sync,
-            reason = "Tests run single-threaded; Arc<Mutex<_>> is safe here",
+            reason = "Tests run single-threaded; Arc<Mutex<_>> is safe here"
         )]
         let circuit = Arc::new(Mutex::new(
             DbspCircuit::new().expect("Failed to create DbspCircuit"),

--- a/tests/geometry_rspec.rs
+++ b/tests/geometry_rspec.rs
@@ -11,7 +11,6 @@ use std::fmt;
 use std::sync::{Arc, Mutex};
 
 #[derive(Clone)]
-#[allow(clippy::arc_with_non_send_sync)]
 struct Env {
     circuit: Arc<Mutex<DbspCircuit>>,
 }
@@ -31,7 +30,10 @@ impl fmt::Debug for Env {
 
 impl Default for Env {
     fn default() -> Self {
-        #[allow(clippy::arc_with_non_send_sync)]
+        #[expect(
+            clippy::arc_with_non_send_sync,
+            reason = "Tests run single-threaded; Arc<Mutex<_>> is safe here",
+        )]
         let circuit = Arc::new(Mutex::new(
             DbspCircuit::new().expect("Failed to create DbspCircuit"),
         ));

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -197,6 +197,19 @@ macro_rules! physics_spec {
     (1.0, 0.0, 2.0),
     (1.0, 0.0, 0.0)
 )]
+#[case::force_mass_z(
+    "an unsupported entity accelerates along Z",
+      |world: &mut TestWorld| {
+          world.spawn_block(Block { id: 1, x: 0, y: 0, z: -2 });
+          world.spawn_entity(
+              Transform::from_xyz(0.0, 0.0, 2.0),
+              VelocityComp::default(),
+              Some(ForceComp { force_x: 0.0, force_y: 0.0, force_z: 10.0, mass: Some(5.0) }),
+          );
+      },
+    (0.0, 0.0, 3.0),
+    (0.0, 0.0, 1.0)
+)]
 #[case::invalid_mass(
     "a force with invalid mass is ignored",
       |world: &mut TestWorld| {

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -187,7 +187,7 @@ macro_rules! physics_spec {
           world.spawn_entity(
               Transform::from_xyz(0.0, 0.0, 1.0),
               VelocityComp::default(),
-              Some(ForceComp { fx: 5.0, fy: 0.0, fz: 0.0, mass: Some(5.0) }),
+              Some(ForceComp { force_x: 5.0, force_y: 0.0, force_z: 0.0, mass: Some(5.0) }),
           );
       },
     (1.0, 0.0, 2.0),
@@ -200,7 +200,7 @@ macro_rules! physics_spec {
           world.spawn_entity(
               Transform::from_xyz(0.0, 0.0, 2.0),
               VelocityComp::default(),
-              Some(ForceComp { fx: 0.0, fy: 0.0, fz: 10.0, mass: Some(0.0) }),
+              Some(ForceComp { force_x: 0.0, force_y: 0.0, force_z: 10.0, mass: Some(0.0) }),
           );
       },
     (0.0, 0.0, 1.0),

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -7,7 +7,7 @@
 use bevy::prelude::*;
 use lille::{
     components::{Block, BlockSlope, ForceComp},
-    DbspPlugin, DdlogId, VelocityComp, GRAVITY_PULL,
+    DbspPlugin, DdlogId, VelocityComp, DEFAULT_MASS, GRAVITY_PULL,
 };
 use rstest::{fixture, rstest};
 use std::fmt;
@@ -209,6 +209,20 @@ macro_rules! physics_spec {
       },
     (0.0, 0.0, 1.0),
     (0.0, 0.0, GRAVITY_PULL as f32)
+)]
+#[case::force_default_mass_y(
+    "an entity accelerates along Y with default mass",
+      |world: &mut TestWorld| {
+          world.spawn_block(Block { id: 1, x: 0, y: 0, z: 0 });
+          world.spawn_block(Block { id: 2, x: 0, y: 1, z: 1 });
+          world.spawn_entity(
+              Transform::from_xyz(0.0, 0.0, 1.0),
+              VelocityComp::default(),
+              Some(ForceComp { force_x: 0.0, force_y: DEFAULT_MASS, force_z: 0.0, mass: None }),
+          );
+      },
+    (0.0, 1.0, 2.0),
+    (0.0, 1.0, 0.0)
 )]
 fn physics_scenarios(
     world: TestWorld,

--- a/tests/physics_bdd.rs
+++ b/tests/physics_bdd.rs
@@ -63,6 +63,11 @@ impl TestWorld {
         self.entity = Some(id);
     }
 
+    /// Spawns an entity without an external force.
+    fn spawn_entity_without_force(&mut self, transform: Transform, vel: VelocityComp) {
+        self.spawn_entity(transform, vel, None);
+    }
+
     /// Advances the simulation by one tick.
     fn tick(&mut self) {
         let mut app = self.app.lock().expect("app lock");
@@ -139,7 +144,7 @@ macro_rules! physics_spec {
     "an unsupported entity",
       |world: &mut TestWorld| {
           world.spawn_block(Block { id: 1, x: 0, y: 0, z: -2 });
-          world.spawn_entity(Transform::from_xyz(0.0, 0.0, 2.0), VelocityComp::default(), None);
+          world.spawn_entity_without_force(Transform::from_xyz(0.0, 0.0, 2.0), VelocityComp::default());
       },
     (0.0, 0.0, 1.0),
     (0.0, 0.0, GRAVITY_PULL as f32)
@@ -148,7 +153,7 @@ macro_rules! physics_spec {
     "an entity on a flat block",
       |world: &mut TestWorld| {
           world.spawn_block(Block { id: 1, x: 0, y: 0, z: 0 });
-          world.spawn_entity(Transform::from_xyz(0.0, 0.0, 1.0), VelocityComp::default(), None);
+          world.spawn_entity_without_force(Transform::from_xyz(0.0, 0.0, 1.0), VelocityComp::default());
       },
     (0.0, 0.0, 1.0),
     (0.0, 0.0, 0.0)
@@ -160,7 +165,7 @@ macro_rules! physics_spec {
               Block { id: 1, x: 0, y: 0, z: 0 },
               BlockSlope { block_id: 1, grad_x: 1.0.into(), grad_y: 0.0.into() },
           );
-          world.spawn_entity(Transform::from_xyz(0.0, 0.0, 1.5), VelocityComp::default(), None);
+          world.spawn_entity_without_force(Transform::from_xyz(0.0, 0.0, 1.5), VelocityComp::default());
       },
     (0.0, 0.0, 1.5),
     (0.0, 0.0, 0.0)
@@ -170,10 +175,9 @@ macro_rules! physics_spec {
       |world: &mut TestWorld| {
           world.spawn_block(Block { id: 1, x: 0, y: 0, z: 0 });
           world.spawn_block(Block { id: 2, x: 1, y: 0, z: 1 });
-          world.spawn_entity(
+          world.spawn_entity_without_force(
               Transform::from_xyz(0.0, 0.0, 1.0),
               VelocityComp { vx: 1.0, vy: 0.0, vz: 0.0 },
-              None,
           );
       },
     (1.0, 0.0, 2.0),

--- a/tests/position_floor_rspec.rs
+++ b/tests/position_floor_rspec.rs
@@ -10,10 +10,9 @@ use lille::{
     dbsp_circuit::{Position, PositionFloor},
     DbspCircuit,
 };
-mod common;
-use common::pos;
 use std::fmt;
 use std::sync::{Arc, Mutex};
+use test_utils::pos;
 
 #[derive(Clone)]
 /// Shared test environment wrapping a `DbspCircuit` in a thread-safe container.


### PR DESCRIPTION
## Summary
- add Force input stream and physics helpers for F=ma
- compute acceleration in DBSP and update positions via velocity integration
- document force-based motion and mark roadmap items complete

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b04e482808322b694a19fa7c8114c

## Summary by Sourcery

Enable force-driven physics in the DBSP-based motion pipeline by adding a Force input stream, computing acceleration with F=ma, integrating it with gravity in velocity updates, and updating positions accordingly; also expose a new ForceComp component and document and test the new force-based motion path.

New Features:
- Add Force stream and ForceComp to support external forces in the DBSP circuit
- Add applied_acceleration helper in a new physics module to compute acceleration via F=ma

Enhancements:
- Integrate force-driven acceleration into the new_velocity_stream to combine external forces with gravity and update velocities and positions
- Extend DbspCircuit, sync system, and ECS components to expose and clear a force_in handle for feeding Force records

Documentation:
- Document external forces and F=ma workflow in the physics engine design doc and mark related roadmap items complete

Tests:
- Introduce parameterized tests for applied_acceleration
- Add BDD and motion logic test cases for force-driven acceleration and handling of invalid mass