### PR TITLE
Add optional rendering and text features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,16 @@ edition = "2021"
 description = "A realtime strategy game"
 build = "build.rs"
 
+[[bin]]
+name = "lille"
+path = "src/main.rs"
+required-features = ["render"]
+
 [dependencies]
 hashbrown = "0.14"  # High performance HashMap implementation
 clap = { version = "4.4", features = ["derive"] }  # Command line argument parsing
 glam = { workspace = true }  # Linear algebra for games
-bevy = { version = "0.12", default-features = false, features = ["bevy_asset","bevy_core_pipeline","bevy_render","bevy_sprite","bevy_text","png"] }
+bevy = { version = "0.12", default-features = false }
 log = "0.4"  # Structured logging facade
 env_logger = "0.10"  # Logger implementation controlled via RUST_LOG
 serde = { version = "1.0", features = ["derive"] }
@@ -20,6 +25,17 @@ ordered-float = { workspace = true }
 size-of = { version = "0.1", package = "feldera-size-of", features = ["ordered-float"] }
 rkyv = { version = "0.7", default-features = false, features = ["std", "size_64", "validation", "uuid"] }
 dbsp = "0.98"
+
+[features]
+default = []
+render = [
+    "bevy/bevy_asset",
+    "bevy/bevy_core_pipeline",
+    "bevy/bevy_render",
+    "bevy/bevy_sprite",
+    "bevy/bevy_winit",
+]
+text = ["render", "bevy/bevy_text"]
 
 [build-dependencies]
 build_support = { path = "build_support" }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Lille
 
 A simple real-time strategy prototype demonstrating a dataflow-driven game loop
-with Bevy rendering. The project currently implements "Phase 1" of the
-migration roadmap, synchronizing the legacy `GameWorld` state into Bevy and
-rendering static entities.
+with optional Bevy subsystems. Rendering is enabled with the `render` feature,
+while text rendering builds on top via the `text` feature. The project
+currently implements "Phase 1" of the migration roadmap, synchronising the
+legacy `GameWorld` state into Bevy and rendering static entities.
 
 ## Game Setting
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod entity;
 pub mod logging;
 mod macros;
 pub mod physics;
+#[cfg(feature = "render")]
 pub mod spawn_world;
 pub mod vector_math;
 pub mod world_handle;
@@ -28,6 +29,7 @@ pub use dbsp_sync::{
 pub use entity::{BadGuy, Entity};
 pub use logging::init as init_logging;
 pub use physics::{applied_acceleration, apply_ground_friction};
+#[cfg(feature = "render")]
 pub use spawn_world::spawn_world_system;
 pub use vector_math::{vec_mag, vec_normalize};
 pub use world_handle::{init_world_handle_system, WorldHandle};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 //! Example game application using the Lille library.
 //! Launches a Bevy app and wires up logging, world state, and basic systems.
 use bevy::log::LogPlugin;

--- a/tests/spawn.rs
+++ b/tests/spawn.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "render")]
 //! Unit tests for the world-spawning system.
 //! Verifies entity counts and component assignments after system execution.
 use bevy::prelude::*;


### PR DESCRIPTION
## Summary
- make rendering optional and add feature-controlled binary
- guard world-spawning code and tests behind rendering feature
- document new render/text cargo features

## Testing
- `RUSTFLAGS="-D warnings" cargo clippy --all-targets`
- `make fmt`
- `make markdownlint`
- `make nixie`
- `RUSTFLAGS="-D warnings" cargo test` *(fails: build exceeded time limits)*
- `make lint` *(fails: build exceeded time limits)*

------
https://chatgpt.com/codex/tasks/task_e_68c09b4dca688322b3dc15648e3c96af