### PR TITLE
Refine dbsp_record trait derivations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ approx = "0.5"
 ordered-float = { workspace = true }
 serial_test = "3.2"
 mockall = "0.13.1"
+static_assertions = "1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rspec = "1.0"
 test_utils = { path = "test_utils" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ approx = "0.5"
 ordered-float = { workspace = true }
 serial_test = "3.2"
 mockall = "0.13.1"
-static_assertions = "1"
+static_assertions = "^1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rspec = "1.0"
 test_utils = { path = "test_utils" }

--- a/src/dbsp_circuit/types.rs
+++ b/src/dbsp_circuit/types.rs
@@ -118,6 +118,8 @@ crate::dbsp_copy_record! {
     }
 }
 
+// Fear levels may evolve to hold non-`Copy` state. We avoid implicit duplication
+// by keeping this record non-`Copy` and requiring explicit clones.
 crate::dbsp_record! {
     /// Fear level computed for an entity.
     ///

--- a/src/dbsp_circuit/types.rs
+++ b/src/dbsp_circuit/types.rs
@@ -127,6 +127,16 @@ crate::dbsp_record! {
     /// This type intentionally omits `Copy`; clone it explicitly when duplication
     /// is required.
     ///
+    /// # Examples
+    /// ```rust
+    /// use ordered_float::OrderedFloat;
+    /// use lille::dbsp_circuit::FearLevel;
+    ///
+    /// let fear = FearLevel { entity: 1, level: OrderedFloat(0.5) };
+    /// let clone = fear.clone();
+    /// assert_eq!(clone.level, OrderedFloat(0.5));
+    /// ```
+    ///
     /// Units:
     /// - `level` ∈ [0.0, 1.0] where higher implies greater fear.
     pub struct FearLevel {

--- a/src/dbsp_circuit/types.rs
+++ b/src/dbsp_circuit/types.rs
@@ -24,7 +24,7 @@ dbsp_record! {
         pub x: OrderedFloat<f64>,
         pub y: OrderedFloat<f64>,
         pub z: OrderedFloat<f64>,
-    }
+    }, Copy
 }
 
 /// Newly computed position emitted by the circuit in the current step.
@@ -37,7 +37,7 @@ dbsp_record! {
         pub vx: OrderedFloat<f64>,
         pub vy: OrderedFloat<f64>,
         pub vz: OrderedFloat<f64>,
-    }
+    }, Copy
 }
 
 /// Newly computed velocity emitted by the circuit in the current step.
@@ -93,7 +93,7 @@ dbsp_record! {
         pub x: i32,
         pub y: i32,
         pub z: i32,
-    }
+    }, Copy
 }
 
 dbsp_record! {
@@ -102,7 +102,7 @@ dbsp_record! {
         pub x: i32,
         pub y: i32,
         pub z: OrderedFloat<f64>,
-    }
+    }, Copy
 }
 
 dbsp_record! {
@@ -117,7 +117,7 @@ dbsp_record! {
         pub entity: i64,
         pub x: OrderedFloat<f64>,
         pub y: OrderedFloat<f64>,
-    }
+    }, Copy
 }
 
 dbsp_record! {
@@ -148,5 +148,5 @@ dbsp_record! {
         pub entity: i64,
         pub dx: OrderedFloat<f64>,
         pub dy: OrderedFloat<f64>,
-    }
+    }, Copy
 }

--- a/src/dbsp_circuit/types.rs
+++ b/src/dbsp_circuit/types.rs
@@ -15,29 +15,29 @@
 
 use ordered_float::OrderedFloat;
 
-use crate::dbsp_record;
+use crate::{dbsp_copy_record, dbsp_record};
 
-dbsp_record! {
+dbsp_copy_record! {
     /// Public data type for entity positions.
     pub struct Position {
         pub entity: i64,
         pub x: OrderedFloat<f64>,
         pub y: OrderedFloat<f64>,
         pub z: OrderedFloat<f64>,
-    }, Copy
+    }
 }
 
 /// Newly computed position emitted by the circuit in the current step.
 pub type NewPosition = Position;
 
-dbsp_record! {
+dbsp_copy_record! {
     /// Entity velocity vector.
     pub struct Velocity {
         pub entity: i64,
         pub vx: OrderedFloat<f64>,
         pub vy: OrderedFloat<f64>,
         pub vz: OrderedFloat<f64>,
-    }, Copy
+    }
 }
 
 /// Newly computed velocity emitted by the circuit in the current step.
@@ -87,25 +87,25 @@ pub struct Force {
     pub mass: Option<OrderedFloat<f64>>,
 }
 
-dbsp_record! {
+dbsp_copy_record! {
     /// Discrete highest block at a grid cell.
     pub struct HighestBlockAt {
         pub x: i32,
         pub y: i32,
         pub z: i32,
-    }, Copy
+    }
 }
 
-dbsp_record! {
+dbsp_copy_record! {
     /// Floor height at a grid cell, accounting for slopes.
     pub struct FloorHeightAt {
         pub x: i32,
         pub y: i32,
         pub z: OrderedFloat<f64>,
-    }, Copy
+    }
 }
 
-dbsp_record! {
+dbsp_copy_record! {
     /// Target position for an entity.
     ///
     /// Units:
@@ -117,7 +117,7 @@ dbsp_record! {
         pub entity: i64,
         pub x: OrderedFloat<f64>,
         pub y: OrderedFloat<f64>,
-    }, Copy
+    }
 }
 
 dbsp_record! {
@@ -131,7 +131,7 @@ dbsp_record! {
     }
 }
 
-dbsp_record! {
+dbsp_copy_record! {
     /// Decided unit movement vector for an entity.
     ///
     /// Units:
@@ -148,5 +148,5 @@ dbsp_record! {
         pub entity: i64,
         pub dx: OrderedFloat<f64>,
         pub dy: OrderedFloat<f64>,
-    }, Copy
+    }
 }

--- a/src/dbsp_circuit/types.rs
+++ b/src/dbsp_circuit/types.rs
@@ -15,9 +15,7 @@
 
 use ordered_float::OrderedFloat;
 
-use crate::{dbsp_copy_record, dbsp_record};
-
-dbsp_copy_record! {
+crate::dbsp_copy_record! {
     /// Public data type for entity positions.
     pub struct Position {
         pub entity: i64,
@@ -30,7 +28,7 @@ dbsp_copy_record! {
 /// Newly computed position emitted by the circuit in the current step.
 pub type NewPosition = Position;
 
-dbsp_copy_record! {
+crate::dbsp_copy_record! {
     /// Entity velocity vector.
     pub struct Velocity {
         pub entity: i64,
@@ -87,7 +85,7 @@ pub struct Force {
     pub mass: Option<OrderedFloat<f64>>,
 }
 
-dbsp_copy_record! {
+crate::dbsp_copy_record! {
     /// Discrete highest block at a grid cell.
     pub struct HighestBlockAt {
         pub x: i32,
@@ -96,7 +94,7 @@ dbsp_copy_record! {
     }
 }
 
-dbsp_copy_record! {
+crate::dbsp_copy_record! {
     /// Floor height at a grid cell, accounting for slopes.
     pub struct FloorHeightAt {
         pub x: i32,
@@ -105,7 +103,7 @@ dbsp_copy_record! {
     }
 }
 
-dbsp_copy_record! {
+crate::dbsp_copy_record! {
     /// Target position for an entity.
     ///
     /// Units:
@@ -120,7 +118,7 @@ dbsp_copy_record! {
     }
 }
 
-dbsp_record! {
+crate::dbsp_record! {
     /// Fear level computed for an entity.
     ///
     /// Units:
@@ -131,7 +129,7 @@ dbsp_record! {
     }
 }
 
-dbsp_copy_record! {
+crate::dbsp_copy_record! {
     /// Decided unit movement vector for an entity.
     ///
     /// Units:

--- a/src/dbsp_circuit/types.rs
+++ b/src/dbsp_circuit/types.rs
@@ -118,10 +118,14 @@ crate::dbsp_copy_record! {
     }
 }
 
-// Fear levels may evolve to hold non-`Copy` state. We avoid implicit duplication
-// by keeping this record non-`Copy` and requiring explicit clones.
+// `FearLevel` must remain non-`Copy` to avoid implicit duplication and to
+// permit future non-`Copy` fields. A compile-time test asserts this type never
+// gains `Copy` accidentally.
 crate::dbsp_record! {
     /// Fear level computed for an entity.
+    ///
+    /// This type intentionally omits `Copy`; clone it explicitly when duplication
+    /// is required.
     ///
     /// Units:
     /// - `level` ∈ [0.0, 1.0] where higher implies greater fear.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,7 +42,7 @@
 //! fields implement `Copy` and the type does not implement `Drop`.
 #[macro_export]
 macro_rules! dbsp_record {
-    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:path)* $(,)? ) => {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:tt)* $(,)? ) => {
         $(#[$meta])*
         #[derive(
             ::rkyv::Archive,
@@ -68,7 +68,7 @@ macro_rules! dbsp_record {
 /// Do not include `Copy` in extras to avoid duplicate derives.
 #[macro_export]
 macro_rules! dbsp_copy_record {
-    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:path)* $(,)? ) => {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:tt)* $(,)? ) => {
         $crate::dbsp_record! {
             $(#[$meta])* $vis struct $name { $($fields)* }, Copy $(, $extra)*
         }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,7 +42,7 @@
 //! fields implement `Copy` and the type does not implement `Drop`.
 #[macro_export]
 macro_rules! dbsp_record {
-    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $($extra:tt)+ ),* $(,)? ) => {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:path)* $(,)? ) => {
         $(#[$meta])*
         #[derive(
             ::rkyv::Archive,
@@ -57,7 +57,7 @@ macro_rules! dbsp_record {
             Hash,
             Default,
             ::size_of::SizeOf
-            $(, $($extra)+ )*
+            $(, $extra)*
         )]
         #[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
         $vis struct $name { $($fields)* }
@@ -65,11 +65,12 @@ macro_rules! dbsp_record {
 }
 
 /// Convenience wrapper around `dbsp_record!` that also derives `Copy`.
+/// Do not include `Copy` in extras to avoid duplicate derives.
 #[macro_export]
 macro_rules! dbsp_copy_record {
-    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $($extra:tt)+ ),* $(,)? ) => {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:path)* $(,)? ) => {
         $crate::dbsp_record! {
-            $(#[$meta])* $vis struct $name { $($fields)* }, Copy $(, $($extra)+ )*
+            $(#[$meta])* $vis struct $name { $($fields)* }, Copy $(, $extra)*
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -14,20 +14,28 @@
 //!         pub value: i32,
 //!     }
 //! }
+//!
+//! // Derive additional traits
+//! dbsp_record! {
+//!     /// Example needing Copy
+//!     pub struct ExampleCopy {
+//!         pub value: i32,
+//!     }, Copy
+//! }
 //! ```
 //!
 //! The macro expands to a struct deriving serialisation, ordering, and size
-//! accounting traits required by the circuit.
+//! accounting traits required by the circuit. Optional traits can be
+//! appended after the struct definition.
 #[macro_export]
 macro_rules! dbsp_record {
-    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* }) => {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:ident)* ) => {
         $(#[$meta])*
         #[derive(
             ::rkyv::Archive,
             ::rkyv::Serialize,
             ::rkyv::Deserialize,
             Clone,
-            Copy,
             Debug,
             PartialEq,
             Eq,
@@ -35,7 +43,8 @@ macro_rules! dbsp_record {
             Ord,
             Hash,
             Default,
-            ::size_of::SizeOf,
+            ::size_of::SizeOf
+            $(, $extra)*
         )]
         #[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
         $vis struct $name { $($fields)* }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@
 //!     /// Example needing Copy
 //!     pub struct ExampleCopy {
 //!         pub value: i32,
-//!     }, Copy
+//!     }, Copy,
 //! }
 //! ```
 //!
@@ -45,12 +45,12 @@
 //! use lille::dbsp_record;
 //!
 //! dbsp_record! {
-//!     pub struct G<T> { pub t: T }, Copy,
+//!     pub struct G<T> { pub t: T }, Copy,,
 //! }
 //! // error: `T` does not implement `Copy`
 //! ```
 //!
-//! A `Copy` bound on the generic parameter is required: `dbsp_record! { pub struct G<T: Copy> { pub t: T }, Copy, }`
+//! A `Copy` bound on the generic parameter is required: `dbsp_record! { pub struct G<T: Copy> { pub t: T }, Copy,, }`
 #[macro_export]
 macro_rules! dbsp_record {
     ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:tt)* $(,)? ) => {
@@ -81,7 +81,7 @@ macro_rules! dbsp_record {
 macro_rules! dbsp_copy_record {
     ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:tt)* $(,)? ) => {
         $crate::dbsp_record! {
-            $(#[$meta])* $vis struct $name { $($fields)* }, Copy $(, $extra)*
+            $(#[$meta])* $vis struct $name { $($fields)* }, Copy, $(, $extra)*
         }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,6 +40,17 @@
 //! Additionally, deriving `Copy` places a `Copy` bound on any generic
 //! parameters of the generated struct, and is only permitted when all
 //! fields implement `Copy` and the type does not implement `Drop`.
+//!
+//! ```compile_fail
+//! use lille::dbsp_record;
+//!
+//! dbsp_record! {
+//!     pub struct G<T> { pub t: T }, Copy,
+//! }
+//! // error: `T` does not implement `Copy`
+//! ```
+//!
+//! A `Copy` bound on the generic parameter is required: `dbsp_record! { pub struct G<T: Copy> { pub t: T }, Copy, }`
 #[macro_export]
 macro_rules! dbsp_record {
     ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:tt)* $(,)? ) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,18 +15,19 @@
 //!     }
 //! }
 //!
-//! // Derive additional traits
+//! // Derive additional traits (any derive path; trailing comma allowed)
 //! dbsp_record! {
 //!     /// Example needing Copy
 //!     pub struct ExampleCopy {
 //!         pub value: i32,
-//!     }, Copy
+//!     }, Copy,
 //! }
 //! ```
 //!
 //! The macro expands to a struct deriving serialisation, ordering, and size
 //! accounting traits required by the circuit. Optional traits can be
-//! appended after the struct definition.
+//! appended after the struct definition as derive paths (e.g.,
+//! `serde::Serialize`), separated by commas, with an optional trailing comma.
 //!
 //! # Note
 //! If the `Copy` trait is omitted from the list of optional traits, the
@@ -35,9 +36,13 @@
 //! required. Users upgrading from earlier versions should ensure their
 //! code does not rely on implicit copying or include `Copy` in the trait
 //! list if necessary.
+//!
+//! Additionally, deriving `Copy` places a `Copy` bound on any generic
+//! parameters of the generated struct, and is only permitted when all
+//! fields implement `Copy` and the type does not implement `Drop`.
 #[macro_export]
 macro_rules! dbsp_record {
-    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:ident)* ) => {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:path)* $(,)? ) => {
         $(#[$meta])*
         #[derive(
             ::rkyv::Archive,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@
 //!     /// Example needing Copy
 //!     pub struct ExampleCopy {
 //!         pub value: i32,
-//!     }, Copy,
+//!     }, serde::Serialize, Copy,
 //! }
 //! ```
 //!

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,7 +20,7 @@
 //!     /// Example needing Copy
 //!     pub struct ExampleCopy {
 //!         pub value: i32,
-//!     }, serde::Serialize, Copy,
+//!     }, Copy
 //! }
 //! ```
 //!
@@ -42,7 +42,7 @@
 //! fields implement `Copy` and the type does not implement `Drop`.
 #[macro_export]
 macro_rules! dbsp_record {
-    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:path)* $(,)? ) => {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $($extra:tt)+ ),* $(,)? ) => {
         $(#[$meta])*
         #[derive(
             ::rkyv::Archive,
@@ -57,9 +57,19 @@ macro_rules! dbsp_record {
             Hash,
             Default,
             ::size_of::SizeOf
-            $(, $extra)*
+            $(, $($extra)+ )*
         )]
         #[archive_attr(derive(Ord, PartialOrd, Eq, PartialEq, Hash))]
         $vis struct $name { $($fields)* }
+    };
+}
+
+/// Convenience wrapper around `dbsp_record!` that also derives `Copy`.
+#[macro_export]
+macro_rules! dbsp_copy_record {
+    ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $($extra:tt)+ ),* $(,)? ) => {
+        $crate::dbsp_record! {
+            $(#[$meta])* $vis struct $name { $($fields)* }, Copy $(, $($extra)+ )*
+        }
     };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -27,6 +27,14 @@
 //! The macro expands to a struct deriving serialisation, ordering, and size
 //! accounting traits required by the circuit. Optional traits can be
 //! appended after the struct definition.
+//!
+//! # Note
+//! If the `Copy` trait is omitted from the list of optional traits, the
+//! generated struct will not implement `Copy`. This means instances of the
+//! struct cannot be implicitly copied and must be explicitly cloned where
+//! required. Users upgrading from earlier versions should ensure their
+//! code does not rely on implicit copying or include `Copy` in the trait
+//! list if necessary.
 #[macro_export]
 macro_rules! dbsp_record {
     ($(#[$meta:meta])* $vis:vis struct $name:ident { $($fields:tt)* } $(, $extra:ident)* ) => {

--- a/tests/copy_record_rspec.rs
+++ b/tests/copy_record_rspec.rs
@@ -1,0 +1,26 @@
+//! Tests verifying that record types using `dbsp_copy_record!` implement `Copy`
+//! and can be duplicated without changing their state.
+use lille::dbsp_circuit::{
+    FloorHeightAt, HighestBlockAt, MovementDecision, Position, Target, Velocity,
+};
+use ordered_float::OrderedFloat;
+use rstest::rstest;
+
+fn assert_copy<T: Copy>() {}
+
+#[rstest]
+#[case::position(Position { entity: 0, x: OrderedFloat(0.0), y: OrderedFloat(0.0), z: OrderedFloat(0.0) })]
+#[case::velocity(Velocity { entity: 0, vx: OrderedFloat(0.0), vy: OrderedFloat(0.0), vz: OrderedFloat(0.0) })]
+#[case::highest_block(HighestBlockAt { x: 0, y: 0, z: 0 })]
+#[case::floor_height(FloorHeightAt { x: 0, y: 0, z: OrderedFloat(0.0) })]
+#[case::target(Target { entity: 0, x: OrderedFloat(0.0), y: OrderedFloat(0.0) })]
+#[case::movement_decision(MovementDecision { entity: 0, dx: OrderedFloat(0.0), dy: OrderedFloat(0.0) })]
+fn copy_records_are_copy<T>(#[case] sample: T)
+where
+    T: Copy + Clone + PartialEq + core::fmt::Debug,
+{
+    assert_copy::<T>();
+    let duplicate = sample;
+    let original = sample;
+    assert_eq!(duplicate, original);
+}

--- a/tests/copy_record_rspec.rs
+++ b/tests/copy_record_rspec.rs
@@ -6,8 +6,6 @@ use lille::dbsp_circuit::{
 use ordered_float::OrderedFloat;
 use rstest::rstest;
 
-fn assert_copy<T: Copy>() {}
-
 #[rstest]
 #[case::position(Position { entity: 0, x: OrderedFloat(0.0), y: OrderedFloat(0.0), z: OrderedFloat(0.0) })]
 #[case::velocity(Velocity { entity: 0, vx: OrderedFloat(0.0), vy: OrderedFloat(0.0), vz: OrderedFloat(0.0) })]
@@ -17,9 +15,8 @@ fn assert_copy<T: Copy>() {}
 #[case::movement_decision(MovementDecision { entity: 0, dx: OrderedFloat(0.0), dy: OrderedFloat(0.0) })]
 fn copy_records_are_copy<T>(#[case] sample: T)
 where
-    T: Copy + Clone + PartialEq + core::fmt::Debug,
+    T: Copy + PartialEq + core::fmt::Debug,
 {
-    assert_copy::<T>();
     let duplicate = sample;
     let original = sample;
     assert_eq!(duplicate, original);

--- a/tests/fear_level_not_copy_rspec.rs
+++ b/tests/fear_level_not_copy_rspec.rs
@@ -1,0 +1,8 @@
+//! Compile-time guard ensuring `FearLevel` does not implement `Copy`.
+use lille::dbsp_circuit::FearLevel;
+use static_assertions::assert_not_impl_any;
+
+#[test]
+fn fear_level_is_not_copy() {
+    assert_not_impl_any!(FearLevel: Copy);
+}

--- a/tests/fear_level_not_copy_rspec.rs
+++ b/tests/fear_level_not_copy_rspec.rs
@@ -2,7 +2,4 @@
 use lille::dbsp_circuit::FearLevel;
 use static_assertions::assert_not_impl_any;
 
-#[test]
-fn fear_level_is_not_copy() {
-    assert_not_impl_any!(FearLevel: Copy);
-}
+assert_not_impl_any!(FearLevel: Copy);


### PR DESCRIPTION
## Summary
- allow `dbsp_record!` to take optional extra derives
- derive `Copy` only for circuit record types that require it

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c09bcdbdc0832286ae6ed5b042bb35

## Summary by Sourcery

Refine record macro derivations by making Copy optional, adding a wrapper macro for Copy derivation, and updating record usages accordingly to derive Copy only when needed

Enhancements:
- Allow dbsp_record! to accept optional extra derive traits after the struct definition
- Remove unconditional Copy derive from dbsp_record! and add it only when specified
- Introduce dbsp_copy_record! macro to automatically derive Copy alongside other traits
- Migrate record definitions in types.rs to use dbsp_copy_record! for Copy-required structs and dbsp_record! otherwise