### PR TITLE
Rename fmt-check target to check-fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
         uses: leynos/shared-actions/.github/actions/setup-rust@v1.1.0
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
-      - name: Format
-        run: make fmt-check
+      - name: Check format
+        run: make check-fmt
       - name: Lint
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all clean build fmt fmt-check test lint build-support-run markdownlint nixie
+.PHONY: all clean build fmt check-fmt test lint build-support-run markdownlint nixie
 
 .ONESHELL:
 SHELL := bash
@@ -21,7 +21,7 @@ fmt:
 	cargo fmt $(WORKSPACE_PACKAGES)
 	mdformat-all
 
-fmt-check:
+check-fmt:
 	cargo fmt $(WORKSPACE_PACKAGES) -- --check
 
 build-support-run:

--- a/docs/bevy-headless-testing.md
+++ b/docs/bevy-headless-testing.md
@@ -612,7 +612,7 @@ configurations observed in such workflows include:
     matrix testing is a best practice for ensuring broad compatibility.
   - Execution with Miri (`miri`) to detect undefined behavior.
   - Static analysis and linting (`clippy`).
-  - Code formatting checks (`rustfmt`).
+  - Code formatting checks (`check-fmt` wrapping `rustfmt`).
   - Spell checking in documentation and comments (`typos`).
 - **Caching Strategy:** The caching configuration in Bevy's CI is typically
   fine-tuned, specifying paths such as `~/.cargo/bin/`,


### PR DESCRIPTION
## Summary
- rename `fmt-check` target to `check-fmt`
- update CI to invoke `make check-fmt`
- document new `check-fmt` target

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68c095dd822883229e424b4288e00735

## Summary by Sourcery

Rename the formatting check target to check-fmt and update CI and documentation accordingly