### PR TITLE
Implement camera panning controls (Task 2.1.2)

### DIFF
--- a/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
+++ b/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
@@ -372,7 +372,7 @@ Table: Edge cases and their handling in the camera pan system
 
 | Edge Case           | Handling                                       |
 | ------------------- | ---------------------------------------------- |
-| No camera entity    | `get_single_mut()` returns `Err`, early return |
+| No camera entity    | `single_mut()` returns `Err`, early return     |
 | No keys pressed     | `direction == Vec2::ZERO`, early return        |
 | Opposing keys (W+S) | Cancel to zero on that axis                    |
 | Diagonal movement   | `normalize()` prevents faster speed            |

--- a/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
+++ b/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
@@ -1,0 +1,342 @@
+# Task 2.1.2: Implement Camera Panning Controls
+
+This ExecPlan is a living document. The sections `Constraints`, `Tolerances`,
+`Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: COMPLETE
+
+This document must be maintained in accordance with
+`docs/documentation-style-guide.md` and the execplans skill.
+
+## Purpose / Big Picture
+
+Enable keyboard-based camera panning so users can navigate the isometric map
+using WASD or arrow keys. After this change, holding any of these keys pans the
+camera smoothly across the map at a configurable speed, independent of frame
+rate. This completes Task 2.1.2 of the Lille development roadmap.
+
+Observable outcome: Running the game and holding W moves the camera up, S moves
+down, A moves left, D moves right. Arrow keys provide equivalent behaviour.
+Diagonal movement (e.g., W+D) moves at the same speed as cardinal movement.
+
+## Constraints
+
+- **Read-only presentation layer**: The camera system must not modify any
+  gameplay or simulation components. It only reads input and modifies the
+  camera's `Transform`.
+- **DBSP is source of truth**: No inferred game behaviour may originate from
+  presentation code.
+- **Feature gating**: All presentation code must be gated behind
+  `#[cfg(feature = "render")]`.
+- **File size limit**: `src/presentation.rs` must not exceed 400 lines.
+- **No new dependencies**: Use only existing crate dependencies (Bevy 0.17.3).
+- **System ordering**: Camera panning must run after `apply_dbsp_outputs_system`
+  for semantic correctness.
+
+## Tolerances (Exception Triggers)
+
+- **Scope**: If implementation requires changes to more than 5 files, stop and
+  escalate.
+- **Lines of code**: If net additions exceed 200 lines (excluding tests), stop
+  and escalate.
+- **Test failures**: If tests fail after 3 fix attempts, stop and escalate.
+- **API changes**: If public API of existing modules must change, stop and
+  escalate.
+
+## Risks
+
+- **Risk**: `ButtonInput<KeyCode>` may not be initialised in headless test
+  environment. Severity: medium Likelihood: low Mitigation: The
+  `map_test_plugins::add_map_test_plugins` helper initialises `MinimalPlugins`
+  which includes input. Verify during testing.
+
+- **Risk**: `Time::delta_secs()` may return zero or very small values during
+  rapid test ticks. Severity: low Likelihood: medium Mitigation: Use
+  `max_delta_seconds` in `CameraSettings` set to 1.0 in tests; accept that
+  movement distances may be small but non-zero.
+
+- **Risk**: Diagonal movement faster than cardinal if direction not normalised.
+  Severity: medium Likelihood: high (if forgotten) Mitigation: Pure
+  `compute_pan_direction` function always normalises; unit tests verify
+  diagonal length equals 1.0.
+
+## Progress
+
+- [x] Add `CameraSettings` resource with `pan_speed` and `max_delta_seconds`
+- [x] Add `compute_pan_direction` pure function with unit tests
+- [x] Add `camera_pan_system` with system ordering
+- [x] Update `PresentationPlugin::build` to register resource and system
+- [x] Update `src/lib.rs` exports for new public items
+- [x] Create behavioural tests in `tests/camera_panning_rspec.rs`
+- [x] Run quality gates: `make check-fmt && make lint && make test`
+- [x] Update roadmap to mark Task 2.1.2 as done
+- [x] Commit with descriptive message
+
+## Surprises & Discoveries
+
+(To be updated during implementation)
+
+## Decision Log
+
+(To be updated during implementation)
+
+## Outcomes & Retrospective
+
+(To be completed after implementation)
+
+## Context and Orientation
+
+### Current State
+
+The `PresentationPlugin` in `src/presentation.rs` (116 lines) currently:
+
+- Defines `CameraController` marker component
+- Spawns `Camera2d` with `CameraController` marker at startup
+- Registers `CameraController` for reflection
+
+No input handling exists yet. The camera is stationary after spawn.
+
+### Key Files
+
+| File                                         | Purpose                                             |
+| -------------------------------------------- | --------------------------------------------------- |
+| `src/presentation.rs`                        | Core module to modify (add settings, system, tests) |
+| `src/lib.rs`                                 | Update exports for new public items                 |
+| `tests/presentation_plugin_rspec.rs`         | Reference for behavioural test structure            |
+| `tests/support/map_fixture.rs`               | Test fixture infrastructure to reuse                |
+| `docs/lille-map-and-presentation-roadmap.md` | Update completion status                            |
+
+### Bevy 0.17.3 API Reference
+
+- `Res<ButtonInput<KeyCode>>` for keyboard input
+- `Res<Time>` with `time.delta_secs()` for frame-rate independence
+- `Query<&mut Transform, With<CameraController>>` for camera access
+- Key codes: `KeyCode::KeyW`, `KeyCode::KeyS`, `KeyCode::KeyA`, `KeyCode::KeyD`,
+  `KeyCode::ArrowUp`, `KeyCode::ArrowDown`, `KeyCode::ArrowLeft`,
+  `KeyCode::ArrowRight`
+
+## Plan of Work
+
+### Stage A: Add CameraSettings Resource
+
+Add a `CameraSettings` resource following the `LilleMapSettings` pattern:
+
+    #[derive(Resource, Clone, Debug, PartialEq)]
+    pub struct CameraSettings {
+        /// Camera pan speed in world units per second.
+        pub pan_speed: f32,
+        /// Maximum delta time to prevent teleporting during frame hitches.
+        pub max_delta_seconds: f32,
+    }
+
+    impl Default for CameraSettings {
+        fn default() -> Self {
+            Self {
+                pan_speed: 500.0,
+                max_delta_seconds: 0.1,
+            }
+        }
+    }
+
+Location: `src/presentation.rs`, after `CameraController` definition.
+
+### Stage B: Add Pure Direction Function
+
+Add `compute_pan_direction` as a pure, testable function:
+
+    #[must_use]
+    pub fn compute_pan_direction(up: bool, down: bool, left: bool, right: bool) -> Vec2 {
+        let x = (right as i8 - left as i8) as f32;
+        let y = (up as i8 - down as i8) as f32;
+        let raw = Vec2::new(x, y);
+        if raw == Vec2::ZERO { Vec2::ZERO } else { raw.normalize() }
+    }
+
+Location: `src/presentation.rs`, after `CameraSettings`.
+
+Add unit tests using rstest parameterisation:
+
+- Cardinal directions return unit vectors
+- Diagonal directions return normalised vectors (length ≈ 1.0)
+- Opposing keys cancel out
+
+### Stage C: Add Camera Pan System
+
+Add `camera_pan_system`:
+
+    pub fn camera_pan_system(
+        keyboard: Res<ButtonInput<KeyCode>>,
+        time: Res<Time>,
+        settings: Res<CameraSettings>,
+        mut camera_query: Query<&mut Transform, With<CameraController>>,
+    ) {
+        let Ok(mut transform) = camera_query.get_single_mut() else { return };
+
+        let up = keyboard.pressed(KeyCode::KeyW) || keyboard.pressed(KeyCode::ArrowUp);
+        let down = keyboard.pressed(KeyCode::KeyS) || keyboard.pressed(KeyCode::ArrowDown);
+        let left = keyboard.pressed(KeyCode::KeyA) || keyboard.pressed(KeyCode::ArrowLeft);
+        let right = keyboard.pressed(KeyCode::KeyD) || keyboard.pressed(KeyCode::ArrowRight);
+
+        let direction = compute_pan_direction(up, down, left, right);
+        if direction == Vec2::ZERO { return }
+
+        let delta = time.delta_secs().min(settings.max_delta_seconds);
+        let velocity = direction * settings.pan_speed * delta;
+        transform.translation.x += velocity.x;
+        transform.translation.y += velocity.y;
+    }
+
+Location: `src/presentation.rs`, after `compute_pan_direction`.
+
+### Stage D: Update Plugin and Exports
+
+Modify `PresentationPlugin::build`:
+
+    fn build(&self, app: &mut App) {
+        app.register_type::<CameraController>();
+        app.init_resource::<CameraSettings>();
+        app.add_systems(Startup, camera_setup);
+        app.add_systems(
+            Update,
+            camera_pan_system.after(apply_dbsp_outputs_system),
+        );
+    }
+
+Update `src/lib.rs` to export new items:
+
+    #[cfg(feature = "render")]
+    pub use presentation::{
+        CameraController, CameraSettings, PresentationPlugin, compute_pan_direction
+    };
+
+### Stage E: Add Behavioural Tests
+
+Create `tests/camera_panning_rspec.rs` following the pattern in
+`tests/presentation_plugin_rspec.rs`:
+
+- Fixture extends `MapPluginFixtureBase`
+- Helper methods: `press_key`, `release_key`, `camera_position`
+- Test scenarios:
+  - W key moves camera up (positive Y)
+  - S key moves camera down (negative Y)
+  - A key moves camera left (negative X)
+  - D key moves camera right (positive X)
+  - Arrow keys equivalent to WASD
+  - Diagonal movement is normalised
+
+### Stage F: Quality Gates and Finalisation
+
+1. Run `make check-fmt && make lint && make test`
+2. Fix any issues
+3. Update `docs/lille-map-and-presentation-roadmap.md` to mark Task 2.1.2 done
+4. Commit with message describing the change
+
+## Concrete Steps
+
+All commands run from `/data/leynos/Projects/lille`.
+
+1. Edit `src/presentation.rs` to add `CameraSettings` resource
+2. Edit `src/presentation.rs` to add `compute_pan_direction` function
+3. Edit `src/presentation.rs` to add unit tests for direction function
+4. Run `make test` to verify unit tests pass
+5. Edit `src/presentation.rs` to add `camera_pan_system`
+6. Edit `src/presentation.rs` to update `PresentationPlugin::build`
+7. Edit `src/lib.rs` to export new items
+8. Create `tests/camera_panning_rspec.rs` with behavioural tests
+9. Run `make check-fmt && make lint && make test`
+10. Edit `docs/lille-map-and-presentation-roadmap.md` to mark task done
+11. Run `git add -A && git commit` with descriptive message
+
+Expected output from `make test`:
+
+    running X tests
+    test presentation::tests::… ok
+    …
+    test result: ok. X passed; 0 failed
+
+## Validation and Acceptance
+
+**Quality criteria:**
+
+- Tests: All existing tests pass plus new unit and behavioural tests
+- Lint: `make lint` passes with no warnings
+- Format: `make check-fmt` passes
+
+**Quality method:**
+
+    make check-fmt && make lint && make test
+
+**Manual verification:**
+
+Run the game with `cargo run --features render` and verify:
+
+1. Camera starts at origin (0, 0)
+2. Holding W pans up smoothly
+3. Holding S pans down smoothly
+4. Holding A pans left smoothly
+5. Holding D pans right smoothly
+6. Arrow keys work identically to WASD
+7. Diagonal movement (W+D) moves at same speed as single key
+8. Releasing keys stops camera movement
+
+## Idempotence and Recovery
+
+All steps are idempotent:
+
+- Editing files can be repeated safely
+- Tests can be run repeatedly
+- Commits can be amended if not pushed
+
+If a step fails, fix the issue and retry from that step.
+
+## Artifacts and Notes
+
+### Unit Test Cases
+
+    #[rstest]
+    #[case::no_keys(false, false, false, false, Vec2::ZERO)]
+    #[case::up_only(true, false, false, false, Vec2::new(0.0, 1.0))]
+    #[case::down_only(false, true, false, false, Vec2::new(0.0, -1.0))]
+    #[case::left_only(false, false, true, false, Vec2::new(-1.0, 0.0))]
+    #[case::right_only(false, false, false, true, Vec2::new(1.0, 0.0))]
+    fn pan_direction_cardinal(…) { … }
+
+    #[rstest]
+    #[case::up_right(true, false, false, true)]
+    #[case::up_left(true, false, true, false)]
+    fn pan_direction_diagonal_is_normalised(…) { … }
+
+### Edge Cases Handled
+
+| Edge Case           | Handling                                       |
+| ------------------- | ---------------------------------------------- |
+| No camera entity    | `get_single_mut()` returns `Err`, early return |
+| No keys pressed     | `direction == Vec2::ZERO`, early return        |
+| Opposing keys (W+S) | Cancel to zero on that axis                    |
+| Diagonal movement   | `normalize()` prevents faster speed            |
+| Frame hitch         | Clamped to `max_delta_seconds`                 |
+
+## Interfaces and Dependencies
+
+### New Public Items in `lille::presentation`
+
+    pub struct CameraSettings {
+        pub pan_speed: f32,
+        pub max_delta_seconds: f32,
+    }
+
+    pub fn compute_pan_direction(up: bool, down: bool, left: bool, right: bool) -> Vec2
+
+    pub fn camera_pan_system(
+        keyboard: Res<ButtonInput<KeyCode>>,
+        time: Res<Time>,
+        settings: Res<CameraSettings>,
+        mut camera_query: Query<&mut Transform, With<CameraController>>,
+    )
+
+### Dependencies
+
+- `bevy::prelude::*` (existing)
+- `bevy::input::ButtonInput` (existing via prelude)
+- `crate::apply_dbsp_outputs_system` (for system ordering)

--- a/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
+++ b/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
@@ -76,15 +76,34 @@ Diagonal movement (e.g., W+D) moves at the same speed as cardinal movement.
 
 ## Surprises & Discoveries
 
-(To be updated during implementation)
+No surprises encountered. The implementation proceeded as planned with all APIs
+behaving as documented.
 
 ## Decision Log
 
-(To be updated during implementation)
+- **Decision**: Use `PanInput` struct instead of four boolean parameters.
+  Rationale: Improves readability and allows future extension (e.g., analog
+  input). Date: Implementation phase.
+
+- **Decision**: Guard against non-positive `max_delta_seconds` by clamping to
+  `f32::EPSILON`. Rationale: Prevents division by zero or negative delta values
+  that could cause unexpected camera behaviour. Date: PR review feedback.
+
+- **Decision**: Use match-based `axis` helper function for direction
+  calculation. Rationale: More explicit than arithmetic approach, easier to
+  verify correctness. Date: PR review feedback.
 
 ## Outcomes & Retrospective
 
-(To be completed after implementation)
+Implementation completed successfully. All progress items achieved:
+
+- Camera panning works with WASD and arrow keys
+- Diagonal movement normalized to prevent faster diagonal speed
+- Frame-rate independent via delta time clamping
+- Behavioural and unit tests provide coverage for edge cases
+
+Lessons learned: The pure function approach (`compute_pan_direction`) made unit
+testing straightforward and kept the system function focused on I/O.
 
 ## Context and Orientation
 
@@ -268,7 +287,7 @@ Create `tests/camera_panning_rspec.rs` following the pattern in
 
 ## Concrete Steps
 
-All commands run from `/data/leynos/Projects/lille`.
+All commands run from the repository root.
 
 1. Edit `src/presentation.rs` to add `CameraSettings` resource
 2. Edit `src/presentation.rs` to add `compute_pan_direction` function

--- a/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
+++ b/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
@@ -370,13 +370,13 @@ fn pan_direction_diagonal_is_normalized(…) { … }
 
 Table: Edge cases and their handling in the camera pan system
 
-| Edge Case           | Handling                                       |
-| ------------------- | ---------------------------------------------- |
-| No camera entity    | `single_mut()` returns `Err`, early return     |
-| No keys pressed     | `direction == Vec2::ZERO`, early return        |
-| Opposing keys (W+S) | Cancel to zero on that axis                    |
-| Diagonal movement   | `normalize()` prevents faster speed            |
-| Frame hitch         | Clamped to `max_delta_seconds`                 |
+| Edge Case           | Handling                                   |
+| ------------------- | ------------------------------------------ |
+| No camera entity    | `single_mut()` returns `Err`, early return |
+| No keys pressed     | `direction == Vec2::ZERO`, early return    |
+| Opposing keys (W+S) | Cancel to zero on that axis                |
+| Diagonal movement   | `normalize()` prevents faster speed        |
+| Frame hitch         | Clamped to `max_delta_seconds`             |
 
 ## Interfaces and Dependencies
 

--- a/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
+++ b/docs/execplans/pres-task-task-2-1-2-camera-panning-controls.md
@@ -246,7 +246,7 @@ Create `tests/camera_panning_rspec.rs` following the pattern in
   - Arrow keys equivalent to WASD
   - Diagonal movement is normalized
 
-### Stage F: Quality Gates and Finalisation
+### Stage F: Quality Gates and Finalization
 
 1. Run `make check-fmt && make lint && make test`
 2. Fix any issues

--- a/docs/lille-map-and-presentation-roadmap.md
+++ b/docs/lille-map-and-presentation-roadmap.md
@@ -117,7 +117,7 @@ input handling while remaining a passive observer of simulation state.
   - Completion criteria: The application renders through the presentation
     camera and legacy camera setup code is removed from map systems.
   - Dependencies: Task 1.1.1.
-- [ ] Task 2.1.2 — Implement camera panning controls
+- [x] Task 2.1.2 — Implement camera panning controls
   - Outcome: An update system reads keyboard input to move the camera based on
     configurable speed scaled by `Time.delta_seconds()`.
   - Completion criteria: Holding WASD or arrow keys pans smoothly across the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,10 @@ pub use map::LilleMapPlugin;
 pub use physics::{applied_acceleration, apply_ground_friction};
 #[cfg(feature = "render")]
 #[cfg_attr(docsrs, doc(cfg(feature = "render")))]
-pub use presentation::{CameraController, PresentationPlugin};
+pub use presentation::{
+    camera_pan_system, compute_pan_direction, CameraController, CameraSettings, PanInput,
+    PresentationPlugin,
+};
 pub use vector_math::{vec_mag, vec_normalize};
 pub use world_handle::{init_world_handle_system, WorldHandle};
 

--- a/src/presentation.rs
+++ b/src/presentation.rs
@@ -9,12 +9,14 @@
 
 use bevy::prelude::*;
 
+use crate::apply_dbsp_outputs_system;
+
 /// Marker component for the main presentation camera.
 ///
 /// Entities with this component are controlled by the presentation layer's
 /// camera systems. Currently there is exactly one such entity, spawned at
-/// startup. Future tasks (2.1.2, 2.1.3) will add panning and zoom controls
-/// that query for this marker.
+/// startup. The `camera_pan_system` queries for this marker to apply
+/// keyboard-based panning.
 ///
 /// # Examples
 ///
@@ -33,13 +35,165 @@ use bevy::prelude::*;
 #[reflect(Component, Default)]
 pub struct CameraController;
 
+/// Runtime configuration for camera panning behaviour.
+///
+/// Controls the speed at which the camera pans when using keyboard input
+/// (WASD or arrow keys). The `max_delta_seconds` field prevents the camera
+/// from teleporting during frame hitches by clamping the delta time.
+///
+/// # Examples
+///
+/// Customising camera speed:
+///
+/// ```ignore
+/// use bevy::prelude::*;
+/// use lille::presentation::CameraSettings;
+///
+/// let mut app = App::new();
+/// app.insert_resource(CameraSettings {
+///     pan_speed: 800.0,
+///     max_delta_seconds: 0.1,
+/// });
+/// ```
+#[derive(Resource, Clone, Debug, PartialEq)]
+pub struct CameraSettings {
+    /// Camera pan speed in world units per second.
+    ///
+    /// A higher value makes the camera move faster across the map.
+    /// Typical values range from 200.0 (slow) to 1000.0 (fast).
+    pub pan_speed: f32,
+
+    /// Maximum delta time to use for movement calculations.
+    ///
+    /// Clamps large frame hitches to prevent the camera jumping
+    /// extreme distances during lag spikes.
+    pub max_delta_seconds: f32,
+}
+
+impl Default for CameraSettings {
+    fn default() -> Self {
+        Self {
+            pan_speed: 500.0,
+            max_delta_seconds: 0.1,
+        }
+    }
+}
+
+/// Directional key states for camera panning.
+///
+/// Captures the pressed state of movement keys (WASD or arrow keys) to
+/// compute a pan direction vector.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "This struct represents the pressed state of exactly four directional keys."
+)]
+pub struct PanInput {
+    /// Whether an "up" key (W or `ArrowUp`) is pressed.
+    pub up: bool,
+    /// Whether a "down" key (S or `ArrowDown`) is pressed.
+    pub down: bool,
+    /// Whether a "left" key (A or `ArrowLeft`) is pressed.
+    pub left: bool,
+    /// Whether a "right" key (D or `ArrowRight`) is pressed.
+    pub right: bool,
+}
+
+/// Computes a normalised pan direction from the given key states.
+///
+/// Returns `Vec2::ZERO` if no movement keys are pressed.
+/// Diagonal movement is normalised to prevent faster movement when
+/// multiple keys are held simultaneously.
+///
+/// # Examples
+///
+/// ```
+/// use bevy::math::Vec2;
+/// use lille::presentation::{compute_pan_direction, PanInput};
+///
+/// // Single key: unit vector
+/// let input = PanInput { up: true, ..Default::default() };
+/// let dir = compute_pan_direction(input);
+/// assert!((dir.y - 1.0).abs() < f32::EPSILON);
+///
+/// // Diagonal: normalised
+/// let input = PanInput { up: true, right: true, ..Default::default() };
+/// let diag = compute_pan_direction(input);
+/// assert!((diag.length() - 1.0).abs() < 0.001);
+/// ```
+#[must_use]
+pub fn compute_pan_direction(input: PanInput) -> Vec2 {
+    let x = f32::from(i8::from(input.right) - i8::from(input.left));
+    let y = f32::from(i8::from(input.up) - i8::from(input.down));
+    let raw = Vec2::new(x, y);
+    if raw == Vec2::ZERO {
+        Vec2::ZERO
+    } else {
+        raw.normalize()
+    }
+}
+
+/// Updates camera position based on keyboard input.
+///
+/// Reads WASD and arrow keys, computes a normalised direction, and moves
+/// the camera at the configured speed scaled by `Time.delta_secs()`.
+/// Large delta times are clamped to `CameraSettings.max_delta_seconds`
+/// to prevent extreme jumps during frame hitches.
+///
+/// This system is ordered to run after `apply_dbsp_outputs_system` to
+/// ensure the camera observes the latest entity positions before panning.
+///
+/// # Examples
+///
+/// The system is added automatically by `PresentationPlugin`. To add it
+/// manually with custom ordering:
+///
+/// ```ignore
+/// app.add_systems(Update, camera_pan_system.after(apply_dbsp_outputs_system));
+/// ```
+#[expect(
+    clippy::needless_pass_by_value,
+    reason = "Bevy systems require parameters by value, not by reference."
+)]
+pub fn camera_pan_system(
+    keyboard: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+    settings: Res<CameraSettings>,
+    mut camera_query: Query<&mut Transform, With<CameraController>>,
+) {
+    // Defensive: skip if no camera exists (e.g., during initialisation).
+    let Ok(mut transform) = camera_query.single_mut() else {
+        return;
+    };
+
+    let input = PanInput {
+        up: keyboard.pressed(KeyCode::KeyW) || keyboard.pressed(KeyCode::ArrowUp),
+        down: keyboard.pressed(KeyCode::KeyS) || keyboard.pressed(KeyCode::ArrowDown),
+        left: keyboard.pressed(KeyCode::KeyA) || keyboard.pressed(KeyCode::ArrowLeft),
+        right: keyboard.pressed(KeyCode::KeyD) || keyboard.pressed(KeyCode::ArrowRight),
+    };
+
+    let direction = compute_pan_direction(input);
+    if direction == Vec2::ZERO {
+        return;
+    }
+
+    // Clamp delta to prevent teleporting during frame hitches.
+    let delta = time.delta_secs().min(settings.max_delta_seconds);
+    let velocity = direction * settings.pan_speed * delta;
+
+    transform.translation.x += velocity.x;
+    transform.translation.y += velocity.y;
+}
+
 /// Plugin owning camera setup and presentation layer systems.
 ///
 /// # Responsibilities
 ///
 /// - Spawns the main `Camera2d` with `CameraController` marker at startup.
 /// - Registers `CameraController` for reflection.
-/// - Future: Hosts panning, zoom, and Y-sorting systems.
+/// - Hosts the `camera_pan_system` for keyboard-based camera panning.
+/// - Future: Hosts zoom and Y-sorting systems.
 ///
 /// # Dependencies
 ///
@@ -65,7 +219,9 @@ pub struct PresentationPlugin;
 impl Plugin for PresentationPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<CameraController>();
+        app.init_resource::<CameraSettings>();
         app.add_systems(Startup, camera_setup);
+        app.add_systems(Update, camera_pan_system.after(apply_dbsp_outputs_system));
     }
 }
 
@@ -89,6 +245,7 @@ fn camera_setup(mut commands: Commands, cameras: Query<&Camera2d>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn camera_controller_is_eq() {
@@ -111,5 +268,98 @@ mod tests {
         let controller = CameraController;
         let debug_str = format!("{controller:?}");
         assert_eq!(debug_str, "CameraController");
+    }
+
+    // --- CameraSettings tests ---
+
+    #[test]
+    fn camera_settings_default_values_are_sensible() {
+        let settings = CameraSettings::default();
+        assert!(settings.pan_speed > 0.0, "pan_speed should be positive");
+        assert!(
+            settings.max_delta_seconds > 0.0,
+            "max_delta_seconds should be positive"
+        );
+        assert!(
+            settings.max_delta_seconds <= 0.5,
+            "max_delta_seconds should be reasonable"
+        );
+    }
+
+    #[test]
+    fn camera_settings_is_clone() {
+        let settings = CameraSettings::default();
+        let cloned = settings.clone();
+        assert_eq!(settings, cloned);
+    }
+
+    // --- compute_pan_direction tests ---
+
+    #[expect(
+        clippy::fn_params_excessive_bools,
+        reason = "Test helper that mirrors the PanInput struct fields."
+    )]
+    fn pan_input(up: bool, down: bool, left: bool, right: bool) -> PanInput {
+        PanInput {
+            up,
+            down,
+            left,
+            right,
+        }
+    }
+
+    #[rstest]
+    #[case::no_keys(PanInput::default(), Vec2::ZERO)]
+    #[case::up_only(PanInput { up: true, ..Default::default() }, Vec2::new(0.0, 1.0))]
+    #[case::down_only(PanInput { down: true, ..Default::default() }, Vec2::new(0.0, -1.0))]
+    #[case::left_only(PanInput { left: true, ..Default::default() }, Vec2::new(-1.0, 0.0))]
+    #[case::right_only(PanInput { right: true, ..Default::default() }, Vec2::new(1.0, 0.0))]
+    fn pan_direction_cardinal(#[case] input: PanInput, #[case] expected: Vec2) {
+        let actual = compute_pan_direction(input);
+        assert!(
+            (actual - expected).length() < 0.001,
+            "expected {expected:?}, got {actual:?}"
+        );
+    }
+
+    #[rstest]
+    #[case::up_right(PanInput { up: true, right: true, ..Default::default() })]
+    #[case::up_left(PanInput { up: true, left: true, ..Default::default() })]
+    #[case::down_right(PanInput { down: true, right: true, ..Default::default() })]
+    #[case::down_left(PanInput { down: true, left: true, ..Default::default() })]
+    fn pan_direction_diagonal_is_normalised(#[case] input: PanInput) {
+        let dir = compute_pan_direction(input);
+        assert!(
+            (dir.length() - 1.0).abs() < 0.001,
+            "diagonal should be normalised, got length {}",
+            dir.length()
+        );
+    }
+
+    #[rstest]
+    #[case::up_and_down(pan_input(true, true, false, false), Vec2::ZERO)]
+    #[case::left_and_right(pan_input(false, false, true, true), Vec2::ZERO)]
+    #[case::all_keys(pan_input(true, true, true, true), Vec2::ZERO)]
+    fn pan_direction_opposing_keys_cancel(#[case] input: PanInput, #[case] expected: Vec2) {
+        let dir = compute_pan_direction(input);
+        assert_eq!(dir, expected, "opposing keys should cancel to zero");
+    }
+
+    #[rstest]
+    #[case::up_left_and_right(pan_input(true, false, true, true))]
+    #[case::down_left_and_right(pan_input(false, true, true, true))]
+    fn pan_direction_partial_cancellation(#[case] input: PanInput) {
+        let dir = compute_pan_direction(input);
+        // When left and right cancel, only vertical movement remains.
+        assert!(
+            dir.x.abs() < 0.001,
+            "horizontal should cancel, got x={}",
+            dir.x
+        );
+        assert!(
+            dir.y.abs() > 0.001,
+            "vertical should remain, got y={}",
+            dir.y
+        );
     }
 }

--- a/tests/camera_panning_rspec.rs
+++ b/tests/camera_panning_rspec.rs
@@ -132,6 +132,7 @@ struct KeyMovementDesc {
 }
 
 /// Helper to test that pressing a key moves the camera in the expected direction.
+#[expect(clippy::expect_used, reason = "test assertions use expect for clarity")]
 fn test_key_movement<F>(
     scenario: &mut Scenario<CameraPanFixture>,
     key: KeyCode,
@@ -152,15 +153,14 @@ fn test_key_movement<F>(
         let check = assertion.clone();
         let error_msg = desc.error_msg;
         ctx.then(desc.then_desc, move |state| {
-            let pos = state
-                .camera_position()
-                .unwrap_or_else(|| panic!("camera should exist"));
+            let pos = state.camera_position().expect("camera should exist");
             assert!(check(&pos), "{error_msg}, got {pos:?}");
         });
     });
 }
 
 /// Helper to test that no movement occurs when no keys are pressed.
+#[expect(clippy::expect_used, reason = "test assertions use expect for clarity")]
 fn test_no_movement(scenario: &mut Scenario<CameraPanFixture>) {
     scenario.when("no movement keys are pressed", |ctx| {
         ctx.before_each(|state| {
@@ -171,9 +171,7 @@ fn test_no_movement(scenario: &mut Scenario<CameraPanFixture>) {
         });
 
         ctx.then("camera position remains unchanged", |state| {
-            let pos = state
-                .camera_position()
-                .unwrap_or_else(|| panic!("camera should exist"));
+            let pos = state.camera_position().expect("camera should exist");
             assert!(
                 pos.x.abs() < 0.001 && pos.y.abs() < 0.001,
                 "camera should not move when no keys pressed, got {pos:?}"

--- a/tests/camera_panning_rspec.rs
+++ b/tests/camera_panning_rspec.rs
@@ -10,7 +10,7 @@
 //! Behavioural test: Camera panning responds to WASD and arrow keys.
 //!
 //! These tests verify that keyboard input correctly moves the camera in the
-//! expected direction and that diagonal movement is normalised.
+//! expected direction and that diagonal movement is normalized.
 
 #[path = "support/map_test_plugins.rs"]
 mod map_test_plugins;
@@ -210,6 +210,25 @@ fn camera_pans_with_wasd_keys() {
                 |pos| pos.x > 0.0,
                 "camera X should increase when D pressed",
             );
+
+            scenario.when("no movement keys are pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    // No keys pressed
+                    state.tick();
+                });
+
+                ctx.then("camera position remains unchanged", |state| {
+                    let pos = state
+                        .camera_position()
+                        .unwrap_or_else(|| panic!("camera should exist"));
+                    assert!(
+                        pos.x.abs() < 0.001 && pos.y.abs() < 0.001,
+                        "camera should not move when no keys pressed, got {pos:?}"
+                    );
+                });
+            });
         },
     ));
 }
@@ -222,76 +241,44 @@ fn camera_pans_with_arrow_keys() {
         "PresentationPlugin camera responds to arrow key input",
         fixture,
         |scenario: &mut Scenario<CameraPanFixture>| {
-            scenario.when("ArrowUp is pressed", |ctx| {
-                ctx.before_each(|state| {
-                    state.reset_state();
-                    state.tick();
-                    state.press_key(KeyCode::ArrowUp);
-                    state.tick();
-                });
-
-                ctx.then("camera moves up", |state| {
-                    let pos = state.camera_position().expect("camera should exist");
-                    assert!(pos.y > 0.0, "ArrowUp should move camera up, got {pos:?}");
-                });
-            });
-
-            scenario.when("ArrowDown is pressed", |ctx| {
-                ctx.before_each(|state| {
-                    state.reset_state();
-                    state.tick();
-                    state.press_key(KeyCode::ArrowDown);
-                    state.tick();
-                });
-
-                ctx.then("camera moves down", |state| {
-                    let pos = state.camera_position().expect("camera should exist");
-                    assert!(
-                        pos.y < 0.0,
-                        "ArrowDown should move camera down, got {pos:?}"
-                    );
-                });
-            });
-
-            scenario.when("ArrowLeft is pressed", |ctx| {
-                ctx.before_each(|state| {
-                    state.reset_state();
-                    state.tick();
-                    state.press_key(KeyCode::ArrowLeft);
-                    state.tick();
-                });
-
-                ctx.then("camera moves left", |state| {
-                    let pos = state.camera_position().expect("camera should exist");
-                    assert!(
-                        pos.x < 0.0,
-                        "ArrowLeft should move camera left, got {pos:?}"
-                    );
-                });
-            });
-
-            scenario.when("ArrowRight is pressed", |ctx| {
-                ctx.before_each(|state| {
-                    state.reset_state();
-                    state.tick();
-                    state.press_key(KeyCode::ArrowRight);
-                    state.tick();
-                });
-
-                ctx.then("camera moves right", |state| {
-                    let pos = state.camera_position().expect("camera should exist");
-                    assert!(
-                        pos.x > 0.0,
-                        "ArrowRight should move camera right, got {pos:?}"
-                    );
-                });
-            });
+            test_key_movement(
+                scenario,
+                KeyCode::ArrowUp,
+                "ArrowUp is pressed",
+                "camera moves up",
+                |pos| pos.y > 0.0,
+                "ArrowUp should move camera up",
+            );
+            test_key_movement(
+                scenario,
+                KeyCode::ArrowDown,
+                "ArrowDown is pressed",
+                "camera moves down",
+                |pos| pos.y < 0.0,
+                "ArrowDown should move camera down",
+            );
+            test_key_movement(
+                scenario,
+                KeyCode::ArrowLeft,
+                "ArrowLeft is pressed",
+                "camera moves left",
+                |pos| pos.x < 0.0,
+                "ArrowLeft should move camera left",
+            );
+            test_key_movement(
+                scenario,
+                KeyCode::ArrowRight,
+                "ArrowRight is pressed",
+                "camera moves right",
+                |pos| pos.x > 0.0,
+                "ArrowRight should move camera right",
+            );
         },
     ));
 }
 
 #[test]
-fn camera_diagonal_movement_is_normalised() {
+fn camera_diagonal_movement_is_normalized() {
     let fixture = CameraPanFixture::bootstrap();
 
     run_serial(&rspec::given(
@@ -307,7 +294,7 @@ fn camera_diagonal_movement_is_normalised() {
                     state.tick();
                 });
 
-                ctx.then("camera moves diagonally at normalised speed", |state| {
+                ctx.then("camera moves diagonally at normalized speed", |state| {
                     let pos = state.camera_position().expect("camera should exist");
                     // Diagonal movement should be roughly sqrt(2)/2 in each axis,
                     // not 1.0 in each axis.
@@ -315,7 +302,7 @@ fn camera_diagonal_movement_is_normalised() {
                         pos.x > 0.0 && pos.y > 0.0,
                         "diagonal should move in both positive axes, got {pos:?}"
                     );
-                    // With normalisation, X and Y components should be roughly equal.
+                    // With normalization, X and Y components should be roughly equal.
                     let ratio = pos.x / pos.y;
                     assert!(
                         (ratio - 1.0).abs() < 0.1,

--- a/tests/camera_panning_rspec.rs
+++ b/tests/camera_panning_rspec.rs
@@ -167,7 +167,7 @@ fn camera_pans_with_wasd_keys() {
         |scenario: &mut Scenario<CameraPanFixture>| {
             scenario.when("the app initialises", |ctx| {
                 ctx.before_each(|state| {
-                    state.tick(); // Finalise plugins and spawn camera
+                    state.tick(); // Finalize plugins and spawn camera
                 });
 
                 ctx.then("camera starts at origin", |state| {

--- a/tests/camera_panning_rspec.rs
+++ b/tests/camera_panning_rspec.rs
@@ -103,11 +103,12 @@ impl CameraPanFixture {
             keyboard.release(KeyCode::ArrowRight);
             keyboard.clear();
         }
-        // Reset camera to origin
+        // Reset camera X/Y to origin, preserving Z (camera depth).
         let world = app.world_mut();
         let mut query = world.query::<(&mut Transform, &CameraController)>();
         for (mut transform, _) in query.iter_mut(world) {
-            transform.translation = Vec3::ZERO;
+            transform.translation.x = 0.0;
+            transform.translation.y = 0.0;
         }
     }
 

--- a/tests/camera_panning_rspec.rs
+++ b/tests/camera_panning_rspec.rs
@@ -1,0 +1,334 @@
+#![cfg_attr(
+    all(feature = "test-support", feature = "render"),
+    doc = "Behavioural tests for camera panning using rust-rspec."
+)]
+#![cfg_attr(
+    not(all(feature = "test-support", feature = "render")),
+    doc = "Behavioural tests require `test-support` and `render` features."
+)]
+#![cfg(all(feature = "test-support", feature = "render"))]
+//! Behavioural test: Camera panning responds to WASD and arrow keys.
+//!
+//! These tests verify that keyboard input correctly moves the camera in the
+//! expected direction and that diagonal movement is normalised.
+
+#[path = "support/map_test_plugins.rs"]
+mod map_test_plugins;
+
+#[path = "support/thread_safe_app.rs"]
+mod thread_safe_app;
+
+#[path = "support/rspec_runner.rs"]
+mod rspec_runner;
+
+#[path = "support/map_fixture.rs"]
+mod map_fixture;
+
+use std::sync::MutexGuard;
+
+use bevy::input::ButtonInput;
+use bevy::prelude::*;
+use lille::presentation::{CameraController, CameraSettings};
+use lille::PresentationPlugin;
+use rspec::block::Context as Scenario;
+use rspec_runner::run_serial;
+use thread_safe_app::ThreadSafeApp;
+
+/// Fixed pan speed for deterministic tests.
+const TEST_PAN_SPEED: f32 = 100.0;
+
+/// Fixture for camera panning behavioural tests.
+#[derive(Debug, Clone)]
+struct CameraPanFixture {
+    base: map_fixture::MapPluginFixtureBase,
+}
+
+impl CameraPanFixture {
+    /// Creates a test fixture with the `PresentationPlugin` installed.
+    fn bootstrap() -> Self {
+        let mut app = App::new();
+        map_test_plugins::add_map_test_plugins(&mut app);
+
+        // Insert custom settings before plugin to override defaults.
+        app.insert_resource(CameraSettings {
+            pan_speed: TEST_PAN_SPEED,
+            max_delta_seconds: 1.0, // Allow large deltas in tests
+        });
+
+        app.add_plugins(PresentationPlugin);
+
+        Self {
+            base: map_fixture::MapPluginFixtureBase::new(app),
+        }
+    }
+
+    /// Locks the underlying `App` for direct inspection or mutation.
+    fn app_guard(&self) -> MutexGuard<'_, ThreadSafeApp> {
+        self.base.app_guard()
+    }
+
+    /// Advances the application by a single tick.
+    fn tick(&self) {
+        self.base.tick();
+    }
+
+    /// Simulates pressing a key.
+    fn press_key(&self, key: KeyCode) {
+        let mut app = self.app_guard();
+        let mut keyboard = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+        keyboard.press(key);
+    }
+
+    /// Simulates releasing a key.
+    #[expect(dead_code, reason = "May be used in future tests")]
+    fn release_key(&self, key: KeyCode) {
+        let mut app = self.app_guard();
+        let mut keyboard = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+        keyboard.release(key);
+    }
+
+    /// Clears all keyboard input and resets camera to origin.
+    fn reset_state(&self) {
+        let mut app = self.app_guard();
+        // Release all movement keys explicitly
+        {
+            let mut keyboard = app.world_mut().resource_mut::<ButtonInput<KeyCode>>();
+            keyboard.release(KeyCode::KeyW);
+            keyboard.release(KeyCode::KeyA);
+            keyboard.release(KeyCode::KeyS);
+            keyboard.release(KeyCode::KeyD);
+            keyboard.release(KeyCode::ArrowUp);
+            keyboard.release(KeyCode::ArrowDown);
+            keyboard.release(KeyCode::ArrowLeft);
+            keyboard.release(KeyCode::ArrowRight);
+            keyboard.clear();
+        }
+        // Reset camera to origin
+        let world = app.world_mut();
+        let mut query = world.query::<(&mut Transform, &CameraController)>();
+        for (mut transform, _) in query.iter_mut(world) {
+            transform.translation = Vec3::ZERO;
+        }
+    }
+
+    /// Returns the camera position if a camera exists.
+    fn camera_position(&self) -> Option<Vec3> {
+        let mut app = self.app_guard();
+        let world = app.world_mut();
+        let mut query = world.query::<(&Transform, &CameraController)>();
+        query
+            .iter(world)
+            .next()
+            .map(|(transform, _)| transform.translation)
+    }
+}
+
+#[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "BDD test with multiple scenarios cannot be easily split."
+)]
+fn camera_pans_with_wasd_keys() {
+    let fixture = CameraPanFixture::bootstrap();
+
+    run_serial(&rspec::given(
+        "PresentationPlugin camera responds to WASD input",
+        fixture,
+        |scenario: &mut Scenario<CameraPanFixture>| {
+            scenario.when("the app initialises", |ctx| {
+                ctx.before_each(|state| {
+                    state.tick(); // Finalise plugins and spawn camera
+                });
+
+                ctx.then("camera starts at origin", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.x.abs() < 0.001 && pos.y.abs() < 0.001,
+                        "camera should start near origin, got {pos:?}"
+                    );
+                });
+            });
+
+            scenario.when("W key is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick(); // Initial tick
+                    state.press_key(KeyCode::KeyW);
+                    state.tick(); // Process input
+                });
+
+                ctx.then("camera moves up (positive Y)", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.y > 0.0,
+                        "camera Y should increase when W pressed, got {pos:?}"
+                    );
+                });
+            });
+
+            scenario.when("S key is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::KeyS);
+                    state.tick();
+                });
+
+                ctx.then("camera moves down (negative Y)", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.y < 0.0,
+                        "camera Y should decrease when S pressed, got {pos:?}"
+                    );
+                });
+            });
+
+            scenario.when("A key is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::KeyA);
+                    state.tick();
+                });
+
+                ctx.then("camera moves left (negative X)", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.x < 0.0,
+                        "camera X should decrease when A pressed, got {pos:?}"
+                    );
+                });
+            });
+
+            scenario.when("D key is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::KeyD);
+                    state.tick();
+                });
+
+                ctx.then("camera moves right (positive X)", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.x > 0.0,
+                        "camera X should increase when D pressed, got {pos:?}"
+                    );
+                });
+            });
+        },
+    ));
+}
+
+#[test]
+fn camera_pans_with_arrow_keys() {
+    let fixture = CameraPanFixture::bootstrap();
+
+    run_serial(&rspec::given(
+        "PresentationPlugin camera responds to arrow key input",
+        fixture,
+        |scenario: &mut Scenario<CameraPanFixture>| {
+            scenario.when("ArrowUp is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::ArrowUp);
+                    state.tick();
+                });
+
+                ctx.then("camera moves up", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(pos.y > 0.0, "ArrowUp should move camera up, got {pos:?}");
+                });
+            });
+
+            scenario.when("ArrowDown is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::ArrowDown);
+                    state.tick();
+                });
+
+                ctx.then("camera moves down", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.y < 0.0,
+                        "ArrowDown should move camera down, got {pos:?}"
+                    );
+                });
+            });
+
+            scenario.when("ArrowLeft is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::ArrowLeft);
+                    state.tick();
+                });
+
+                ctx.then("camera moves left", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.x < 0.0,
+                        "ArrowLeft should move camera left, got {pos:?}"
+                    );
+                });
+            });
+
+            scenario.when("ArrowRight is pressed", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::ArrowRight);
+                    state.tick();
+                });
+
+                ctx.then("camera moves right", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    assert!(
+                        pos.x > 0.0,
+                        "ArrowRight should move camera right, got {pos:?}"
+                    );
+                });
+            });
+        },
+    ));
+}
+
+#[test]
+fn camera_diagonal_movement_is_normalised() {
+    let fixture = CameraPanFixture::bootstrap();
+
+    run_serial(&rspec::given(
+        "diagonal movement does not exceed cardinal speed",
+        fixture,
+        |scenario: &mut Scenario<CameraPanFixture>| {
+            scenario.when("W and D are pressed simultaneously", |ctx| {
+                ctx.before_each(|state| {
+                    state.reset_state();
+                    state.tick();
+                    state.press_key(KeyCode::KeyW);
+                    state.press_key(KeyCode::KeyD);
+                    state.tick();
+                });
+
+                ctx.then("camera moves diagonally at normalised speed", |state| {
+                    let pos = state.camera_position().expect("camera should exist");
+                    // Diagonal movement should be roughly sqrt(2)/2 in each axis,
+                    // not 1.0 in each axis.
+                    assert!(
+                        pos.x > 0.0 && pos.y > 0.0,
+                        "diagonal should move in both positive axes, got {pos:?}"
+                    );
+                    // With normalisation, X and Y components should be roughly equal.
+                    let ratio = pos.x / pos.y;
+                    assert!(
+                        (ratio - 1.0).abs() < 0.1,
+                        "diagonal components should be roughly equal, got ratio {ratio}"
+                    );
+                });
+            });
+        },
+    ));
+}

--- a/tests/camera_panning_rspec.rs
+++ b/tests/camera_panning_rspec.rs
@@ -52,7 +52,7 @@ impl CameraPanFixture {
         // Insert custom settings before plugin to override defaults.
         app.insert_resource(CameraSettings {
             pan_speed: TEST_PAN_SPEED,
-            max_delta_seconds: 1.0, // Allow large deltas in tests
+            max_delta_seconds: 1.0, // Deterministic timing for tests
         });
 
         app.add_plugins(PresentationPlugin);
@@ -165,7 +165,7 @@ fn camera_pans_with_wasd_keys() {
         "PresentationPlugin camera responds to WASD input",
         fixture,
         |scenario: &mut Scenario<CameraPanFixture>| {
-            scenario.when("the app initialises", |ctx| {
+            scenario.when("the app initializes", |ctx| {
                 ctx.before_each(|state| {
                     state.tick(); // Finalize plugins and spawn camera
                 });


### PR DESCRIPTION
Add keyboard-based camera panning using WASD and arrow keys. The camera smoothly pans across the isometric map at a configurable speed, independent of frame rate via Time.delta_secs().

Changes:
- Add CameraSettings resource with pan_speed (500.0 units/sec) and max_delta_seconds (0.1s) for frame hitch protection
- Add PanInput struct to aggregate directional key states
- Add compute_pan_direction pure function with vector normalisation ensuring diagonal movement matches cardinal speed
- Add camera_pan_system ordered after apply_dbsp_outputs_system
- Export new public items from lib.rs

Testing:
- Unit tests for compute_pan_direction covering cardinal directions, diagonals, opposing keys, and no input
- Behavioural tests for WASD keys, arrow keys, and diagonal movement

## Summary by Sourcery

Implement configurable keyboard-based camera panning for the presentation camera and document completion of the corresponding roadmap task.

New Features:
- Add a CameraSettings resource to configure camera pan speed and clamp maximum delta time for hitch protection.
- Introduce a camera_pan_system that pans the CameraController entity using WASD and arrow keys based on frame-rate-independent input.
- Expose new presentation helpers (CameraSettings, PanInput, compute_pan_direction, camera_pan_system) via the crate public API.

Enhancements:
- Add a pure compute_pan_direction helper to derive a normalised pan direction from directional key states, ensuring consistent diagonal and cardinal speeds.
- Extend PresentationPlugin to initialise CameraSettings and register the camera panning system after DBSP output application.

Documentation:
- Mark Task 2.1.2 (camera panning controls) as complete in the map and presentation roadmap and add a detailed execplan document describing its design and implementation.

Tests:
- Add unit tests for CameraSettings defaults and compute_pan_direction covering cardinal, diagonal, opposing, and partial key combinations.
- Add behavioural rspec-style integration tests verifying camera movement for WASD, arrow keys, and diagonal normalisation in a running app.