### PR TITLE
Enable the CodeScene changed-line coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          # Full history so a future CodeScene changed-line gate
+          # Full history so the CodeScene changed-line gate
           # (`upload-codescene-coverage` with `mode: check`) can reach
           # the pull request's merge base.
           fetch-depth: 0
@@ -37,13 +37,6 @@ jobs:
       # Coverage is generated with the shared action (replacing the bespoke
       # cargo-llvm-cov steps) so the whole estate shares one recipe. The
       # ratchet compares against the baseline written by coverage-main.yml.
-      #
-      # The CodeScene changed-line gate (upload-codescene-coverage with
-      # `mode: check`) is deferred: it fails until CodeScene enables the
-      # per-project gates configuration, which is off for every estate
-      # project except mxd today. Once the gate is enabled for project
-      # 68983, add the guarded `mode: check` step here. Main-branch
-      # coverage is uploaded by coverage-main.yml.
       - name: Generate coverage
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
@@ -52,3 +45,18 @@ jobs:
           format: lcov
           use-cargo-nextest: 'false'
           with-ratchet: 'true'
+      # The CodeScene changed-line gate: diffs the PR against its merge
+      # base and evaluates changed-line coverage. Guarded so secret-less
+      # runs (forks, repos not yet onboarded) skip rather than fail.
+      # Main-branch coverage is uploaded separately by coverage-main.yml.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: lcov
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/68983
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene has now switched on the gates configuration for project
  68983, so add the guarded `mode: check` step to the pull-request
  coverage job in [`.github/workflows/ci.yml`](https://github.com/leynos/lille/blob/codescene-mode-check/.github/workflows/ci.yml), replacing the
  deferred-gate comment left by the earlier upload-wiring PR (#270).
- The step reuses the existing `927edd45ae77be4251a8a18ca9eb5613a2e32cbd`
  shared-actions pin (already used by `setup-rust` and
  `generate-coverage` in this workflow) and the repo's `lcov` coverage
  format.
- `coverage-main.yml` is untouched; it continues to run `mode: upload`
  on pushes to `main`.

## Review walkthrough

- The new step runs after `Generate coverage` and is guarded by
  `env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'`,
  so forks and secret-less runs skip it rather than failing.
- `project-url` uses the `/v2/projects/68983` form, matching the
  action's expected input.
- `fetch-depth: 0` was already present on the checkout step from the
  earlier upload-wiring PR, so the merge base is reachable for the
  changed-line diff.
- Confirmed via a direct `GET
  https://api.codescene.io/v2/code-coverage/projects/68983/config`
  probe that the project's `gates` array is populated (matching the
  known-working mxd project's shape), so `cs-coverage check` should
  succeed rather than error with "Lacks the gates configuration".

## Validation

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
- [x] No workflow-contract tests reference `ci.yml`'s structure in this
      repo.
- [ ] CI green on this PR, with the "Check coverage against CodeScene
      gates" step executing (not skipped) and succeeding, and the
      `CodeScene Code Coverage` PR check completing.
