### PR TITLE
Add test utils prelude

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+# Documentation index
+
+This directory gathers design notes and testing references. The following pages
+provide further detail:
+
+- [Architecture](architecture.md)
+- [Bevy headless testing](bevy-headless-testing.md)
+- [Behavioural testing in Rust with RSpec](behavioural-testing-in-rust-with-rspec.md)
+- [Complexity antipatterns and refactoring strategies](
+  complexity-antipatterns-and-refactoring-strategies.md)
+- [Declarative world inference with DBSP and Rust](
+  declarative-world-inference-with-dbsp-and-rust.md)
+- [Documentation style guide](documentation-style-guide.md)
+- [Lille physics and world engine roadmap](
+  lille-physics-and-world-engine-roadmap.md)
+- [Lille physics engine design](lille-physics-engine-design.md)
+- [Map data format](map-data-format.md)
+- [Rust testing with rstest fixtures](rust-testing-with-rstest-fixtures.md)
+- [Testing declarative game logic in DBSP](testing-declarative-game-logic-in-dbsp.md)
+- [Test utilities](test_utils.md)

--- a/docs/test_utils.md
+++ b/docs/test_utils.md
@@ -1,0 +1,26 @@
+# Test utilities
+
+The `test_utils` crate provides constructors and assertions for tests. To avoid
+repetitive import lists, it exposes a `prelude` module that bundles the most
+common helpers.
+
+```rust
+use test_utils::prelude::*;
+
+#[test]
+fn example() {
+    assert_all_present("block", &["block"]);
+}
+```
+
+The prelude includes:
+
+- Assertions: `assert_all_present`, `assert_all_absent`,
+  `assert_valid_rust_syntax`
+- Constructors: `block`, `force`, `force_with_mass`, `new_circuit`, `pos`,
+  `slope`, `target`, `vel`
+- Physics types: `BlockCoords`, `BlockId`, `Coords2D`, `Coords3D`, `EntityId`,
+  `FearValue`, `ForceVector`, `Gradient`, `Mass`
+
+Default to `use test_utils::prelude::*;` in tests unless a module only needs a
+small subset of helpers.

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -8,6 +8,15 @@ pub use physics::{
     BlockId, Coords2D, Coords3D, EntityId, FearValue, ForceVector, Gradient, Mass,
 };
 
+/// Re-export commonly used test helpers.
+pub mod prelude {
+    pub use super::{
+        assert_all_absent, assert_all_present, assert_valid_rust_syntax, block, fear, force,
+        force_with_mass, new_circuit, pos, slope, target, vel, BlockCoords, BlockId, Coords2D,
+        Coords3D, EntityId, FearValue, ForceVector, Gradient, Mass,
+    };
+}
+
 /// Assert that all strings in `keys` are present in `code`.
 ///
 /// # Panics

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -8,8 +8,8 @@ pub use physics::{
     BlockId, Coords2D, Coords3D, EntityId, FearValue, ForceVector, Gradient, Mass,
 };
 
-/// Re-export commonly used test helpers.
 pub mod prelude {
+    //! Re-export commonly used test helpers.
     pub use super::{
         assert_all_absent, assert_all_present, assert_valid_rust_syntax, block, fear, force,
         force_with_mass, new_circuit, pos, slope, target, vel, BlockCoords, BlockId, Coords2D,

--- a/tests/position_floor_rspec.rs
+++ b/tests/position_floor_rspec.rs
@@ -12,7 +12,7 @@ use lille::{
 };
 use std::fmt;
 use std::sync::{Arc, Mutex};
-use test_utils::{pos, Coords3D, EntityId};
+use test_utils::prelude::*;
 
 #[derive(Clone)]
 /// Shared test environment wrapping a `DbspCircuit` in a thread-safe container.

--- a/tests/reactive_behaviour_rspec.rs
+++ b/tests/reactive_behaviour_rspec.rs
@@ -7,9 +7,7 @@ use approx::assert_relative_eq;
 use lille::components::Block;
 use lille::dbsp_circuit::{DbspCircuit, FearLevel, NewPosition, Position, Target, Velocity};
 use rstest::rstest;
-use test_utils::{
-    block, fear, pos, target, vel, BlockCoords, BlockId, Coords2D, Coords3D, EntityId, FearValue,
-};
+use test_utils::prelude::*;
 
 struct Env {
     // Owns the circuit directly so tests can mutate it without synchronisation


### PR DESCRIPTION
## Summary
- re-export common test helpers via `test_utils::prelude`
- streamline test imports to use the new prelude

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2f1664848322bf44d6c23b2b8bcd

## Summary by Sourcery

Introduce a prelude in the test_utils crate to simplify importing common test helpers and refactor existing tests to use it

New Features:
- Add test_utils::prelude module that re-exports commonly used test helper functions and types

Enhancements:
- Refactor test files to replace explicit test_utils imports with a single prelude import