### PR TITLE
Refactor DBSP sync to require world handle

### DIFF
--- a/src/dbsp_circuit/streams.rs
+++ b/src/dbsp_circuit/streams.rs
@@ -438,7 +438,11 @@ pub(super) fn apply_movement(
         .inspect(|batch| {
             for (entity, _, weight) in batch.iter() {
                 if weight > 1 {
-                    panic!("duplicate movement decisions for entity {entity}");
+                    debug_assert!(
+                        weight <= 1,
+                        "duplicate movement decisions for entity {entity}"
+                    );
+                    warn!("duplicate movement decisions for entity {entity}");
                 }
             }
         });

--- a/src/dbsp_circuit/streams.rs
+++ b/src/dbsp_circuit/streams.rs
@@ -427,7 +427,7 @@ pub(super) fn movement_decision_stream(
 
 /// Applies movement decisions to base positions.
 ///
-/// Panics in tests if multiple movement records exist for a single entity.
+/// Panics if multiple movement records exist for a single entity.
 pub(super) fn apply_movement(
     base: &Stream<RootCircuit, OrdZSet<Position>>,
     movement: &Stream<RootCircuit, OrdZSet<MovementDecision>>,
@@ -438,11 +438,7 @@ pub(super) fn apply_movement(
         .inspect(|batch| {
             for (entity, _, weight) in batch.iter() {
                 if weight > 1 {
-                    if cfg!(test) {
-                        panic!("duplicate movement decisions for entity {entity}");
-                    } else {
-                        warn!("duplicate movement decisions for entity {entity}");
-                    }
+                    panic!("duplicate movement decisions for entity {entity}");
                 }
             }
         });

--- a/src/dbsp_circuit/streams.rs
+++ b/src/dbsp_circuit/streams.rs
@@ -427,7 +427,10 @@ pub(super) fn movement_decision_stream(
 
 /// Applies movement decisions to base positions.
 ///
-/// Panics if multiple movement records exist for a single entity.
+/// # Panics
+///
+/// Panics in debug builds if more than one movement record exists for the same
+/// entity in a single tick.
 pub(super) fn apply_movement(
     base: &Stream<RootCircuit, OrdZSet<Position>>,
     movement: &Stream<RootCircuit, OrdZSet<MovementDecision>>,
@@ -436,12 +439,18 @@ pub(super) fn apply_movement(
     let mv = movement
         .map_index(|m| (m.entity, (m.dx, m.dy)))
         .inspect(|batch| {
-            for (entity, _, weight) in batch.iter() {
-                if weight > 1 {
-                    debug_assert!(
-                        weight <= 1,
-                        "duplicate movement decisions for entity {entity}"
-                    );
+            // Accumulate counts per entity to catch duplicates emitted within a
+            // single tick. Duplicates indicate a bug upstream; release builds
+            // log the issue while debug builds panic for visibility.
+            use std::collections::HashMap;
+
+            let mut counts: HashMap<i64, i64> = HashMap::new();
+            for (entity, _mv, weight) in batch.iter() {
+                *counts.entry(entity).or_default() += weight;
+            }
+            for (entity, total) in counts {
+                if total > 1 {
+                    debug_assert!(false, "duplicate movement decisions for entity {entity}");
                     warn!("duplicate movement decisions for entity {entity}");
                 }
             }

--- a/src/dbsp_sync.rs
+++ b/src/dbsp_sync.rs
@@ -274,10 +274,12 @@ mod sync {
 
 /// Applies DBSP outputs back to ECS components.
 ///
-/// Steps the circuit, reads new positions and velocities, and updates the
-/// corresponding entities. The [`WorldHandle`] resource is updated with the
-/// latest positions for diagnostics. Output handles are drained afterwards to
-/// avoid reapplying stale data.
+/// Steps the circuit, consolidates new positions and velocities, and updates
+/// the corresponding entities. The [`WorldHandle`] resource is updated with the
+/// latest positions for diagnostics.
+///
+/// Outputs are drained after application to prevent reapplying stale deltas on
+/// subsequent frames.
 pub fn apply_dbsp_outputs_system(
     mut state: NonSendMut<DbspState>,
     mut write_query: Query<(Entity, &mut Transform, Option<&mut VelocityComp>), With<DdlogId>>,

--- a/tests/dbsp_sync_id_map.rs
+++ b/tests/dbsp_sync_id_map.rs
@@ -1,7 +1,6 @@
 //! Tests for incremental maintenance of the entity ID mapping.
 
 use bevy::prelude::*;
-use bevy::ecs::system::RunSystemOnce;
 use rstest::{fixture, rstest};
 
 use lille::components::DdlogId;
@@ -19,7 +18,7 @@ use lille::init_world_handle_system;
 fn app() -> App {
     let mut app = App::new();
     init_dbsp_system(&mut app.world).expect("failed to initialise DbspState");
-    app.world.run_system_once(init_world_handle_system);
+    app.add_systems(Startup, init_world_handle_system);
     app.add_systems(Update, cache_state_for_dbsp_system);
     app
 }

--- a/tests/dbsp_sync_id_map.rs
+++ b/tests/dbsp_sync_id_map.rs
@@ -1,10 +1,12 @@
 //! Tests for incremental maintenance of the entity ID mapping.
 
 use bevy::prelude::*;
+use bevy::ecs::system::RunSystemOnce;
 use rstest::{fixture, rstest};
 
 use lille::components::DdlogId;
 use lille::dbsp_sync::{cache_state_for_dbsp_system, init_dbsp_system, DbspState};
+use lille::init_world_handle_system;
 
 /// Returns an [`App`] with the DBSP cache system wired.
 ///
@@ -17,6 +19,7 @@ use lille::dbsp_sync::{cache_state_for_dbsp_system, init_dbsp_system, DbspState}
 fn app() -> App {
     let mut app = App::new();
     init_dbsp_system(&mut app.world).expect("failed to initialise DbspState");
+    app.world.run_system_once(init_world_handle_system);
     app.add_systems(Update, cache_state_for_dbsp_system);
     app
 }


### PR DESCRIPTION
## Summary
- require `WorldHandle` in DBSP sync systems and plugin
- split cache synchronisation into focused helpers
- panic on duplicate movement decisions

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68aa503dd3488322ba7229f9c78713b5

## Summary by Sourcery

Refactor DBSP synchronization to centralize WorldHandle initialization, decompose cache state synchronization into helper functions, and enforce strict duplicate movement decision handling.

Enhancements:
- Require WorldHandle resource in all DBSP sync systems and plugin initialization
- Extract cache synchronization logic into focused helper functions (sync_blocks, sync_id_maps, sync_entities, sync_forces)
- Simplify apply_dbsp_outputs_system to directly update WorldHandle entities and enforce WorldHandle mutability

Tests:
- Add init_world_handle_system call in tests to initialize WorldHandle before running cache_state_for_dbsp_system