### PR TITLE
Maintain DBSP entity ID map incrementally

### DIFF
--- a/tests/dbsp_sync_id_map.rs
+++ b/tests/dbsp_sync_id_map.rs
@@ -1,16 +1,28 @@
 //! Tests for incremental maintenance of the entity ID mapping.
 
 use bevy::prelude::*;
+use rstest::{fixture, rstest};
 
 use lille::components::DdlogId;
 use lille::dbsp_sync::{cache_state_for_dbsp_system, init_dbsp_system, DbspState};
 
-#[test]
-fn removes_entity_from_id_map_when_ddlog_id_removed() {
+/// Returns an [`App`] with the DBSP cache system wired.
+///
+/// # Examples
+///
+/// ```
+/// let mut app = app();
+/// ```
+#[fixture]
+fn app() -> App {
     let mut app = App::new();
     init_dbsp_system(&mut app.world).expect("failed to initialise DbspState");
     app.add_systems(Update, cache_state_for_dbsp_system);
+    app
+}
 
+#[rstest]
+fn removes_entity_from_id_map_when_ddlog_id_removed(mut app: App) {
     let entity = app.world.spawn((DdlogId(1), Transform::default())).id();
 
     app.update();
@@ -26,12 +38,8 @@ fn removes_entity_from_id_map_when_ddlog_id_removed() {
     assert!(state.entity_for_id(1).is_none());
 }
 
-#[test]
-fn updates_id_map_when_ddlog_id_changed() {
-    let mut app = App::new();
-    init_dbsp_system(&mut app.world).expect("failed to initialise DbspState");
-    app.add_systems(Update, cache_state_for_dbsp_system);
-
+#[rstest]
+fn updates_id_map_when_ddlog_id_changed(mut app: App) {
     let entity = app.world.spawn((DdlogId(1), Transform::default())).id();
 
     app.update();

--- a/tests/dbsp_sync_id_map.rs
+++ b/tests/dbsp_sync_id_map.rs
@@ -8,7 +8,7 @@ use lille::dbsp_sync::{cache_state_for_dbsp_system, init_dbsp_system, DbspState}
 #[test]
 fn removes_entity_from_id_map_when_ddlog_id_removed() {
     let mut app = App::new();
-    init_dbsp_system(&mut app.world).unwrap();
+    init_dbsp_system(&mut app.world).expect("failed to initialise DbspState");
     app.add_systems(Update, cache_state_for_dbsp_system);
 
     let entity = app.world.spawn((DdlogId(1), Transform::default())).id();
@@ -19,9 +19,28 @@ fn removes_entity_from_id_map_when_ddlog_id_removed() {
         assert_eq!(state.entity_for_id(1), Some(entity));
     }
 
-    app.world.despawn(entity);
+    app.world.entity_mut(entity).remove::<DdlogId>();
     app.update();
 
     let state = app.world.non_send_resource::<DbspState>();
     assert!(state.entity_for_id(1).is_none());
+}
+
+#[test]
+fn updates_id_map_when_ddlog_id_changed() {
+    let mut app = App::new();
+    init_dbsp_system(&mut app.world).expect("failed to initialise DbspState");
+    app.add_systems(Update, cache_state_for_dbsp_system);
+
+    let entity = app.world.spawn((DdlogId(1), Transform::default())).id();
+
+    app.update();
+
+    app.world.entity_mut(entity).insert(DdlogId(2));
+
+    app.update();
+
+    let state = app.world.non_send_resource::<DbspState>();
+    assert!(state.entity_for_id(1).is_none());
+    assert_eq!(state.entity_for_id(2), Some(entity));
 }

--- a/tests/dbsp_sync_id_map.rs
+++ b/tests/dbsp_sync_id_map.rs
@@ -1,0 +1,27 @@
+//! Tests for incremental maintenance of the entity ID mapping.
+
+use bevy::prelude::*;
+
+use lille::components::DdlogId;
+use lille::dbsp_sync::{cache_state_for_dbsp_system, init_dbsp_system, DbspState};
+
+#[test]
+fn removes_entity_from_id_map_when_ddlog_id_removed() {
+    let mut app = App::new();
+    init_dbsp_system(&mut app.world).unwrap();
+    app.add_systems(Update, cache_state_for_dbsp_system);
+
+    let entity = app.world.spawn((DdlogId(1), Transform::default())).id();
+
+    app.update();
+    {
+        let state = app.world.non_send_resource::<DbspState>();
+        assert_eq!(state.entity_for_id(1), Some(entity));
+    }
+
+    app.world.despawn(entity);
+    app.update();
+
+    let state = app.world.non_send_resource::<DbspState>();
+    assert!(state.entity_for_id(1).is_none());
+}


### PR DESCRIPTION
## Summary
- avoid rebuilding the DBSP entity lookup each frame by updating it from Added/Changed/Removed queries
- expose a helper to retrieve an Entity for a DBSP id
- test ID map updates when entities are removed

## Testing
- `make fmt`
- `make lint`
- `make test`

closes #159

------
https://chatgpt.com/codex/tasks/task_e_689fd3a9d7808322a96c8e8443de6888

## Summary by Sourcery

Maintain the DBSP entity ID map incrementally by handling added, changed, and removed DdlogId components, expose an entity lookup helper, and add a test for removal behavior

New Features:
- Add DbspState::entity_for_id helper to look up Bevy entities by DBSP identifier

Enhancements:
- Maintain the internal DBSP ID-to-Entity map incrementally using Added, Changed, and Removed queries instead of rebuilding it each frame
- Update cache_state_for_dbsp_system to remove, replace, and insert mappings based on entity lifecycle events

Tests:
- Add integration test to verify that removed entities are correctly pruned from the ID map