### PR TITLE
Document DBSP circuit struct and step method

### DIFF
--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -32,6 +32,20 @@ pub use types::{
     FloorHeightAt, Force, HighestBlockAt, NewPosition, NewVelocity, Position, Velocity,
 };
 
+/// Authoritative DBSP dataflow for Lille's world simulation.
+///
+/// `DbspCircuit` owns the underlying [`RootCircuit`] and exposes typed
+/// handles for feeding entity state and environment records into the
+/// dataflow. After updating the inputs, advance the circuit with
+/// [`DbspCircuit::step`] to derive new positions, velocities, and terrain
+/// queries.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use lille::prelude::*;
+/// let circuit = DbspCircuit::new().expect("circuit construction failed");
+/// ```
 pub struct DbspCircuit {
     circuit: CircuitHandle,
     position_in: ZSetHandle<Position>,
@@ -95,6 +109,26 @@ impl DbspCircuit {
         })
     }
 
+    /// Advances the DBSP circuit by one tick.
+    ///
+    /// Call this after pushing all input records for the current frame. The
+    /// evaluation propagates changes through the dataflow and refreshes the
+    /// `*_out` handles with derived positions, velocities, and terrain
+    /// queries. Input collections persist across steps; invoke
+    /// [`DbspCircuit::clear_inputs`] once outputs are processed to avoid stale
+    /// state.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error reported by the underlying DBSP circuit.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// # use lille::prelude::*;
+    /// let mut circuit = DbspCircuit::new().expect("circuit construction failed");
+    /// circuit.step().expect("circuit evaluation failed");
+    /// ```
     pub fn step(&mut self) -> Result<(), dbsp::Error> {
         self.circuit.step()
     }

--- a/src/dbsp_circuit.rs
+++ b/src/dbsp_circuit.rs
@@ -44,7 +44,23 @@ pub use types::{
 ///
 /// ```rust,no_run
 /// # use lille::prelude::*;
-/// let circuit = DbspCircuit::new().expect("circuit construction failed");
+/// let mut circuit = DbspCircuit::new().expect("circuit construction failed");
+///
+/// // 1) Feed inputs for this frame.
+/// // circuit.position_in().push(Position { /* ... */ }, 1);
+/// // circuit.velocity_in().push(Velocity { /* ... */ }, 1);
+/// // circuit.force_in().push(Force { /* ... */ }, 1);
+/// // circuit.block_in().push(Block { /* ... */ }, 1);
+/// // circuit.block_slope_in().push(BlockSlope { /* ... */ }, 1);
+///
+/// // 2) Advance the circuit.
+/// circuit.step().expect("circuit evaluation failed");
+///
+/// // 3) Read outputs via the getters.
+/// // let _ = circuit.new_position_out();
+///
+/// // 4) Clear inputs before the next frame.
+/// circuit.clear_inputs();
 /// ```
 pub struct DbspCircuit {
     circuit: CircuitHandle,
@@ -111,12 +127,12 @@ impl DbspCircuit {
 
     /// Advances the DBSP circuit by one tick.
     ///
-    /// Call this after pushing all input records for the current frame. The
-    /// evaluation propagates changes through the dataflow and refreshes the
-    /// `*_out` handles with derived positions, velocities, and terrain
-    /// queries. Input collections persist across steps; invoke
-    /// [`DbspCircuit::clear_inputs`] once outputs are processed to avoid stale
-    /// state.
+    /// Call this once per frame after pushing all input records. The evaluation
+    /// propagates changes through the dataflow and atomically refreshes the output
+    /// handles with derived positions, velocities, and terrain queries for this
+    /// tick. This method does not clear inputs; input collections persist across
+    /// steps. Invoke [`DbspCircuit::clear_inputs`] after processing outputs to avoid
+    /// stale state carrying into the next frame.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
## Summary
- describe `DbspCircuit` as the game's authoritative DBSP dataflow
- document when and why to call `DbspCircuit::step`

## Testing
- `make fmt`
- `make lint` *(fails: command interrupted during dependency build)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f86790f483228a7202f76478c316

## Summary by Sourcery

Add detailed documentation for the DbspCircuit struct and its step method to clarify their roles and usage

Documentation:
- Document DbspCircuit as the authoritative game dataflow with typed input handles and lifecycle
- Add doc comments for step method describing when to call it, its effects, error behavior, and usage examples