### PR TITLE
Wire CodeScene coverage upload and ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,18 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+      # Bevy's render features make the coverage build heavy; lift the
+      # shared-action cargo wall-clock cap (default 600 s) accordingly.
+      RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
     steps:
       - uses: actions/checkout@v5
+        with:
+          # Full history so a future CodeScene changed-line gate
+          # (`upload-codescene-coverage` with `mode: check`) can reach
+          # the pull request's merge base.
+          fetch-depth: 0
       - name: Setup Rust
-        uses: leynos/shared-actions/.github/actions/setup-rust@v1.2.1
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Check format
@@ -26,14 +32,21 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
       - name: Test
         run: cargo test
-      - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov
-      - name: Run coverage
-        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
-      - name: Upload coverage data to CodeScene
-        if: env.CS_ACCESS_TOKEN
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@v1.2.1
+      # Coverage is generated with the shared action (replacing the bespoke
+      # cargo-llvm-cov steps) so the whole estate shares one recipe. The
+      # ratchet compares against the baseline written by coverage-main.yml.
+      #
+      # The CodeScene changed-line gate (upload-codescene-coverage with
+      # `mode: check`) is deferred: it fails until CodeScene enables the
+      # per-project gates configuration, which is off for every estate
+      # project except mxd today. Once the gate is enabled for project
+      # 68983, add the guarded `mode: check` step here. Main-branch
+      # coverage is uploaded by coverage-main.yml.
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
+          features: render map text test-support observers-v1-spike
+          output-path: lcov.info
           format: lcov
-          access-token: ${{ env.CS_ACCESS_TOKEN }}
-          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,48 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests run the
+# coverage build (and, once CodeScene enables the per-project gate, the
+# changed-line `cs-coverage check`) in ci.yml instead. This workflow also
+# advances the coverage ratchet baseline: caches saved on main are
+# readable by every pull-request run, so the baseline written here is the
+# one PR ratchet checks compare against.
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-upload:
+    runs-on: ubicloud-standard-8
+    permissions:
+      contents: read
+    env:
+      CARGO_TERM_COLOR: always
+      BUILD_PROFILE: debug
+      # Bevy's render features make the coverage build heavy; lift the
+      # shared-action cargo wall-clock cap (default 600 s) accordingly.
+      RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Rust
+        uses: leynos/shared-actions/.github/actions/setup-rust@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          features: render map text test-support observers-v1-spike
+          output-path: lcov.info
+          format: lcov
+          use-cargo-nextest: 'false'
+          with-ratchet: 'true'
+      - name: Upload coverage data to CodeScene
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@1213d7874aa42ff034587d9385f35178d51e1f65
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Onboards lille to the estate CodeScene coverage recipe (see mxd#362 and
netsuke's `ci.yml` for the reference pattern), and migrates the repo's
bespoke `cargo llvm-cov` coverage steps to the shared
`generate-coverage` action in the same change.

The CodeScene "Code Coverage" check is **not** a repository-required
check; when enabled it blocks pull requests through the status-check
rollup that the shared Dependabot automerge gate reads, not through the
branch ruleset. lille's CodeScene project (68983) posts only a Code
Health Review today — the coverage gate is off — so this change wires
the CI side and leaves the changed-line gate deferred until CodeScene
enables the per-project gates configuration (off for every estate
project except mxd). A comment in `ci.yml` marks where the guarded
`mode: check` step belongs once that happens.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/lille/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  - Replaces the `Install cargo-llvm-cov` + `Run coverage` steps with
    the shared `generate-coverage` action (`format: lcov`,
    `use-cargo-nextest: 'false'` to match the existing plain
    `cargo test` suite, `with-ratchet: 'true'`). The prior
    `--all-features` run is preserved by enumerating every crate feature
    (`render map text test-support observers-v1-spike`).
  - Checks out with `fetch-depth: 0` so a future changed-line gate can
    reach the pull request's merge base.
  - Removes the old `upload-codescene-coverage` step. It defaulted to
    `mode: upload`, which CodeScene rejects on pull-request branches;
    uploads now live in `coverage-main.yml`.
  - Lifts `RUN_RUST_CARGO_WAIT_TIMEOUT` to 1800 s: the `927edd4` pin
    adds a 600 s cargo wall-clock cap, and Bevy's render features make
    the coverage build heavy.
- [`.github/workflows/coverage-main.yml`](https://github.com/leynos/lille/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  - New workflow: on push to `main`, generates coverage with the same
    inputs and uploads it to CodeScene with the default `mode: upload`
    (a plain checkout suffices). It also carries the ratchet, writing
    the authoritative baseline that every pull-request run compares
    against.
- [`.github/workflows/dependabot-automerge.yml`](https://github.com/leynos/lille/blob/codescene-coverage-gate/.github/workflows/dependabot-automerge.yml)
  - Bumps the reusable-workflow pin to `927edd4` so the whole repo
    holds one shared-actions SHA.

## Mechanism: rollup and automerge

The shared Dependabot automerge workflow reads the whole status-check
rollup, so any timed-out or failing CodeScene check would keep
`autoMergeRequest` from firing even while the required `build-test`
check is green. Wiring the upload (and, later, the changed-line gate)
keeps that rollup green so Dependabot automerge proceeds.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` on every workflow —
  all parse.
- No workflow-contract tests exist in this repo (nothing pins workflow
  text), so none needed updating.
- CI on this pull request exercises the migrated coverage build.
