### PR TITLE
Clamp falling speed to terminal velocity

### DIFF
--- a/docs/lille-physics-and-world-engine-roadmap.md
+++ b/docs/lille-physics-and-world-engine-roadmap.md
@@ -156,7 +156,7 @@ physical properties and agent behaviours.
    - [x] Implement a `friction` operator that reduces velocity for `Standing`
      entities.
 
-   - [ ] Implement `terminal_velocity` clamping.
+   - [x] Implement `terminal_velocity` clamping.
 
 2. **Reactive Agent Behaviours**:
 

--- a/docs/lille-physics-engine-design.md
+++ b/docs/lille-physics-engine-design.md
@@ -116,6 +116,11 @@ their new position.
   to update positions (`p_new = p_old + v*dt`), ensuring the DBSP circuit
   remains the authoritative source for derived motion.
 
+- **Terminal Velocity**: Downward speed for unsupported entities is clamped to
+  the constant `TERMINAL_VELOCITY`. The clamp is applied inside the DBSP
+  `new_velocity_stream`, avoiding unbounded acceleration and keeping the
+  circuit, rather than Bevy, as the sole authority on motion limits.
+
   - **Movement for Standing Entities**: The `Standing` stream is joined with AI
   data (see below) to determine a desired movement vector `(dx, dy)`. The
   proposed new location `(x+dx, y+dy)` is then fed back into the
@@ -129,11 +134,11 @@ their new position.
 
 This design cements the DBSP circuit as the authoritative source for motion
 inference. Bevy systems simply marshal inputs and apply the circuit's outputs;
-ground friction and other derived effects are computed inside the circuit, so
-no secondary motion logic exists outside it. Behavioural tests verify falling
-entities, stationary entities on flat or sloped blocks, and movement between
-blocks of differing heights, ensuring the circuit governs all inferred
-behaviour.
+ground friction, terminal velocity, and other derived effects are computed
+inside the circuit, so no secondary motion logic exists outside it. Behavioural
+tests verify falling entities, stationary entities on flat or sloped blocks,
+and movement between blocks of differing heights, ensuring the circuit governs
+all inferred behaviour.
 
 ### 3.4. Motion Dataflow Diagrams
 

--- a/tests/dbsp_motion_logic.rs
+++ b/tests/dbsp_motion_logic.rs
@@ -6,7 +6,7 @@
 use approx::assert_relative_eq;
 use lille::components::Block;
 use lille::dbsp_circuit::{Force, NewPosition, NewVelocity, Position, Velocity};
-use lille::{apply_ground_friction, GRAVITY_PULL};
+use lille::{apply_ground_friction, GRAVITY_PULL, TERMINAL_VELOCITY};
 use rstest::rstest;
 use test_utils::{block, force, force_with_mass, new_circuit, vel};
 
@@ -188,4 +188,44 @@ fn airborne_preserves_velocity() {
     assert_relative_eq!(vel_out[0].vx.into_inner(), 1.0);
     assert_relative_eq!(vel_out[0].vy.into_inner(), 0.0);
     assert_relative_eq!(vel_out[0].vz.into_inner(), GRAVITY_PULL);
+}
+
+/// Ensures falling speed never exceeds the configured terminal velocity.
+#[rstest]
+#[case::at_limit(-TERMINAL_VELOCITY, -TERMINAL_VELOCITY)]
+#[case::beyond_limit(-5.0, -TERMINAL_VELOCITY)]
+fn terminal_velocity_clamping(#[case] start_vz: f64, #[case] expected_vz: f64) {
+    let mut circuit = new_circuit();
+
+    circuit.block_in().push(block(1, 0, 0, -10), 1);
+    circuit.position_in().push(
+        Position {
+            entity: 1,
+            x: 0.0.into(),
+            y: 0.0.into(),
+            z: 5.0.into(),
+        },
+        1,
+    );
+    circuit.velocity_in().push(vel(1, 0.0, 0.0, start_vz), 1);
+
+    circuit.step().expect("circuit step failed");
+
+    let pos_out: Vec<NewPosition> = circuit
+        .new_position_out()
+        .consolidate()
+        .iter()
+        .map(|t| t.0)
+        .collect();
+    assert_eq!(pos_out.len(), 1);
+    assert_relative_eq!(pos_out[0].z.into_inner(), 5.0 + expected_vz);
+
+    let vel_out: Vec<NewVelocity> = circuit
+        .new_velocity_out()
+        .consolidate()
+        .iter()
+        .map(|t| t.0)
+        .collect();
+    assert_eq!(vel_out.len(), 1);
+    assert_relative_eq!(vel_out[0].vz.into_inner(), expected_vz);
 }


### PR DESCRIPTION
## Summary
- enforce terminal velocity for unsupported entities in the DBSP circuit
- document terminal velocity design and mark roadmap item complete
- cover terminal velocity with unit and behavioural tests

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`
- `make nixie` *(fails: FileNotFound: failed copying files from cache to destination for package @swc/helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c142063483229c0fad72f9449a08