### PR TITLE
Use anyhow for error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ log = "0.4"  # Structured logging facade
 env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-color-eyre = "0.6"
 anyhow = "^1"
 ordered-float = { workspace = true }
 size-of = { version = "0.1", package = "feldera-size-of", features = ["ordered-float"] }
@@ -23,7 +22,7 @@ dbsp = "0.98"
 
 [build-dependencies]
 build_support = { path = "build_support" }
-color-eyre = "0.6"
+anyhow = "^1"
 
 [workspace]
 members = ["build_support", "test_utils"]

--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,7 @@
 //! Cargo build script for the project.
 //! Delegates to the `build_support` crate so the logic can be tested.
-use color_eyre::eyre::Result;
+use anyhow::Result;
 
 fn main() -> Result<()> {
-    color_eyre::install()?;
     build_support::build()
 }

--- a/build_support/Cargo.toml
+++ b/build_support/Cargo.toml
@@ -10,7 +10,7 @@ dotenvy = "0.15.7"
 reqwest = { version = "0.11.27", default-features = false, features = ["blocking", "rustls-tls-native-roots"] }
 sha2 = "0.10.9"
 tempfile = "3.20.0"
-color-eyre = "0.6"
+anyhow = "^1"
 
 [dev-dependencies]
 rstest = "0.18.0"

--- a/build_support/src/bin/build_support_runner.rs
+++ b/build_support/src/bin/build_support_runner.rs
@@ -1,9 +1,8 @@
 //! Small wrapper binary to invoke build_support::build for testing.
 //!
 //! Allows running the build pipeline without compiling the entire game.
-use color_eyre::eyre::Result;
+use anyhow::Result;
 
 fn main() -> Result<()> {
-    color_eyre::install()?;
     build_support::build()
 }

--- a/build_support/src/font.rs
+++ b/build_support/src/font.rs
@@ -4,7 +4,7 @@
 //! [`FontFetcher`], checks its SHA-256 digest and writes the verified font to
 //! disk. This ensures deterministic builds without shipping the font in the
 //! repository.
-use color_eyre::eyre::{eyre, Result};
+use anyhow::{anyhow, Result};
 use reqwest::blocking::Client;
 use sha2::{Digest, Sha256};
 use std::fs;
@@ -76,7 +76,7 @@ fn fallback_font_path() -> PathBuf {
 /// ```rust,no_run
 /// # use std::env;
 /// build_support::font::download_font(env::current_dir()?)?;
-/// # Ok::<(), color_eyre::Report>(())
+/// # Ok::<(), anyhow::Error>(())
 /// ```
 pub fn download_font(manifest_dir: impl AsRef<Path>) -> Result<PathBuf> {
     download_font_with(&HttpFontFetcher, manifest_dir)
@@ -156,7 +156,7 @@ fn fetch_font_data() -> Result<Vec<u8>> {
     let digest = Sha256::digest(&bytes);
     let actual = format!("{digest:x}");
     if actual != FONT_SHA256 {
-        return Err(eyre!("font checksum mismatch"));
+        return Err(anyhow!("font checksum mismatch"));
     }
     Ok(bytes.to_vec())
 }
@@ -207,7 +207,7 @@ mod tests {
         let mut fetcher = MockFontFetcher::new();
         fetcher
             .expect_fetch()
-            .returning(|| Err(eyre!("network error")));
+            .returning(|| Err(anyhow!("network error")));
         let result = download_font_with(&fetcher, &manifest_path).unwrap();
         assert!(result == fallback_font_path() || result.exists());
     }
@@ -217,7 +217,7 @@ mod tests {
         let mut fetcher = MockFontFetcher::new();
         fetcher
             .expect_fetch()
-            .returning(|| Err(eyre!("network error")));
+            .returning(|| Err(anyhow!("network error")));
         let result = download_font_with(&fetcher, Path::new("/non/existent/path"));
         assert!(result.is_ok());
         let p = result.unwrap();

--- a/build_support/src/lib.rs
+++ b/build_support/src/lib.rs
@@ -3,7 +3,7 @@
 
 pub mod font;
 
-use color_eyre::eyre::Result;
+use anyhow::Result;
 use std::path::PathBuf;
 
 /// Execute all build steps required by `build.rs`.
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 ///
 /// # Examples
 /// ```rust,no_run
-/// use color_eyre::eyre::Result;
+/// use anyhow::Result;
 /// fn main() -> Result<()> {
 ///     build_support::build()
 /// }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -125,5 +125,8 @@ architecture.
   computation while expressing complex rules in a clear, declarative style, as
   outlined in `docs/lille-physics-engine-design.md`.
 
+- **Flexible error handling**: `anyhow` supplies context-rich errors without
+  ceremony.
+
 This architecture provides a robust and scalable foundation for building the
 complex, emergent world of Lille.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,9 @@
 //! Example game application using the Lille library.
 //! Launches a Bevy app and wires up logging, world state, and basic systems.
+use anyhow::Result;
 use bevy::log::LogPlugin;
 use bevy::prelude::*;
 use clap::Parser;
-use color_eyre::eyre::Result;
 use lille::{init_logging, spawn_world_system, DbspPlugin};
 
 /// A realtime strategy game
@@ -19,7 +19,6 @@ struct Args {
 ///
 /// Parses command-line arguments, configures logging, and launches the Bevy app with custom system scheduling for world state integration and world setup.
 fn main() -> Result<()> {
-    color_eyre::install()?;
     let args = Args::parse();
     init_logging(args.verbose);
 


### PR DESCRIPTION
## Summary
- remove `color-eyre` and adopt `anyhow` for error reporting
- update build utilities and docs for the new error crate

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c09b396100832290955c119605f2eb