### PR TITLE
Document tick timing and floor rounding semantics

### DIFF
--- a/docs/lille-physics-and-world-engine-roadmap.md
+++ b/docs/lille-physics-and-world-engine-roadmap.md
@@ -242,6 +242,13 @@ physical properties and agent behaviours.
         - Debounce: add a per-entity cooldown of `LANDING_COOLDOWN_TICKS: u32`
           (default: 6 ticks). Document how ticks map to wall time in the engine.
 
+### Tick timing
+
+The fixed-step simulation runs at 1 Hz, as configured by `DELTA_TIME = 1.0` in
+`src/constants.rs`. Each tick therefore spans 1,000 milliseconds of wall time.
+With `LANDING_COOLDOWN_TICKS` defaulting to six ticks, landing suppression
+lasts for 6,000 milliseconds before another fall-damage event may trigger.
+
         - Hysteresis: reuse the motion system's `z_floor` grace band to avoid
           chatter-induced re-triggers.
 
@@ -256,9 +263,9 @@ physical properties and agent behaviours.
           `FALL_DAMAGE_SCALE = 4.0`. State that tuning may change but tests pin
           current values.
 
-        - Clamp: never emit negative damage; round down before casting to `u16`.
-          Clamp `vz_before_contact` by `TERMINAL_VELOCITY` before computing
-          impact.
+        - Clamp: never emit negative damage; apply `.floor()` before casting to
+          `u16`. Clamp `vz_before_contact` by `TERMINAL_VELOCITY` before
+          computing impact.
 
       - [x] Emit derived damage events into the `Damage` stream and reduce
         entity health through the circuit's health accumulator.


### PR DESCRIPTION
## Summary
- add a Tick timing subsection that explains the 1 Hz fixed-step cadence and the landing cooldown duration
- clarify that fall damage should use .floor() before casting to u16 so the implementation matches the spec

## Testing
- make fmt
- make markdownlint
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d950cbbfa083229f2eaaadebcdf30b

## Summary by Sourcery

Add a Tick timing section to the physics roadmap and clarify the fall damage rounding semantics in the documentation.

Documentation:
- Introduce a Tick timing subsection explaining the 1 Hz fixed-step cadence and landing cooldown duration in wall time.
- Clarify that fall damage calculations use floor rounding before casting to u16 in the spec.