### PR TITLE
Bump whitaker-installer to 0.2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
       BUILD_PROFILE: debug
-      WHITAKER_INSTALLER_VERSION: '0.2.6'
+      WHITAKER_INSTALLER_VERSION: '0.2.7'
       # Bevy's render features make the coverage build heavy; lift the
       # shared-action cargo wall-clock cap (default 600 s) accordingly.
       RUN_RUST_CARGO_WAIT_TIMEOUT: '1800'


### PR DESCRIPTION
## Summary

This branch pins the Whitaker installer to the released `0.2.7` on `main`. The adoption PR [#269](https://github.com/leynos/lille/pull/269) merged while the installer still pinned `0.2.6`, whose `dylint-link` verification defect leaves the lint gate unable to install the suite.

Installer 0.2.6 downloaded the correct, checksummed `dylint-link` 6.0.1 artefact but then executed it as a `--help` health check. `dylint-link` is a linker wrapper with no reliable self-reporting subcommand, so that probe failed and verification fell back to a source build of `dylint-link` 6.0.1, which cannot compile on this repository's pinned toolchain. Installer 0.2.7 ([leynos/whitaker#300](https://github.com/leynos/whitaker/pull/300), closing [#299](https://github.com/leynos/whitaker/issues/299)) trusts the download, checksum, extraction, and permission pipeline instead of executing the wrapper.

## Changes

- Set `WHITAKER_INSTALLER_VERSION` from `0.2.6` to `0.2.7` in [.github/workflows/ci.yml](https://github.com/leynos/lille/blob/bump-whitaker-installer-0.2.7/.github/workflows/ci.yml). The Whitaker installer cache key already interpolates the version, so it is invalidated automatically.

## Validation

- CI on this PR exercises the lint gate; it should now install the suite without a Cargo source build of `dylint-link`.

## Notes

No Rust toolchain pin is changed and the Whitaker lint gate is not weakened.
