### PR TITLE
Add PresentationPlugin with CameraController marker

### DIFF
--- a/build_support/src/font.rs
+++ b/build_support/src/font.rs
@@ -4,6 +4,11 @@
 //! [`FontFetcher`], checks its SHA-256 digest and writes the verified font to
 //! disk. This ensures deterministic builds without shipping the font in the
 //! repository.
+//!
+//! Build scripts require ambient filesystem authority to create asset
+//! directories and write files to paths determined by Cargo environment
+//! variables. The `cap_std` capability model cannot be applied here because
+//! Cargo does not provide directory handles.
 use anyhow::{anyhow, Context, Result};
 use reqwest::blocking::Client;
 use sha2::{Digest, Sha256};

--- a/docs/execplans/pres-task-1-3-2-spawn-player-and-actors-on-map-readiness.md
+++ b/docs/execplans/pres-task-1-3-2-spawn-player-and-actors-on-map-readiness.md
@@ -77,10 +77,10 @@ Created `src/map/spawn.rs` containing:
 
 ### ID Assignment Strategy
 
-| Entity | ID Source                                       |
-| ------ | ----------------------------------------------- |
-| Player | `spawn_entity.to_bits() as i64`                 |
-| NPC    | `NPC_ID_BASE (i64::MIN) + NpcIdCounter.0`       |
+| Entity | ID Source                                 |
+| ------ | ----------------------------------------- |
+| Player | `spawn_entity.to_bits() as i64`           |
+| NPC    | `NPC_ID_BASE (i64::MIN) + NpcIdCounter.0` |
 
 The offset ensures no collision between player entity bits and NPC IDs. The
 `NpcIdCounter` resource persists across map loads within a session, preventing

--- a/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
+++ b/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
@@ -108,11 +108,13 @@ Thresholds that trigger escalation when breached:
     `src/main.rs` (line 1). Presentation is meaningless without rendering.
   - Date/Author: 2026-01-08 / Planning phase
 
-- **Decision**: Use `Camera2d` with explicit `OrthographicProjection` component
+- **Decision**: Use `Camera2d` and rely on Required Components for projection
   - Rationale: Design doc (`docs/lille-presentational-layer.md` lines 121-124)
-    specifies spawning "Camera2d plus a 2D Projection". Explicit projection
-    allows future zoom control (Task 2.1.3).
-  - Date/Author: 2026-01-08 / Planning phase
+    specifies spawning "Camera2d plus a 2D Projection". Bevy 0.17's Required
+    Components mechanism automatically inserts `Projection` when `Camera2d` is
+    spawned, making explicit `OrthographicProjection` unnecessary. Future zoom
+    control (Task 2.1.3) can query/mutate the auto-inserted component.
+  - Date/Author: 2026-01-08 / Planning phase (updated during implementation)
 
 - **Decision**: Remove `should_bootstrap_camera` setting from `LilleMapSettings`
   - Rationale: Setting becomes meaningless once `PresentationPlugin` owns camera

--- a/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
+++ b/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
@@ -16,7 +16,8 @@ camera setup. After this change, the application will render through a camera
 spawned by `PresentationPlugin` rather than the temporary bootstrap camera in
 `LilleMapPlugin`. This separates rendering concerns from map loading, allowing
 the presentation layer to evolve independently (panning, zooming, Y-sorting in
-later tasks) whilst keeping the simulation authoritative via the DBSP circuit.
+later tasks) whilst keeping the simulation authoritative via the Differential
+Dataflow-Based Stream Processing (DBSP) circuit.
 
 The user-visible outcome: launching the game produces the same visual output,
 but the camera is now controlled by a dedicated presentation module that can be
@@ -165,7 +166,8 @@ superseded by `PresentationPlugin` in Task 2.1.1.
 
 ### Test Infrastructure
 
-- `tests/support/rspec_runner.rs` - `run_serial()` function for BDD tests
+- `tests/support/rspec_runner.rs` - `run_serial()` function for behaviour-driven
+  development (BDD) tests
 - `tests/support/map_fixture.rs` - `MapPluginFixtureBase` pattern
 - `tests/support/thread_safe_app.rs` - `SharedApp` wrapper
 - `tests/support/map_test_plugins.rs` - Headless test plugin helpers
@@ -174,7 +176,9 @@ superseded by `PresentationPlugin` in Task 2.1.1.
 
 DBSP systems run in `Update` schedule (or `PostUpdate` with feature flag):
 
-    cache_state_for_dbsp_system → apply_dbsp_outputs_system
+```text
+cache_state_for_dbsp_system → apply_dbsp_outputs_system
+```
 
 Presentation systems needing current transforms must use
 `.after(apply_dbsp_outputs_system)`. This task (2.1.1) only creates the camera;
@@ -203,9 +207,11 @@ Create `src/presentation.rs` with:
 
 In `src/presentation.rs`, define:
 
-    #[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
-    #[reflect(Component, Default)]
-    pub struct CameraController;
+```rust
+#[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[reflect(Component, Default)]
+pub struct CameraController;
+```
 
 This follows the pattern from `src/map/mod.rs` (e.g., `Collidable` line 114).
 
@@ -220,19 +226,23 @@ Create Startup system that:
 
 Example:
 
-    fn camera_setup(mut commands: Commands) {
-        commands.spawn((
-            Camera2d,
-            OrthographicProjection::default_2d(),
-            CameraController,
-            Name::new("PresentationCamera"),
-        ));
-    }
+```rust
+fn camera_setup(mut commands: Commands) {
+    commands.spawn((
+        Camera2d,
+        OrthographicProjection::default_2d(),
+        CameraController,
+        Name::new("PresentationCamera"),
+    ));
+}
+```
 
 Register in plugin's `build()` method:
 
-    app.register_type::<CameraController>();
-    app.add_systems(Startup, camera_setup);
+```rust
+app.register_type::<CameraController>();
+app.add_systems(Startup, camera_setup);
+```
 
 ### Stage E: Wire Module into Crate
 
@@ -277,9 +287,11 @@ Create `tests/presentation_plugin_rspec.rs`:
 
 Execute in order:
 
-    make check-fmt 2>&1 | tee /tmp/fmt.log
-    make lint 2>&1 | tee /tmp/lint.log
-    make test 2>&1 | tee /tmp/test.log
+```shell
+make check-fmt 2>&1 | tee /tmp/fmt.log
+make lint 2>&1 | tee /tmp/lint.log
+make test 2>&1 | tee /tmp/test.log
+```
 
 Fix any failures before proceeding.
 
@@ -287,29 +299,35 @@ Fix any failures before proceeding.
 
 In `docs/lille-map-and-presentation-roadmap.md`, change line 113:
 
-    - [ ] Task 2.1.1
+```markdown
+- [ ] Task 2.1.1
+```
 
 To:
 
-    - [x] Task 2.1.1
+```markdown
+- [x] Task 2.1.1
+```
 
 ### Stage K: Commit
 
 Create atomic commit with message:
 
-    Add PresentationPlugin with CameraController marker
+```text
+Add PresentationPlugin with CameraController marker
 
-    Introduce src/presentation.rs defining PresentationPlugin, which spawns
-    a Camera2d with CameraController marker component. This supersedes the
-    temporary bootstrap camera in LilleMapPlugin.
+Introduce src/presentation.rs defining PresentationPlugin, which spawns
+a Camera2d with CameraController marker component. This supersedes the
+temporary bootstrap camera in LilleMapPlugin.
 
-    - Add CameraController component with Reflect derives
-    - Add camera_setup Startup system spawning presentation camera
-    - Remove MapBootstrapCamera and bootstrap_camera_if_missing from map module
-    - Remove should_bootstrap_camera setting from LilleMapSettings
-    - Add behavioural test verifying camera spawns with marker
+- Add CameraController component with Reflect derives
+- Add camera_setup Startup system spawning presentation camera
+- Remove MapBootstrapCamera and bootstrap_camera_if_missing from map module
+- Remove should_bootstrap_camera setting from LilleMapSettings
+- Add behavioural test verifying camera spawns with marker
 
-    Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+```
 
 ## Concrete Steps
 
@@ -337,9 +355,11 @@ Write `tests/presentation_plugin_rspec.rs`.
 
 ### 6. Run validation
 
-    make check-fmt 2>&1 | tee /tmp/fmt.log
-    make lint 2>&1 | tee /tmp/lint.log
-    make test 2>&1 | tee /tmp/test.log
+```shell
+make check-fmt 2>&1 | tee /tmp/fmt.log
+make lint 2>&1 | tee /tmp/lint.log
+make test 2>&1 | tee /tmp/test.log
+```
 
 Expected: All pass with no warnings.
 
@@ -349,24 +369,26 @@ Mark Task 2.1.1 as complete in roadmap.
 
 ### 8. Commit
 
-    git add src/presentation.rs src/lib.rs src/main.rs src/map/mod.rs \
-        tests/presentation_plugin_rspec.rs docs/lille-map-and-presentation-roadmap.md
-    git commit -m "$(cat <<'EOF'
-    Add PresentationPlugin with CameraController marker
+```shell
+git add src/presentation.rs src/lib.rs src/main.rs src/map/mod.rs \
+    tests/presentation_plugin_rspec.rs docs/lille-map-and-presentation-roadmap.md
+git commit -m "$(cat <<'EOF'
+Add PresentationPlugin with CameraController marker
 
-    Introduce src/presentation.rs defining PresentationPlugin, which spawns
-    a Camera2d with CameraController marker component. This supersedes the
-    temporary bootstrap camera in LilleMapPlugin.
+Introduce src/presentation.rs defining PresentationPlugin, which spawns
+a Camera2d with CameraController marker component. This supersedes the
+temporary bootstrap camera in LilleMapPlugin.
 
-    - Add CameraController component with Reflect derives
-    - Add camera_setup Startup system spawning presentation camera
-    - Remove MapBootstrapCamera and bootstrap_camera_if_missing from map module
-    - Remove should_bootstrap_camera setting from LilleMapSettings
-    - Add behavioural test verifying camera spawns with marker
+- Add CameraController component with Reflect derives
+- Add camera_setup Startup system spawning presentation camera
+- Remove MapBootstrapCamera and bootstrap_camera_if_missing from map module
+- Remove should_bootstrap_camera setting from LilleMapSettings
+- Add behavioural test verifying camera spawns with marker
 
-    Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
-    EOF
-    )"
+Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+EOF
+)"
+```
 
 ## Validation and Acceptance
 
@@ -380,7 +402,9 @@ Mark Task 2.1.1 as complete in roadmap.
 
 ### Quality Method
 
-    make check-fmt && make lint && make test
+```shell
+make check-fmt && make lint && make test
+```
 
 ### Acceptance Behaviour
 
@@ -400,40 +424,46 @@ After implementation:
 - Module creation is idempotent (overwrites existing file)
 - Git commit is safe to amend if not yet pushed
 
-## Artifacts and Notes
+## Artefacts and Notes
 
 ### Expected File Structure After Implementation
 
-    src/
-      presentation.rs    # NEW - ~80 lines
-      lib.rs             # MODIFIED - add module + exports
-      main.rs            # MODIFIED - add plugin
-      map/
-        mod.rs           # MODIFIED - remove bootstrap camera
-    tests/
-      presentation_plugin_rspec.rs  # NEW - ~80 lines
+```text
+src/
+  presentation.rs    # NEW - ~80 lines
+  lib.rs             # MODIFIED - add module + exports
+  main.rs            # MODIFIED - add plugin
+  map/
+    mod.rs           # MODIFIED - remove bootstrap camera
+tests/
+  presentation_plugin_rspec.rs  # NEW - ~80 lines
+```
 
 ### Component Definition Pattern (from src/map/mod.rs)
 
-    #[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
-    #[reflect(Component, Default)]
-    pub struct MarkerName;
+```rust
+#[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[reflect(Component, Default)]
+pub struct MarkerName;
+```
 
 ### Test Fixture Pattern (from tests/support/map_fixture.rs)
 
-    #[derive(Debug, Clone)]
-    struct PresentationPluginFixture {
-        base: MapPluginFixtureBase,
-    }
+```rust
+#[derive(Debug, Clone)]
+struct PresentationPluginFixture {
+    base: MapPluginFixtureBase,
+}
 
-    impl PresentationPluginFixture {
-        fn bootstrap() -> Self {
-            let mut app = App::new();
-            map_test_plugins::add_map_test_plugins(&mut app);
-            app.add_plugins(PresentationPlugin);
-            Self { base: MapPluginFixtureBase::new(app) }
-        }
+impl PresentationPluginFixture {
+    fn bootstrap() -> Self {
+        let mut app = App::new();
+        map_test_plugins::add_map_test_plugins(&mut app);
+        app.add_plugins(PresentationPlugin);
+        Self { base: MapPluginFixtureBase::new(app) }
     }
+}
+```
 
 ## Interfaces and Dependencies
 
@@ -441,27 +471,31 @@ After implementation:
 
 In `src/presentation.rs`:
 
-    /// Marker component for the main presentation camera.
-    #[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
-    #[reflect(Component, Default)]
-    pub struct CameraController;
+```rust
+/// Marker component for the main presentation camera.
+#[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[reflect(Component, Default)]
+pub struct CameraController;
 
-    /// Plugin owning camera setup and presentation layer systems.
-    pub struct PresentationPlugin;
+/// Plugin owning camera setup and presentation layer systems.
+pub struct PresentationPlugin;
 
-    impl Plugin for PresentationPlugin {
-        fn build(&self, app: &mut App) { … }
-    }
+impl Plugin for PresentationPlugin {
+    fn build(&self, app: &mut App) { /* … */ }
+}
+```
 
 ### Re-exports in `src/lib.rs`
 
-    #[cfg(feature = "render")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "render")))]
-    pub mod presentation;
+```rust
+#[cfg(feature = "render")]
+#[cfg_attr(docsrs, doc(cfg(feature = "render")))]
+pub mod presentation;
 
-    #[cfg(feature = "render")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "render")))]
-    pub use presentation::{PresentationPlugin, CameraController};
+#[cfg(feature = "render")]
+#[cfg_attr(docsrs, doc(cfg(feature = "render")))]
+pub use presentation::{PresentationPlugin, CameraController};
+```
 
 ### Dependencies
 

--- a/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
+++ b/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
@@ -70,13 +70,15 @@ Thresholds that trigger escalation when breached:
 ## Progress
 
 - [x] (2026-01-08) Stage A: Understand current camera bootstrap mechanism
-- [x] (2026-01-08) Stage B: Create `src/presentation.rs` with `PresentationPlugin` skeleton
+- [x] (2026-01-08) Stage B: Create `src/presentation.rs` with
+      `PresentationPlugin` skeleton
 - [x] (2026-01-08) Stage C: Define `CameraController` marker component
 - [x] (2026-01-08) Stage D: Implement `camera_setup` Startup system
 - [x] (2026-01-08) Stage E: Wire module into `src/lib.rs` and `src/main.rs`
 - [x] (2026-01-08) Stage F: Remove legacy camera bootstrap from `LilleMapPlugin`
 - [x] (2026-01-08) Stage G: Add unit tests for component definitions
-- [x] (2026-01-08) Stage H: Add behavioural test (rust-rspec) verifying camera spawns
+- [x] (2026-01-08) Stage H: Add behavioural test (rust-rspec) verifying camera
+      spawns
 - [x] (2026-01-08) Stage I: Run quality gates (fmt, lint, test)
 - [x] (2026-01-08) Stage J: Update roadmap to mark task complete
 - [x] (2026-01-08) Stage K: Commit with descriptive message

--- a/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
+++ b/docs/execplans/pres-task-task-2-1-1-create-presentation-plugin-and-camera-marker.md
@@ -1,0 +1,473 @@
+# Create PresentationPlugin and Camera Marker (Task 2.1.1)
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: COMPLETE
+
+This document must be maintained in accordance with
+`docs/documentation-style-guide.md` and `AGENTS.md`.
+
+## Purpose / Big Picture
+
+Task 2.1.1 establishes the presentation layer as a dedicated plugin that owns
+camera setup. After this change, the application will render through a camera
+spawned by `PresentationPlugin` rather than the temporary bootstrap camera in
+`LilleMapPlugin`. This separates rendering concerns from map loading, allowing
+the presentation layer to evolve independently (panning, zooming, Y-sorting in
+later tasks) whilst keeping the simulation authoritative via the DBSP circuit.
+
+The user-visible outcome: launching the game produces the same visual output,
+but the camera is now controlled by a dedicated presentation module that can be
+extended for interactive controls.
+
+## Constraints
+
+Hard invariants that must hold throughout implementation:
+
+- DBSP circuit must remain the sole source of truth for inferred behaviour;
+  presentation systems must be passive observers of simulation state.
+- No changes to `src/dbsp_circuit/` or `src/dbsp_sync/` modules.
+- No modifications to map asset loading logic in `src/map/translate.rs` or
+  spawn logic in `src/map/spawn.rs`.
+- File size limit: no single code file may exceed 400 lines.
+- Use en-GB-oxendict spelling in comments and documentation.
+- Tests must use `rstest` for unit tests and `rust-rspec` for behavioural tests.
+
+## Tolerances (Exception Triggers)
+
+Thresholds that trigger escalation when breached:
+
+- **Scope**: If implementation requires changes to more than 6 files (excluding
+  test files), stop and escalate.
+- **Interface**: If any public API signature in `src/dbsp_sync/` must change,
+  stop and escalate.
+- **Dependencies**: No new external crate dependencies are required; if one
+  becomes necessary, stop and escalate.
+- **Iterations**: If tests still fail after 3 attempts at fixing, stop and
+  escalate.
+- **Ambiguity**: If multiple valid interpretations exist for camera projection
+  configuration, present options with trade-offs.
+
+## Risks
+
+- **Risk**: Removing `bootstrap_camera_if_missing()` may cause tests that depend
+  on having a camera to fail.
+  - Severity: medium
+  - Likelihood: medium
+  - Mitigation: Ensure `PresentationPlugin` is added to test apps that require
+    rendering, or update `LilleMapSettings::should_bootstrap_camera` to default
+    false and remove the system in a subsequent commit.
+
+- **Risk**: Feature flag gating (`#[cfg(feature = "render")]`) may cause compile
+  errors when features are toggled.
+  - Severity: low
+  - Likelihood: medium
+  - Mitigation: Gate `PresentationPlugin` behind `render` feature like existing
+    code; verify with `cargo check --all-features` and without.
+
+## Progress
+
+- [x] (2026-01-08) Stage A: Understand current camera bootstrap mechanism
+- [x] (2026-01-08) Stage B: Create `src/presentation.rs` with `PresentationPlugin` skeleton
+- [x] (2026-01-08) Stage C: Define `CameraController` marker component
+- [x] (2026-01-08) Stage D: Implement `camera_setup` Startup system
+- [x] (2026-01-08) Stage E: Wire module into `src/lib.rs` and `src/main.rs`
+- [x] (2026-01-08) Stage F: Remove legacy camera bootstrap from `LilleMapPlugin`
+- [x] (2026-01-08) Stage G: Add unit tests for component definitions
+- [x] (2026-01-08) Stage H: Add behavioural test (rust-rspec) verifying camera spawns
+- [x] (2026-01-08) Stage I: Run quality gates (fmt, lint, test)
+- [x] (2026-01-08) Stage J: Update roadmap to mark task complete
+- [x] (2026-01-08) Stage K: Commit with descriptive message
+
+## Surprises & Discoveries
+
+- **Observation**: Removing `should_bootstrap_camera` required updating 11 test
+  files that referenced the now-removed field.
+  - Evidence: Grep revealed tests explicitly setting `should_bootstrap_camera:
+    false` in `LilleMapSettings` construction.
+  - Impact: Minor additional work, but the removal cleaned up dead code and made
+    the `LilleMapSettings` struct simpler.
+
+- **Observation**: Bevy 0.17's Required Components mechanism means `Camera2d`
+  automatically provides `Projection`, so explicit `OrthographicProjection`
+  spawn is not required for basic camera functionality.
+  - Evidence: Original plan called for spawning `OrthographicProjection`
+    explicitly, but tests confirmed the camera works without it.
+  - Impact: Simpler camera spawn code. Future zoom control (Task 2.1.3) can
+    query/mutate the auto-inserted `Projection` component.
+
+## Decision Log
+
+- **Decision**: Gate `PresentationPlugin` behind `#[cfg(feature = "render")]`
+  - Rationale: Matches existing pattern in `src/map/mod.rs` (line 199) and
+    `src/main.rs` (line 1). Presentation is meaningless without rendering.
+  - Date/Author: 2026-01-08 / Planning phase
+
+- **Decision**: Use `Camera2d` with explicit `OrthographicProjection` component
+  - Rationale: Design doc (`docs/lille-presentational-layer.md` lines 121-124)
+    specifies spawning "Camera2d plus a 2D Projection". Explicit projection
+    allows future zoom control (Task 2.1.3).
+  - Date/Author: 2026-01-08 / Planning phase
+
+- **Decision**: Remove `should_bootstrap_camera` setting from `LilleMapSettings`
+  - Rationale: Setting becomes meaningless once `PresentationPlugin` owns camera
+    setup. Keeping it creates dead code and confusion.
+  - Date/Author: 2026-01-08 / Planning phase
+
+## Outcomes & Retrospective
+
+**Outcomes:**
+
+- `src/presentation.rs` now defines `PresentationPlugin` with `CameraController`
+  marker component and `camera_setup` Startup system.
+- Legacy camera bootstrap (`MapBootstrapCamera`, `bootstrap_camera_if_missing`,
+  `should_bootstrap_camera`) removed from `src/map/mod.rs`.
+- Behavioural test (`tests/presentation_plugin_rspec.rs`) validates camera
+  spawns with correct components and naming.
+- All quality gates pass: `make check-fmt`, `make lint`, `make test`.
+
+**Retrospective:**
+
+- The implementation went smoothly, matching the plan closely.
+- Removing the `should_bootstrap_camera` field required more test file updates
+  than anticipated (11 files), but this was straightforward search-and-replace.
+- The Bevy 0.17 Required Components model simplified the camera spawn since we
+  don't need to explicitly add projection components.
+- Next time: when removing a struct field, grep for it across test files early
+  to scope the change accurately.
+
+## Context and Orientation
+
+### Current State
+
+The codebase has a temporary camera bootstrap in `src/map/mod.rs`:
+
+- **Component**: `MapBootstrapCamera` (marker, line 201)
+- **System**: `bootstrap_camera_if_missing()` (lines 275-289)
+- **Setting**: `LilleMapSettings::should_bootstrap_camera` (line 100)
+- **Schedule**: `Startup` (line 524)
+
+This was explicitly marked as temporary in the design docs, intended to be
+superseded by `PresentationPlugin` in Task 2.1.1.
+
+### Key Files
+
+- `src/map/mod.rs` - Contains legacy camera bootstrap to remove
+- `src/lib.rs` - Module declarations and re-exports (lines 1-73)
+- `src/main.rs` - App plugin registration (lines 1-43)
+- `src/components.rs` - Component definition patterns (lines 1-199)
+- `docs/lille-presentational-layer.md` - Design specification
+- `docs/lille-map-and-presentation-roadmap.md` - Task definition
+
+### Test Infrastructure
+
+- `tests/support/rspec_runner.rs` - `run_serial()` function for BDD tests
+- `tests/support/map_fixture.rs` - `MapPluginFixtureBase` pattern
+- `tests/support/thread_safe_app.rs` - `SharedApp` wrapper
+- `tests/support/map_test_plugins.rs` - Headless test plugin helpers
+
+### DBSP System Ordering (for Task 2.1.4 context)
+
+DBSP systems run in `Update` schedule (or `PostUpdate` with feature flag):
+
+    cache_state_for_dbsp_system → apply_dbsp_outputs_system
+
+Presentation systems needing current transforms must use
+`.after(apply_dbsp_outputs_system)`. This task (2.1.1) only creates the camera;
+ordering will be addressed in Task 2.1.4.
+
+## Plan of Work
+
+### Stage A: Understand (read-only, no code changes)
+
+Verify understanding of current camera mechanism by reading:
+
+- `src/map/mod.rs` lines 199-289, 524
+- `src/lib.rs` module structure
+- `src/main.rs` plugin registration
+
+### Stage B: Create Presentation Module Skeleton
+
+Create `src/presentation.rs` with:
+
+- Module-level documentation comment (`//!`)
+- Empty `PresentationPlugin` struct
+- `impl Plugin for PresentationPlugin` with empty `build()`
+- Feature gate: `#![cfg(feature = "render")]`
+
+### Stage C: Define CameraController Component
+
+In `src/presentation.rs`, define:
+
+    #[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
+    #[reflect(Component, Default)]
+    pub struct CameraController;
+
+This follows the pattern from `src/map/mod.rs` (e.g., `Collidable` line 114).
+
+### Stage D: Implement camera_setup System
+
+Create Startup system that:
+
+1. Spawns entity with `Camera2d`
+2. Adds `OrthographicProjection` (or relies on Required Components)
+3. Tags with `CameraController` marker
+4. Adds `Name::new("PresentationCamera")`
+
+Example:
+
+    fn camera_setup(mut commands: Commands) {
+        commands.spawn((
+            Camera2d,
+            OrthographicProjection::default_2d(),
+            CameraController,
+            Name::new("PresentationCamera"),
+        ));
+    }
+
+Register in plugin's `build()` method:
+
+    app.register_type::<CameraController>();
+    app.add_systems(Startup, camera_setup);
+
+### Stage E: Wire Module into Crate
+
+In `src/lib.rs`:
+
+- Add `#[cfg(feature = "render")]` gated module declaration
+- Add `#[cfg_attr(docsrs, doc(cfg(feature = "render")))]` for docs
+- Re-export `PresentationPlugin` and `CameraController`
+
+In `src/main.rs`:
+
+- Add `app.add_plugins(PresentationPlugin);` after `DbspPlugin`
+
+### Stage F: Remove Legacy Camera Bootstrap
+
+In `src/map/mod.rs`:
+
+1. Remove `MapBootstrapCamera` component (line 201)
+2. Remove `bootstrap_camera_if_missing()` system (lines 275-289)
+3. Remove `should_bootstrap_camera` field from `LilleMapSettings` (line 100)
+4. Remove `add_systems(Startup, bootstrap_camera_if_missing)` (line 524)
+5. Update `LilleMapSettings::default()` impl
+
+### Stage G: Add Unit Tests
+
+Create unit test in `src/presentation.rs` under `#[cfg(test)]` module:
+
+- Test `CameraController` derives (Default, Clone, etc.)
+
+### Stage H: Add Behavioural Test
+
+Create `tests/presentation_plugin_rspec.rs`:
+
+- Fixture: `PresentationPluginFixture` following `MapPluginFixtureBase` pattern
+- Scenario: "PresentationPlugin spawns camera with controller marker"
+- Assertions:
+  - Exactly one `Camera2d` entity exists after first tick
+  - That entity has `CameraController` component
+  - That entity has `OrthographicProjection` component
+
+### Stage I: Run Quality Gates
+
+Execute in order:
+
+    make check-fmt 2>&1 | tee /tmp/fmt.log
+    make lint 2>&1 | tee /tmp/lint.log
+    make test 2>&1 | tee /tmp/test.log
+
+Fix any failures before proceeding.
+
+### Stage J: Update Roadmap
+
+In `docs/lille-map-and-presentation-roadmap.md`, change line 113:
+
+    - [ ] Task 2.1.1
+
+To:
+
+    - [x] Task 2.1.1
+
+### Stage K: Commit
+
+Create atomic commit with message:
+
+    Add PresentationPlugin with CameraController marker
+
+    Introduce src/presentation.rs defining PresentationPlugin, which spawns
+    a Camera2d with CameraController marker component. This supersedes the
+    temporary bootstrap camera in LilleMapPlugin.
+
+    - Add CameraController component with Reflect derives
+    - Add camera_setup Startup system spawning presentation camera
+    - Remove MapBootstrapCamera and bootstrap_camera_if_missing from map module
+    - Remove should_bootstrap_camera setting from LilleMapSettings
+    - Add behavioural test verifying camera spawns with marker
+
+    Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+
+## Concrete Steps
+
+All commands run from `/data/leynos/Projects/lille`.
+
+### 1. Create presentation module
+
+Write `src/presentation.rs` with full implementation.
+
+### 2. Update lib.rs
+
+Add module declaration and re-exports.
+
+### 3. Update main.rs
+
+Add plugin registration.
+
+### 4. Modify map/mod.rs
+
+Remove legacy camera bootstrap code.
+
+### 5. Create behavioural test
+
+Write `tests/presentation_plugin_rspec.rs`.
+
+### 6. Run validation
+
+    make check-fmt 2>&1 | tee /tmp/fmt.log
+    make lint 2>&1 | tee /tmp/lint.log
+    make test 2>&1 | tee /tmp/test.log
+
+Expected: All pass with no warnings.
+
+### 7. Update roadmap
+
+Mark Task 2.1.1 as complete in roadmap.
+
+### 8. Commit
+
+    git add src/presentation.rs src/lib.rs src/main.rs src/map/mod.rs \
+        tests/presentation_plugin_rspec.rs docs/lille-map-and-presentation-roadmap.md
+    git commit -m "$(cat <<'EOF'
+    Add PresentationPlugin with CameraController marker
+
+    Introduce src/presentation.rs defining PresentationPlugin, which spawns
+    a Camera2d with CameraController marker component. This supersedes the
+    temporary bootstrap camera in LilleMapPlugin.
+
+    - Add CameraController component with Reflect derives
+    - Add camera_setup Startup system spawning presentation camera
+    - Remove MapBootstrapCamera and bootstrap_camera_if_missing from map module
+    - Remove should_bootstrap_camera setting from LilleMapSettings
+    - Add behavioural test verifying camera spawns with marker
+
+    Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+    EOF
+    )"
+
+## Validation and Acceptance
+
+### Quality Criteria
+
+- **Tests**: `make test` passes; new test
+  `presentation_plugin_rspec::presentation_plugin_spawns_camera_with_marker`
+  passes
+- **Lint**: `make lint` passes with zero warnings
+- **Format**: `make check-fmt` passes
+
+### Quality Method
+
+    make check-fmt && make lint && make test
+
+### Acceptance Behaviour
+
+After implementation:
+
+1. Run `cargo run --features "render map"` - game window appears with camera
+   rendering the isometric map
+2. Run `cargo test --features "render map" presentation_plugin` - behavioural
+   test passes
+3. Query in test: `world.query::<&CameraController>()` returns exactly one
+   entity
+4. That entity also has `Camera2d` and `OrthographicProjection` components
+
+## Idempotence and Recovery
+
+- If any step fails, fix the issue and re-run from Stage I (quality gates)
+- Module creation is idempotent (overwrites existing file)
+- Git commit is safe to amend if not yet pushed
+
+## Artifacts and Notes
+
+### Expected File Structure After Implementation
+
+    src/
+      presentation.rs    # NEW - ~80 lines
+      lib.rs             # MODIFIED - add module + exports
+      main.rs            # MODIFIED - add plugin
+      map/
+        mod.rs           # MODIFIED - remove bootstrap camera
+    tests/
+      presentation_plugin_rspec.rs  # NEW - ~80 lines
+
+### Component Definition Pattern (from src/map/mod.rs)
+
+    #[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
+    #[reflect(Component, Default)]
+    pub struct MarkerName;
+
+### Test Fixture Pattern (from tests/support/map_fixture.rs)
+
+    #[derive(Debug, Clone)]
+    struct PresentationPluginFixture {
+        base: MapPluginFixtureBase,
+    }
+
+    impl PresentationPluginFixture {
+        fn bootstrap() -> Self {
+            let mut app = App::new();
+            map_test_plugins::add_map_test_plugins(&mut app);
+            app.add_plugins(PresentationPlugin);
+            Self { base: MapPluginFixtureBase::new(app) }
+        }
+    }
+
+## Interfaces and Dependencies
+
+### New Public API
+
+In `src/presentation.rs`:
+
+    /// Marker component for the main presentation camera.
+    #[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
+    #[reflect(Component, Default)]
+    pub struct CameraController;
+
+    /// Plugin owning camera setup and presentation layer systems.
+    pub struct PresentationPlugin;
+
+    impl Plugin for PresentationPlugin {
+        fn build(&self, app: &mut App) { … }
+    }
+
+### Re-exports in `src/lib.rs`
+
+    #[cfg(feature = "render")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "render")))]
+    pub mod presentation;
+
+    #[cfg(feature = "render")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "render")))]
+    pub use presentation::{PresentationPlugin, CameraController};
+
+### Dependencies
+
+- `bevy::prelude::*` (existing)
+- No new crate dependencies
+
+______________________________________________________________________
+
+## Revision Notes
+
+- 2026-01-08: Initial draft created during planning phase.

--- a/docs/lille-map-and-presentation-roadmap.md
+++ b/docs/lille-map-and-presentation-roadmap.md
@@ -110,7 +110,7 @@ between simulation and presentation.
 What we will build: A dedicated `PresentationPlugin` that owns camera setup and
 input handling while remaining a passive observer of simulation state.
 
-- [ ] Task 2.1.1 — Create PresentationPlugin and camera marker
+- [x] Task 2.1.1 — Create PresentationPlugin and camera marker
   - Outcome: `src/presentation.rs` defines `PresentationPlugin`, spawns a
     `Camera2d` with a 2D `Projection`, and tags it with a `CameraController`
     component.

--- a/dylint.toml
+++ b/dylint.toml
@@ -1,0 +1,8 @@
+# Dylint configuration for custom lint rules.
+#
+# Build scripts require ambient filesystem authority since Cargo provides paths
+# rather than directory handles. The `cap_std` capability model cannot be
+# applied in this context.
+
+[no_std_fs_operations]
+excluded_crates = ["build_support"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ mod macros;
 pub mod map;
 pub mod numeric;
 pub mod physics;
+#[cfg(feature = "render")]
+#[cfg_attr(docsrs, doc(cfg(feature = "render")))]
+pub mod presentation;
 pub mod vector_math;
 pub mod world_handle;
 pub use constants::*;
@@ -50,6 +53,9 @@ pub use logging::init as init_logging;
 #[cfg_attr(docsrs, doc(cfg(feature = "map")))]
 pub use map::LilleMapPlugin;
 pub use physics::{applied_acceleration, apply_ground_friction};
+#[cfg(feature = "render")]
+#[cfg_attr(docsrs, doc(cfg(feature = "render")))]
+pub use presentation::{CameraController, PresentationPlugin};
 pub use vector_math::{vec_mag, vec_normalize};
 pub use world_handle::{init_world_handle_system, WorldHandle};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 use clap::Parser;
 #[cfg(feature = "map")]
 use lille::LilleMapPlugin;
-use lille::{init_logging, DbspPlugin};
+use lille::{init_logging, DbspPlugin, PresentationPlugin};
 
 /// A realtime strategy game
 #[derive(Parser)]
@@ -31,6 +31,7 @@ fn main() -> Result<()> {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.build().disable::<LogPlugin>());
     app.add_plugins(DbspPlugin);
+    app.add_plugins(PresentationPlugin);
 
     #[cfg(feature = "map")]
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ use bevy::prelude::*;
 use clap::Parser;
 #[cfg(feature = "map")]
 use lille::LilleMapPlugin;
-use lille::{init_logging, DbspPlugin, PresentationPlugin};
+use lille::PresentationPlugin;
+use lille::{init_logging, DbspPlugin};
 
 /// A realtime strategy game
 #[derive(Parser)]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -69,16 +69,21 @@ impl Plugin for PresentationPlugin {
     }
 }
 
-/// Spawns the presentation camera at startup.
+/// Spawns the presentation camera at startup if no camera exists.
 ///
 /// Creates a `Camera2d` entity with:
 /// - `CameraController` marker for presentation layer queries
 /// - `Name` component for inspector visibility
 ///
+/// If a `Camera2d` already exists (e.g. spawned by the host application), this
+/// system does nothing to avoid creating duplicate cameras.
+///
 /// Bevy's Required Components mechanism automatically inserts
 /// `OrthographicProjection` and other camera infrastructure.
-fn camera_setup(mut commands: Commands) {
-    commands.spawn((Camera2d, CameraController, Name::new("PresentationCamera")));
+fn camera_setup(mut commands: Commands, cameras: Query<&Camera2d>) {
+    if cameras.is_empty() {
+        commands.spawn((Camera2d, CameraController, Name::new("PresentationCamera")));
+    }
 }
 
 #[cfg(test)]

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -1,0 +1,110 @@
+//! Presentation layer plugin owning camera setup and visual rendering systems.
+//!
+//! `PresentationPlugin` manages the camera lifecycle and will eventually host
+//! systems for panning, zooming, and Y-sorting of isometric sprites. It remains
+//! a passive observer of simulation state: the DBSP circuit is the sole source
+//! of truth for inferred game behaviour.
+//!
+//! This module supersedes the temporary camera bootstrap in `LilleMapPlugin`.
+
+use bevy::prelude::*;
+
+/// Marker component for the main presentation camera.
+///
+/// Entities with this component are controlled by the presentation layer's
+/// camera systems. Currently there is exactly one such entity, spawned at
+/// startup. Future tasks (2.1.2, 2.1.3) will add panning and zoom controls
+/// that query for this marker.
+///
+/// # Examples
+///
+/// Querying for the presentation camera:
+///
+/// ```ignore
+/// fn camera_controls(
+///     mut query: Query<&mut Transform, With<CameraController>>,
+/// ) {
+///     for mut transform in &mut query {
+///         // Adjust camera position
+///     }
+/// }
+/// ```
+#[derive(Component, Reflect, Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[reflect(Component, Default)]
+pub struct CameraController;
+
+/// Plugin owning camera setup and presentation layer systems.
+///
+/// # Responsibilities
+///
+/// - Spawns the main `Camera2d` with `CameraController` marker at startup.
+/// - Registers `CameraController` for reflection.
+/// - Future: Hosts panning, zoom, and Y-sorting systems.
+///
+/// # Dependencies
+///
+/// This plugin has no hard dependencies but is typically added alongside
+/// `DbspPlugin` and `LilleMapPlugin` in the main application.
+///
+/// # Examples
+///
+/// Adding the plugin to an application:
+///
+/// ```ignore
+/// use bevy::prelude::*;
+/// use lille::PresentationPlugin;
+///
+/// App::new()
+///     .add_plugins(DefaultPlugins)
+///     .add_plugins(PresentationPlugin)
+///     .run();
+/// ```
+#[derive(Debug)]
+pub struct PresentationPlugin;
+
+impl Plugin for PresentationPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_type::<CameraController>();
+        app.add_systems(Startup, camera_setup);
+    }
+}
+
+/// Spawns the presentation camera at startup.
+///
+/// Creates a `Camera2d` entity with:
+/// - `CameraController` marker for presentation layer queries
+/// - `Name` component for inspector visibility
+///
+/// Bevy's Required Components mechanism automatically inserts
+/// `OrthographicProjection` and other camera infrastructure.
+fn camera_setup(mut commands: Commands) {
+    commands.spawn((Camera2d, CameraController, Name::new("PresentationCamera")));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn camera_controller_is_eq() {
+        // Verify Eq derive allows comparison.
+        let a = CameraController;
+        let b = CameraController;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn camera_controller_is_copy() {
+        let controller = CameraController;
+        let copied = controller;
+        // Both variables are valid because CameraController is Copy.
+        assert_eq!(controller, copied);
+    }
+
+    #[test]
+    fn camera_controller_debug_format() {
+        let controller = CameraController;
+        let debug_str = format!("{controller:?}");
+        assert_eq!(debug_str, "CameraController");
+    }
+}

--- a/tests/dbsp_spawn_sync_rspec.rs
+++ b/tests/dbsp_spawn_sync_rspec.rs
@@ -54,7 +54,6 @@ impl SpawnSyncFixture {
         app.insert_resource(LilleMapSettings {
             primary_map: MapAssetPath::from(CUSTOM_PROPERTIES_MAP_PATH),
             should_spawn_primary_map: true,
-            should_bootstrap_camera: false,
         });
         app.add_plugins(LilleMapPlugin);
 

--- a/tests/map_collision_rspec_block_attachment.rs
+++ b/tests/map_collision_rspec_block_attachment.rs
@@ -59,7 +59,6 @@ impl BlockAttachmentFixture {
         app.insert_resource(LilleMapSettings {
             primary_map: MapAssetPath::from(CUSTOM_PROPERTIES_MAP_PATH),
             should_spawn_primary_map: true,
-            should_bootstrap_camera: false,
         });
         app.add_plugins(LilleMapPlugin);
 

--- a/tests/map_lifecycle.rs
+++ b/tests/map_lifecycle.rs
@@ -34,7 +34,6 @@ fn test_app() -> App {
     app.insert_resource(LilleMapSettings {
         primary_map: MapAssetPath::from(PRIMARY_ISOMETRIC_MAP_PATH),
         should_spawn_primary_map: false,
-        should_bootstrap_camera: false,
     });
     app.add_plugins(LilleMapPlugin);
     app.finish();

--- a/tests/map_lifecycle_rspec.rs
+++ b/tests/map_lifecycle_rspec.rs
@@ -53,7 +53,6 @@ impl MapLifecycleFixture {
         app.insert_resource(LilleMapSettings {
             primary_map: MapAssetPath::from(TEST_MAP_PATH),
             should_spawn_primary_map: true,
-            should_bootstrap_camera: false,
         });
         app.add_plugins(LilleMapPlugin);
 

--- a/tests/map_plugin_invalid_path.rs
+++ b/tests/map_plugin_invalid_path.rs
@@ -25,7 +25,6 @@ fn invalid_primary_map_path_triggers_error(mut map_test_app: App) {
     map_test_app.insert_resource(LilleMapSettings {
         primary_map: MapAssetPath::from("/not-a-valid-asset-path.tmx"),
         should_spawn_primary_map: true,
-        should_bootstrap_camera: false,
     });
 
     map_test_app.add_plugins(LilleMapPlugin);

--- a/tests/map_plugin_missing_map.rs
+++ b/tests/map_plugin_missing_map.rs
@@ -29,7 +29,6 @@ fn missing_primary_map_triggers_error_and_map_does_not_load(mut map_test_app: Ap
     map_test_app.insert_resource(LilleMapSettings {
         primary_map: MapAssetPath::from("maps/does-not-exist.tmx"),
         should_spawn_primary_map: true,
-        should_bootstrap_camera: false,
     });
 
     map_test_app.add_plugins(LilleMapPlugin);

--- a/tests/map_plugin_rspec_custom_properties.rs
+++ b/tests/map_plugin_rspec_custom_properties.rs
@@ -60,7 +60,6 @@ impl MapCustomPropertiesFixture {
         app.insert_resource(LilleMapSettings {
             primary_map: MapAssetPath::from(CUSTOM_PROPERTIES_MAP_PATH),
             should_spawn_primary_map: true,
-            should_bootstrap_camera: false,
         });
         app.add_plugins(LilleMapPlugin);
 

--- a/tests/map_plugin_rspec_missing_map.rs
+++ b/tests/map_plugin_rspec_missing_map.rs
@@ -52,7 +52,6 @@ impl MapPluginFixture {
         app.insert_resource(LilleMapSettings {
             primary_map: MapAssetPath::from("maps/does-not-exist.tmx"),
             should_spawn_primary_map: true,
-            should_bootstrap_camera: false,
         });
 
         map_test_plugins::install_map_error_capture(&mut app);

--- a/tests/map_plugin_rspec_no_maps.rs
+++ b/tests/map_plugin_rspec_no_maps.rs
@@ -84,7 +84,6 @@ fn map_plugin_disabled_spawn_leaves_dbsp_authoritative_and_is_idempotent() {
     let fixture = MapPluginFixture::bootstrap_with_settings(LilleMapSettings {
         primary_map: MapAssetPath::from(PRIMARY_ISOMETRIC_MAP_PATH),
         should_spawn_primary_map: false,
-        should_bootstrap_camera: false,
     });
 
     run_serial(&rspec::given(

--- a/tests/map_plugin_spawn_disabled.rs
+++ b/tests/map_plugin_spawn_disabled.rs
@@ -25,7 +25,6 @@ fn does_not_spawn_primary_map_when_disabled() {
     app.insert_resource(LilleMapSettings {
         primary_map: MapAssetPath::from(PRIMARY_ISOMETRIC_MAP_PATH),
         should_spawn_primary_map: false,
-        should_bootstrap_camera: false,
     });
 
     app.add_plugins(LilleMapPlugin);

--- a/tests/map_spawn_actors_rspec.rs
+++ b/tests/map_spawn_actors_rspec.rs
@@ -64,7 +64,6 @@ impl SpawnActorsFixture {
         app.insert_resource(LilleMapSettings {
             primary_map: MapAssetPath::from(CUSTOM_PROPERTIES_MAP_PATH),
             should_spawn_primary_map: true,
-            should_bootstrap_camera: false,
         });
         app.add_plugins(LilleMapPlugin);
 

--- a/tests/presentation_plugin_rspec.rs
+++ b/tests/presentation_plugin_rspec.rs
@@ -1,0 +1,147 @@
+#![cfg_attr(
+    feature = "test-support",
+    doc = "Behavioural tests for `PresentationPlugin` using rust-rspec."
+)]
+#![cfg_attr(
+    not(feature = "test-support"),
+    doc = "Behavioural tests require `test-support`."
+)]
+#![cfg(feature = "test-support")]
+//! Behavioural test: `PresentationPlugin` spawns a camera with `CameraController` marker.
+//!
+//! This file contains a single test because it ticks the Bevy app under
+//! `--all-features`, which initialises a render device and uses process-global
+//! renderer state.
+
+#[path = "support/map_test_plugins.rs"]
+mod map_test_plugins;
+
+#[path = "support/thread_safe_app.rs"]
+mod thread_safe_app;
+
+#[path = "support/rspec_runner.rs"]
+mod rspec_runner;
+
+#[path = "support/map_fixture.rs"]
+mod map_fixture;
+
+use std::sync::MutexGuard;
+
+use bevy::prelude::*;
+use lille::presentation::CameraController;
+use lille::PresentationPlugin;
+use rspec::block::Context as Scenario;
+use rspec_runner::run_serial;
+use thread_safe_app::ThreadSafeApp;
+
+/// Fixture for presentation plugin behavioural tests.
+#[derive(Debug, Clone)]
+struct PresentationPluginFixture {
+    base: map_fixture::MapPluginFixtureBase,
+}
+
+impl PresentationPluginFixture {
+    /// Creates a test fixture with the `PresentationPlugin` installed.
+    fn bootstrap() -> Self {
+        let mut app = App::new();
+        map_test_plugins::add_map_test_plugins(&mut app);
+        app.add_plugins(PresentationPlugin);
+
+        Self {
+            base: map_fixture::MapPluginFixtureBase::new(app),
+        }
+    }
+
+    /// Locks the underlying `App` for direct inspection or mutation.
+    fn app_guard(&self) -> MutexGuard<'_, ThreadSafeApp> {
+        self.base.app_guard()
+    }
+
+    /// Advances the application by a single tick.
+    fn tick(&self) {
+        self.base.tick();
+    }
+
+    /// Returns the count of entities with `CameraController` component.
+    fn camera_controller_count(&self) -> usize {
+        let mut app = self.app_guard();
+        let world = app.world_mut();
+        let mut query = world.query::<&CameraController>();
+        query.iter(world).count()
+    }
+
+    /// Returns the count of entities with `Camera2d` component.
+    fn camera_2d_count(&self) -> usize {
+        let mut app = self.app_guard();
+        let world = app.world_mut();
+        let mut query = world.query::<&Camera2d>();
+        query.iter(world).count()
+    }
+
+    /// Returns true if the camera entity has both `CameraController` and `Camera2d`.
+    fn camera_is_properly_configured(&self) -> bool {
+        let mut app = self.app_guard();
+        let world = app.world_mut();
+        let mut query = world.query::<(&CameraController, &Camera2d)>();
+        query.iter(world).next().is_some()
+    }
+
+    /// Returns the name of the camera entity if it has one.
+    fn camera_name(&self) -> Option<String> {
+        let mut app = self.app_guard();
+        let world = app.world_mut();
+        let mut query = world.query::<(&CameraController, &Name)>();
+        query
+            .iter(world)
+            .next()
+            .map(|(_, name)| name.as_str().to_owned())
+    }
+}
+
+#[test]
+fn presentation_plugin_spawns_camera_with_controller_marker() {
+    let fixture = PresentationPluginFixture::bootstrap();
+
+    run_serial(&rspec::given(
+        "PresentationPlugin initialises camera setup",
+        fixture,
+        |scenario: &mut Scenario<PresentationPluginFixture>| {
+            scenario.when("the app ticks once", |ctx| {
+                ctx.before_each(|state| {
+                    state.tick();
+                });
+
+                ctx.then("exactly one Camera2d entity exists", |state| {
+                    assert_eq!(
+                        state.camera_2d_count(),
+                        1,
+                        "expected exactly one Camera2d entity"
+                    );
+                });
+
+                ctx.then("exactly one CameraController entity exists", |state| {
+                    assert_eq!(
+                        state.camera_controller_count(),
+                        1,
+                        "expected exactly one CameraController entity"
+                    );
+                });
+
+                ctx.then("the camera has both Camera2d and CameraController", |state| {
+                    assert!(
+                        state.camera_is_properly_configured(),
+                        "expected camera to have both Camera2d and CameraController"
+                    );
+                });
+
+                ctx.then("the camera is named PresentationCamera", |state| {
+                    assert_eq!(
+                        state.camera_name(),
+                        Some("PresentationCamera".to_owned()),
+                        "expected camera to be named PresentationCamera"
+                    );
+                });
+            });
+        },
+    ));
+}

--- a/tests/presentation_plugin_rspec.rs
+++ b/tests/presentation_plugin_rspec.rs
@@ -127,12 +127,15 @@ fn presentation_plugin_spawns_camera_with_controller_marker() {
                     );
                 });
 
-                ctx.then("the camera has both Camera2d and CameraController", |state| {
-                    assert!(
-                        state.camera_is_properly_configured(),
-                        "expected camera to have both Camera2d and CameraController"
-                    );
-                });
+                ctx.then(
+                    "the camera has both Camera2d and CameraController",
+                    |state| {
+                        assert!(
+                            state.camera_is_properly_configured(),
+                            "expected camera to have both Camera2d and CameraController"
+                        );
+                    },
+                );
 
                 ctx.then("the camera is named PresentationCamera", |state| {
                     assert_eq!(

--- a/tests/presentation_plugin_rspec.rs
+++ b/tests/presentation_plugin_rspec.rs
@@ -1,12 +1,12 @@
 #![cfg_attr(
-    feature = "test-support",
+    all(feature = "test-support", feature = "render"),
     doc = "Behavioural tests for `PresentationPlugin` using rust-rspec."
 )]
 #![cfg_attr(
-    not(feature = "test-support"),
-    doc = "Behavioural tests require `test-support`."
+    not(all(feature = "test-support", feature = "render")),
+    doc = "Behavioural tests require `test-support` and `render` features."
 )]
-#![cfg(feature = "test-support")]
+#![cfg(all(feature = "test-support", feature = "render"))]
 //! Behavioural test: `PresentationPlugin` spawns a camera with `CameraController` marker.
 //!
 //! This file contains a single test because it ticks the Bevy app under


### PR DESCRIPTION
Introduce src/presentation.rs defining PresentationPlugin, which spawns a Camera2d with CameraController marker component at Startup. This supersedes the temporary bootstrap camera in LilleMapPlugin, separating rendering concerns from map loading.

- Add CameraController component with Reflect, Default, Debug, Clone, Copy, PartialEq, and Eq derives
- Add camera_setup Startup system spawning presentation camera
- Remove MapBootstrapCamera and bootstrap_camera_if_missing from map module
- Remove should_bootstrap_camera setting from LilleMapSettings
- Update 11 test files to remove references to removed setting
- Add behavioural test verifying camera spawns with marker
- Mark Task 2.1.1 complete in roadmap

## Summary by Sourcery

Introduce a dedicated presentation layer plugin that owns camera setup and migrate camera bootstrapping responsibilities out of the map module.

New Features:
- Add PresentationPlugin and CameraController marker component to manage the main 2D presentation camera.
- Expose the presentation module and its types from the crate API under the render feature flag.

Enhancements:
- Remove legacy camera bootstrap logic and configuration from LilleMapPlugin and LilleMapSettings to decouple rendering from map loading.
- Refine roadmap and execution plan documentation to reflect the new presentation plugin and completed task.
- Tidy documentation formatting in the exec plan table for ID assignment.

Documentation:
- Add an execution plan document for creating the PresentationPlugin and camera marker, and mark the roadmap task as complete.

Tests:
- Add a behavioural test verifying that PresentationPlugin spawns a Camera2d entity tagged with the CameraController marker and expected name.
- Update existing map-related tests to remove references to the deprecated should_bootstrap_camera setting.