### PR TITLE
Use macro for physics test helpers

### DIFF
--- a/src/dbsp_circuit/streams/test_utils.rs
+++ b/src/dbsp_circuit/streams/test_utils.rs
@@ -15,7 +15,7 @@ macro_rules! impl_test_helper {
         }
     ) => {
         $(#[$attr])*
-        pub fn $fn_name<$($generic),+>($($param: $generic),+) -> $ret_type
+        pub fn $fn_name<$($generic),+>($($param: $generic_param),+) -> $ret_type
         where
             $($generic: Into<$target>),+
         {
@@ -67,8 +67,8 @@ impl_test_helper!(
     /// Builds a [`Position`] from an entity identifier and coordinates.
     ///
     /// # Examples
-    /// ```ignore
-    /// // Given EntityId(u64) and Coords3D { x, y, z }
+    /// ```rust,no_run
+    /// use lille::dbsp_circuit::streams::test_utils::{pos, EntityId, Coords3D};
     /// let p = pos(EntityId(42), Coords3D { x: 1.0, y: 2.0, z: 3.0 });
     /// assert_eq!(p.entity, 42);
     /// assert_eq!((p.x, p.y, p.z), (1.0, 2.0, 3.0));
@@ -85,7 +85,8 @@ impl_test_helper!(
     /// Builds a [`Velocity`] with the given entity and components.
     ///
     /// # Examples
-    /// ```ignore
+    /// ```rust,no_run
+    /// use lille::dbsp_circuit::streams::test_utils::{vel, EntityId, Coords3D};
     /// let v = vel(EntityId(42), Coords3D { x: 0.1, y: 0.0, z: -0.1 });
     /// assert_eq!(v.entity, 42);
     /// assert_eq!((v.vx, v.vy, v.vz), (0.1, 0.0, -0.1));
@@ -102,7 +103,8 @@ impl_test_helper!(
     /// Constructs a [`Force`] without specifying mass.
     ///
     /// # Examples
-    /// ```ignore
+    /// ```rust,no_run
+    /// use lille::dbsp_circuit::streams::test_utils::{force, EntityId, ForceVector};
     /// let f = force(EntityId(7), ForceVector { x: 3.0, y: 0.0, z: -1.0 });
     /// assert_eq!(f.entity, 7);
     /// assert_eq!((f.fx, f.fy, f.fz), (3.0, 0.0, -1.0));
@@ -121,12 +123,15 @@ impl_test_helper!(
     /// Constructs a [`Force`] with an explicit mass.
     ///
     /// # Examples
-    /// ```ignore
+    /// ```rust,no_run
     /// use ordered_float::OrderedFloat;
+    /// use lille::dbsp_circuit::streams::test_utils::{
+    ///     force_with_mass, EntityId, ForceVector, Mass,
+    /// };
     /// let f = force_with_mass(
     ///     EntityId(7),
     ///     ForceVector { x: 3.0, y: 0.0, z: -1.0 },
-    ///     Mass(2.0)
+    ///     Mass(2.0),
     /// );
     /// assert_eq!(f.entity, 7);
     /// assert_eq!((f.fx, f.fy, f.fz), (3.0, 0.0, -1.0));

--- a/src/dbsp_circuit/streams/test_utils.rs
+++ b/src/dbsp_circuit/streams/test_utils.rs
@@ -7,6 +7,26 @@ pub use test_utils::physics::{
     BlockCoords, BlockId, Coords3D, EntityId, ForceVector, Gradient, Mass,
 };
 
+macro_rules! impl_test_helper {
+    (
+        $(#[$attr:meta])*
+        $fn_name:ident<$($generic:ident: Into<$target:ty>),+>($($param:ident: $generic_param:ident),+) -> $ret_type:path {
+            $($field:ident: $expr:expr),+ $(,)?
+        }
+    ) => {
+        $(#[$attr])*
+        pub fn $fn_name<$($generic),+>($($param: $generic),+) -> $ret_type
+        where
+            $($generic: Into<$target>),+
+        {
+            $(let $param: $target = $param.into();)+
+            $ret_type {
+                $($field: $expr),+
+            }
+        }
+    };
+}
+
 /// Builds a new [`DbspCircuit`] for tests.
 pub fn new_circuit() -> DbspCircuit {
     DbspCircuit::new().expect("failed to build DBSP circuit")
@@ -43,70 +63,44 @@ where
     }
 }
 
-/// Builds a [`Position`] from an entity identifier and coordinates.
-pub fn pos<E, C>(entity: E, coords: C) -> Position
-where
-    E: Into<EntityId>,
-    C: Into<Coords3D>,
-{
-    let entity: EntityId = entity.into();
-    let coords: Coords3D = coords.into();
-    Position {
+impl_test_helper!(
+    /// Builds a [`Position`] from an entity identifier and coordinates.
+    pos<E: Into<EntityId>, C: Into<Coords3D> >(entity: E, coords: C) -> Position {
         entity: entity.0,
         x: coords.x.into(),
         y: coords.y.into(),
         z: coords.z.into(),
     }
-}
+);
 
-/// Builds a [`Velocity`] with the given entity and components.
-pub fn vel<E, V>(entity: E, velocity: V) -> Velocity
-where
-    E: Into<EntityId>,
-    V: Into<Coords3D>,
-{
-    let entity: EntityId = entity.into();
-    let velocity: Coords3D = velocity.into();
-    Velocity {
+impl_test_helper!(
+    /// Builds a [`Velocity`] with the given entity and components.
+    vel<E: Into<EntityId>, V: Into<Coords3D> >(entity: E, velocity: V) -> Velocity {
         entity: entity.0,
         vx: velocity.x.into(),
         vy: velocity.y.into(),
         vz: velocity.z.into(),
     }
-}
+);
 
-/// Constructs a [`Force`] without specifying mass.
-pub fn force<E, V>(entity: E, vec: V) -> Force
-where
-    E: Into<EntityId>,
-    V: Into<ForceVector>,
-{
-    let entity: EntityId = entity.into();
-    let vec: ForceVector = vec.into();
-    Force {
+impl_test_helper!(
+    /// Constructs a [`Force`] without specifying mass.
+    force<E: Into<EntityId>, V: Into<ForceVector> >(entity: E, vec: V) -> Force {
         entity: entity.0,
         fx: vec.x.into(),
         fy: vec.y.into(),
         fz: vec.z.into(),
         mass: None,
     }
-}
+);
 
-/// Constructs a [`Force`] with an explicit mass.
-pub fn force_with_mass<E, V, M>(entity: E, vec: V, mass: M) -> Force
-where
-    E: Into<EntityId>,
-    V: Into<ForceVector>,
-    M: Into<Mass>,
-{
-    let entity: EntityId = entity.into();
-    let vec: ForceVector = vec.into();
-    let mass: Mass = mass.into();
-    Force {
+impl_test_helper!(
+    /// Constructs a [`Force`] with an explicit mass.
+    force_with_mass<E: Into<EntityId>, V: Into<ForceVector>, M: Into<Mass> >(entity: E, vec: V, mass: M) -> Force {
         entity: entity.0,
         fx: vec.x.into(),
         fy: vec.y.into(),
         fz: vec.z.into(),
         mass: Some(mass.0.into()),
     }
-}
+);

--- a/src/dbsp_circuit/streams/test_utils.rs
+++ b/src/dbsp_circuit/streams/test_utils.rs
@@ -142,6 +142,6 @@ impl_test_helper!(
         fx: vec.x.into(),
         fy: vec.y.into(),
         fz: vec.z.into(),
-        mass: Some(mass.0.into()),
+        mass: Some(mass.into()),
     }
 );

--- a/src/dbsp_circuit/streams/test_utils.rs
+++ b/src/dbsp_circuit/streams/test_utils.rs
@@ -19,7 +19,7 @@ macro_rules! impl_test_helper {
         where
             $($generic: Into<$target>),+
         {
-            $(let $param = $param.into();)+
+            $(let $param: $target = $param.into();)+
             $ret_type {
                 $($field: $expr),+
             }

--- a/src/dbsp_circuit/streams/test_utils.rs
+++ b/src/dbsp_circuit/streams/test_utils.rs
@@ -19,7 +19,7 @@ macro_rules! impl_test_helper {
         where
             $($generic: Into<$target>),+
         {
-            $(let $param: $target = $param.into();)+
+            $(let $param = $param.into();)+
             $ret_type {
                 $($field: $expr),+
             }
@@ -65,6 +65,14 @@ where
 
 impl_test_helper!(
     /// Builds a [`Position`] from an entity identifier and coordinates.
+    ///
+    /// # Examples
+    /// ```ignore
+    /// // Given EntityId(u64) and Coords3D { x, y, z }
+    /// let p = pos(EntityId(42), Coords3D { x: 1.0, y: 2.0, z: 3.0 });
+    /// assert_eq!(p.entity, 42);
+    /// assert_eq!((p.x, p.y, p.z), (1.0, 2.0, 3.0));
+    /// ```
     pos<E: Into<EntityId>, C: Into<Coords3D> >(entity: E, coords: C) -> Position {
         entity: entity.0,
         x: coords.x.into(),
@@ -75,6 +83,13 @@ impl_test_helper!(
 
 impl_test_helper!(
     /// Builds a [`Velocity`] with the given entity and components.
+    ///
+    /// # Examples
+    /// ```ignore
+    /// let v = vel(EntityId(42), Coords3D { x: 0.1, y: 0.0, z: -0.1 });
+    /// assert_eq!(v.entity, 42);
+    /// assert_eq!((v.vx, v.vy, v.vz), (0.1, 0.0, -0.1));
+    /// ```
     vel<E: Into<EntityId>, V: Into<Coords3D> >(entity: E, velocity: V) -> Velocity {
         entity: entity.0,
         vx: velocity.x.into(),
@@ -85,6 +100,14 @@ impl_test_helper!(
 
 impl_test_helper!(
     /// Constructs a [`Force`] without specifying mass.
+    ///
+    /// # Examples
+    /// ```ignore
+    /// let f = force(EntityId(7), ForceVector { x: 3.0, y: 0.0, z: -1.0 });
+    /// assert_eq!(f.entity, 7);
+    /// assert_eq!((f.fx, f.fy, f.fz), (3.0, 0.0, -1.0));
+    /// assert!(f.mass.is_none());
+    /// ```
     force<E: Into<EntityId>, V: Into<ForceVector> >(entity: E, vec: V) -> Force {
         entity: entity.0,
         fx: vec.x.into(),
@@ -96,6 +119,19 @@ impl_test_helper!(
 
 impl_test_helper!(
     /// Constructs a [`Force`] with an explicit mass.
+    ///
+    /// # Examples
+    /// ```ignore
+    /// use ordered_float::OrderedFloat;
+    /// let f = force_with_mass(
+    ///     EntityId(7),
+    ///     ForceVector { x: 3.0, y: 0.0, z: -1.0 },
+    ///     Mass(2.0)
+    /// );
+    /// assert_eq!(f.entity, 7);
+    /// assert_eq!((f.fx, f.fy, f.fz), (3.0, 0.0, -1.0));
+    /// assert_eq!(f.mass, Some(OrderedFloat(2.0)));
+    /// ```
     force_with_mass<E: Into<EntityId>, V: Into<ForceVector>, M: Into<Mass> >(entity: E, vec: V, mass: M) -> Force {
         entity: entity.0,
         fx: vec.x.into(),

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -7,3 +7,4 @@ publish = false
 [dependencies]
 syn = { version = "2.0.103", features = ["full"] }
 lille = { path = ".." }
+ordered-float = { workspace = true }

--- a/test_utils/src/physics.rs
+++ b/test_utils/src/physics.rs
@@ -2,6 +2,7 @@
 
 use lille::components::{Block, BlockSlope};
 use lille::dbsp_circuit::{DbspCircuit, FearLevel, Force, Position, Target, Velocity};
+use ordered_float::OrderedFloat;
 
 #[derive(Clone, Copy, Debug)]
 pub struct EntityId(pub i64);
@@ -147,12 +148,21 @@ impl Mass {
     ///
     /// # Examples
     /// ```
+    /// use ordered_float::OrderedFloat;
     /// use test_utils::physics::Mass;
     /// let m = Mass::new(5.0);
-    /// assert_eq!(m.0, 5.0);
+    /// let val: OrderedFloat<f64> = m.into();
+    /// assert_eq!(val, OrderedFloat(5.0));
     /// ```
     pub fn new(val: f64) -> Self {
         Self(val)
+    }
+}
+
+impl From<Mass> for OrderedFloat<f64> {
+    fn from(mass: Mass) -> Self {
+        let Mass(inner) = mass;
+        OrderedFloat(inner)
     }
 }
 
@@ -322,7 +332,7 @@ fn force_inner(entity: EntityId, vec: ForceVector, mass: Option<Mass>) -> Force 
         fx: vec.x.into(),
         fy: vec.y.into(),
         fz: vec.z.into(),
-        mass: mass.map(|m| m.0.into()),
+        mass: mass.map(|m| m.into()),
     }
 }
 


### PR DESCRIPTION
## Summary
- introduce `impl_test_helper` macro for physics record constructors
- generate `pos`, `vel`, `force`, and `force_with_mass` helpers via macro

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ad1ff00c83229717eea0204e910b

## Summary by Sourcery

Introduce a macro to consolidate repetitive physics test helper constructors and replace their manual implementations with macro-generated functions.

Enhancements:
- Add impl_test_helper macro to streamline physics test helper function generation
- Replace manual pos, vel, force, and force_with_mass implementations with macro invocations