### PR TITLE
Refactor vector normalisation tests

### DIFF
--- a/tests/vector_math.rs
+++ b/tests/vector_math.rs
@@ -2,37 +2,23 @@
 //! Focuses on normalisation and NaN handling.
 use approx::assert_relative_eq;
 use lille::vec_normalize;
+use rstest::rstest;
 
-#[test]
-fn normalize_returns_zero_for_nan() {
-    let result = vec_normalize(f32::NAN, 1.0, 0.0);
-    assert_relative_eq!(result.0, 0.0, max_relative = 1e-6);
-    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
-    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
-}
-
-#[test]
-fn normalize_returns_normalized_vector() {
-    let result = vec_normalize(3.0, 0.0, 0.0);
-    assert_relative_eq!(result.0, 1.0, max_relative = 1e-6);
-    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
-    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
-}
-
-#[test]
-fn normalize_returns_zero_for_zero_vector() {
-    let result = vec_normalize(0.0, 0.0, 0.0);
-    assert_relative_eq!(result.0, 0.0, max_relative = 1e-6);
-    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
-    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
-}
-
-#[test]
-fn normalize_returns_zero_for_infinite_vector() {
-    let result = vec_normalize(f32::INFINITY, 0.0, 0.0);
-    assert_relative_eq!(result.0, 0.0, max_relative = 1e-6);
-    assert_relative_eq!(result.1, 0.0, max_relative = 1e-6);
-    assert_relative_eq!(result.2, 0.0, max_relative = 1e-6);
+#[rstest]
+#[case(f32::NAN, 1.0, 0.0, (0.0, 0.0, 0.0))]
+#[case(3.0, 0.0, 0.0, (1.0, 0.0, 0.0))]
+#[case(0.0, 0.0, 0.0, (0.0, 0.0, 0.0))]
+#[case(f32::INFINITY, 0.0, 0.0, (0.0, 0.0, 0.0))]
+fn vec_normalize_returns_expected(
+    #[case] x: f32,
+    #[case] y: f32,
+    #[case] z: f32,
+    #[case] expected: (f32, f32, f32),
+) {
+    let result = vec_normalize(x, y, z);
+    assert_relative_eq!(result.0, expected.0, max_relative = 1e-6);
+    assert_relative_eq!(result.1, expected.1, max_relative = 1e-6);
+    assert_relative_eq!(result.2, expected.2, max_relative = 1e-6);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- replace four `vec_normalize` unit tests with a single `rstest` using `#[case]`
- keep `vec_mag_matches_pythagoras` test unchanged

## Testing
- `make fmt`
- `make lint` *(fails: sccache error and long compile, interrupted)*
- `make test` *(fails: long build, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f89eb3a883228d4488d1427997ac