### PR TITLE
Refactor civvy movement logic

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -11,6 +11,9 @@ pub const DELTA_TIME: f64 = 1.0;
 pub const DEFAULT_MASS: f64 = 70.0;
 pub const FEAR_RADIUS_MULTIPLIER: f64 = 2.0;
 pub const FEAR_THRESHOLD: f64 = 0.2;
+/// Minimum squared distance added to fear calculations to avoid division by
+/// zero when threats coincide with the actor.
+pub const FEAR_DISTANCE_EPSILON: f64 = 0.001;
 /// The normalised offset used to sample slopes within a block.
 ///
 /// The `FloorHeightAt` calculation currently evaluates the slope at the


### PR DESCRIPTION
## Summary
- extract `aggregate_fear` helper to compute fear and nearest threat
- add `movement_vector` helper to choose movement based on fear or target
- use `BLOCK_TOP_OFFSET`, `FEAR_RADIUS_MULTIPLIER`, and `FEAR_THRESHOLD` constants in world logic
- introduce `FEAR_DISTANCE_EPSILON` to stabilise fear calculations
- document `DdlogEntity`, `NewPosition`, `WorldHandle`, and `step`

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f890e8a48322ad2386a0ca014dd7

## Summary by Sourcery

Refactor civvy movement logic by extracting fear aggregation and movement decision into dedicated helpers, leveraging new constants for stability, and updating floor height calculations to use BLOCK_TOP_OFFSET.

Enhancements:
- Extract aggregate_fear and movement_vector helpers to encapsulate fear computation and movement choice.
- Replace hardcoded terrain offsets with the BLOCK_TOP_OFFSET constant in floor height calculations.
- Introduce FEAR_DISTANCE_EPSILON to stabilize fear accumulation and use FEAR_RADIUS_MULTIPLIER and FEAR_THRESHOLD constants for parameterization.
- Simplify civvy_move by delegating to the new helper functions and constants.

Documentation:
- Add doc comments to DdlogEntity, NewPosition, WorldHandle, and the step method.